### PR TITLE
Changes for clients generation

### DIFF
--- a/oas_apivideo.json
+++ b/oas_apivideo.json
@@ -17,11 +17,13 @@
         "summary" : "Authenticate",
         "description" : "To get started, submit your API key in the body of your request. api.video returns an access token that is valid for one hour (3600 seconds). A refresh token is also returned. View a [tutorial](https://api.video/blog/tutorials/authentication-tutorial) on authentication.",
         "operationId" : "POST_auth-api-key",
+        "x-client-action" : "authenticate",
+        "x-client-hidden" : true,
         "requestBody" : {
           "content" : {
             "application/json" : {
               "schema" : {
-                "$ref" : "#/components/schemas/body"
+                "$ref" : "#/components/schemas/authenticate-payload"
               }
             }
           }
@@ -76,11 +78,13 @@
         "summary" : "Refresh token",
         "description" : "Use the refresh endpoint with the refresh token you received when you first authenticated using the api-key endpoint. Send the refresh token in the body of your request. The api.video API returns a new access token that is valid for one hour (3600 seconds) and a new refresh token. \n",
         "operationId" : "POST_auth-refresh",
+        "x-client-action" : "refresh",
+        "x-client-hidden" : true,
         "requestBody" : {
           "content" : {
             "application/json" : {
               "schema" : {
-                "$ref" : "#/components/schemas/body_1"
+                "$ref" : "#/components/schemas/refresh-token-payload"
               }
             }
           }
@@ -135,6 +139,9 @@
         "summary" : "List all videos",
         "description" : "Requests to this endpoint return a list of your videos (with all their details). With no parameters added to this query, the API returns all videos. You can filter what videos the API returns using the parameters described below.",
         "operationId" : "LIST-videos",
+        "x-client-action" : "list",
+        "x-group-parameters" : true,
+        "x-client-paginated" : true,
         "parameters" : [ {
           "name" : "title",
           "in" : "query",
@@ -219,123 +226,103 @@
           },
           "example" : "asc"
         }, {
-          "name" : "currentPage",
-          "in" : "query",
-          "description" : "Choose the number of search results to return per page. Minimum value: 1",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "integer",
-            "default" : 1
-          },
-          "example" : 2
-        }, {
-          "name" : "pageSize",
-          "in" : "query",
-          "description" : "Results per page. Allowed values 1-100, default is 25.",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "integer",
-            "default" : 25
-          },
-          "example" : 30
-        } ],
+            "$ref" : "#/components/parameters/currentPage"
+          }, {
+            "$ref" : "#/components/parameters/pageSize"
+          } ],
         "responses" : {
           "200" : {
             "description" : "Success",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/inline_response_200"
+                  "$ref" : "#/components/schemas/videos-list-response"
                 },
                 "examples" : {
                   "response" : {
                     "value" : {
                       "data" : [ {
-                        "videoId" : "vi4k0jvEUuaTdRAEjQ4Prklg",
-                        "playerId" : "pl45KFKdlddgk654dspkze",
-                        "title" : "Maths video",
-                        "description" : "An amazing video explaining the string theory",
-                        "public" : false,
-                        "panoramic" : false,
-                        "mp4Support" : true,
-                        "tags" : [ "maths", "string theory", "video" ],
-                        "metadata" : [ {
-                          "key" : "Author",
-                          "value" : "John Doe"
+                          "videoId" : "vi4k0jvEUuaTdRAEjQ4Prklg",
+                          "playerId" : "pl45KFKdlddgk654dspkze",
+                          "title" : "Maths video",
+                          "description" : "An amazing video explaining the string theory",
+                          "public" : false,
+                          "panoramic" : false,
+                          "mp4Support" : true,
+                          "tags" : [ "maths", "string theory", "video" ],
+                          "metadata" : [ {
+                              "key" : "Author",
+                              "value" : "John Doe"
+                            }, {
+                              "key" : "Format",
+                              "value" : "Tutorial"
+                            } ],
+                          "publishedAt" : "2019-12-16T08:25:51+00:00",
+                          "updateddAt" : "2019-12-16T08:48:49+00:00",
+                          "source" : {
+                            "uri" : "/videos/c188ed58-3403-46a2-b91b-44603d10b2c9/source"
+                          },
+                          "assets" : {
+                            "iframe" : "<iframe src=\"//embed.api.video/c188ed58-3403-46a2-b91b-44603d10b2c9?token=831a9bd9-9f50-464c-a369-8e9d914371ae\" width=\"100%\" height=\"100%\" frameborder=\"0\" scrolling=\"no\" allowfullscreen=\"\"></iframe>",
+                            "player" : "https://embed.api.video/c188ed58-3403-46a2-b91b-44603d10b2c9?token=831a9bd9-9f50-464c-a369-8e9d914371ae",
+                            "hls" : "https://cdn.api.video/stream/831a9bd9-9f50-464c-a369-8e9d914371ae/hls/manifest.m3u8",
+                            "thumbnail" : "https://cdn.api.video/stream/831a9bd9-9f50-464c-a369-8e9d914371ae/thumbnail.jpg",
+                            "mp4" : "https://cdn.api.video/vod/vi4k0jvEUuaTdRAEjQ4Jfrgz/token/8fd70443-d9f0-45d2-b01c-12c8cfc707c9/mp4/720/source.mp4"
+                          }
                         }, {
-                          "key" : "Format",
-                          "value" : "Tutorial"
-                        } ],
-                        "publishedAt" : "2019-12-16T08:25:51+00:00",
-                        "updateddAt" : "2019-12-16T08:48:49+00:00",
-                        "source" : {
-                          "uri" : "/videos/c188ed58-3403-46a2-b91b-44603d10b2c9/source"
-                        },
-                        "assets" : {
-                          "iframe" : "<iframe src=\"//embed.api.video/c188ed58-3403-46a2-b91b-44603d10b2c9?token=831a9bd9-9f50-464c-a369-8e9d914371ae\" width=\"100%\" height=\"100%\" frameborder=\"0\" scrolling=\"no\" allowfullscreen=\"\"></iframe>",
-                          "player" : "https://embed.api.video/c188ed58-3403-46a2-b91b-44603d10b2c9?token=831a9bd9-9f50-464c-a369-8e9d914371ae",
-                          "hls" : "https://cdn.api.video/stream/831a9bd9-9f50-464c-a369-8e9d914371ae/hls/manifest.m3u8",
-                          "thumbnail" : "https://cdn.api.video/stream/831a9bd9-9f50-464c-a369-8e9d914371ae/thumbnail.jpg",
-                          "mp4" : "https://cdn.api.video/vod/vi4k0jvEUuaTdRAEjQ4Jfrgz/token/8fd70443-d9f0-45d2-b01c-12c8cfc707c9/mp4/720/source.mp4"
-                        }
-                      }, {
-                        "videoId" : "vi4k0jvEUuaTdRAEjQ4Jfrgz",
-                        "title" : "Video Title",
-                        "description" : "A description for your video.",
-                        "public" : false,
-                        "panoramic" : false,
-                        "mp4Support" : true,
-                        "tags" : [ "books", "short stories" ],
-                        "metadata" : [ {
-                          "key" : "Author",
-                          "value" : "John Doe"
+                          "videoId" : "vi4k0jvEUuaTdRAEjQ4Jfrgz",
+                          "title" : "Video Title",
+                          "description" : "A description for your video.",
+                          "public" : false,
+                          "panoramic" : false,
+                          "mp4Support" : true,
+                          "tags" : [ "books", "short stories" ],
+                          "metadata" : [ {
+                              "key" : "Author",
+                              "value" : "John Doe"
+                            }, {
+                              "key" : "Science Fiction",
+                              "value" : "Cyberpunk"
+                            }, {
+                              "key" : "Technology",
+                              "value" : "Computers"
+                            } ],
+                          "publishedAt" : "2019-12-16T08:25:51+00:00",
+                          "updateddAt" : "2019-12-16T08:48:49+00:00",
+                          "source" : {
+                            "uri" : "/videos/1b9d6ae8-8f57-4b6d-8552-d636926b4f5f/source"
+                          },
+                          "assets" : {
+                            "iframe" : "<iframe src=\"//embed.api.video/1b9d6ae8-8f57-4b6d-8552-d636926b4f5f?token=831a9bd9-9f50-464c-a369-8e9d914371ae\" width=\"100%\" height=\"100%\" frameborder=\"0\" scrolling=\"no\" allowfullscreen=\"\"></iframe>",
+                            "player" : "https://embed.api.video/1b9d6ae8-8f57-4b6d-8552-d636926b4f5f?token=831a9bd9-9f50-464c-a369-8e9d914371ae",
+                            "hls" : "https://cdn.api.video/stream/831a9bd9-9f50-464c-a369-8e9d914371ae/hls/manifest.m3u8",
+                            "thumbnail" : "https://cdn.api.video/stream/831a9bd9-9f50-464c-a369-8e9d914371ae/thumbnail.jpg"
+                          }
                         }, {
-                          "key" : "Science Fiction",
-                          "value" : "Cyberpunk"
-                        }, {
-                          "key" : "Technology",
-                          "value" : "Computers"
+                          "videoId" : "vi4k0jvEUuaTdRAEjQ4Jfrgz",
+                          "playerId" : "pl45KFKdlddgk654dspkze",
+                          "title" : "My Video Title",
+                          "description" : "A brief description of the video.",
+                          "public" : false,
+                          "panoramic" : false,
+                          "mp4Support" : true,
+                          "tags" : [ "General", "Videos" ],
+                          "metadata" : [ {
+                              "key" : "Length",
+                              "value" : "Short"
+                            } ],
+                          "publishedAt" : "2019-12-16T08:25:51+00:00",
+                          "updateddAt" : "2019-12-16T08:48:49+00:00",
+                          "source" : {
+                            "uri" : "/videos/73129412-e320-4b93-99f6-59a85e3cedcd/source"
+                          },
+                          "assets" : {
+                            "iframe" : "<iframe src=\"//embed.api.video/73129412-e320-4b93-99f6-59a85e3cedcd?token=831a9bd9-9f50-464c-a369-8e9d914371ae\" width=\"100%\" height=\"100%\" frameborder=\"0\" scrolling=\"no\" allowfullscreen=\"\"></iframe>",
+                            "player" : "https://embed.api.video/73129412-e320-4b93-99f6-59a85e3cedcd?token=831a9bd9-9f50-464c-a369-8e9d914371ae",
+                            "hls" : "https://cdn.api.video/stream/831a9bd9-9f50-464c-a369-8e9d914371ae/hls/manifest.m3u8",
+                            "thumbnail" : "https://cdn.api.video/stream/831a9bd9-9f50-464c-a369-8e9d914371ae/thumbnail.jpg"
+                          }
                         } ],
-                        "publishedAt" : "2019-12-16T08:25:51+00:00",
-                        "updateddAt" : "2019-12-16T08:48:49+00:00",
-                        "source" : {
-                          "uri" : "/videos/1b9d6ae8-8f57-4b6d-8552-d636926b4f5f/source"
-                        },
-                        "assets" : {
-                          "iframe" : "<iframe src=\"//embed.api.video/1b9d6ae8-8f57-4b6d-8552-d636926b4f5f?token=831a9bd9-9f50-464c-a369-8e9d914371ae\" width=\"100%\" height=\"100%\" frameborder=\"0\" scrolling=\"no\" allowfullscreen=\"\"></iframe>",
-                          "player" : "https://embed.api.video/1b9d6ae8-8f57-4b6d-8552-d636926b4f5f?token=831a9bd9-9f50-464c-a369-8e9d914371ae",
-                          "hls" : "https://cdn.api.video/stream/831a9bd9-9f50-464c-a369-8e9d914371ae/hls/manifest.m3u8",
-                          "thumbnail" : "https://cdn.api.video/stream/831a9bd9-9f50-464c-a369-8e9d914371ae/thumbnail.jpg"
-                        }
-                      }, {
-                        "videoId" : "vi4k0jvEUuaTdRAEjQ4Jfrgz",
-                        "playerId" : "pl45KFKdlddgk654dspkze",
-                        "title" : "My Video Title",
-                        "description" : "A brief description of the video.",
-                        "public" : false,
-                        "panoramic" : false,
-                        "mp4Support" : true,
-                        "tags" : [ "General", "Videos" ],
-                        "metadata" : [ {
-                          "key" : "Length",
-                          "value" : "Short"
-                        } ],
-                        "publishedAt" : "2019-12-16T08:25:51+00:00",
-                        "updateddAt" : "2019-12-16T08:48:49+00:00",
-                        "source" : {
-                          "uri" : "/videos/73129412-e320-4b93-99f6-59a85e3cedcd/source"
-                        },
-                        "assets" : {
-                          "iframe" : "<iframe src=\"//embed.api.video/73129412-e320-4b93-99f6-59a85e3cedcd?token=831a9bd9-9f50-464c-a369-8e9d914371ae\" width=\"100%\" height=\"100%\" frameborder=\"0\" scrolling=\"no\" allowfullscreen=\"\"></iframe>",
-                          "player" : "https://embed.api.video/73129412-e320-4b93-99f6-59a85e3cedcd?token=831a9bd9-9f50-464c-a369-8e9d914371ae",
-                          "hls" : "https://cdn.api.video/stream/831a9bd9-9f50-464c-a369-8e9d914371ae/hls/manifest.m3u8",
-                          "thumbnail" : "https://cdn.api.video/stream/831a9bd9-9f50-464c-a369-8e9d914371ae/thumbnail.jpg"
-                        }
-                      } ],
                       "pagination" : {
                         "currentPage" : 1,
                         "pageSize" : 25,
@@ -362,7 +349,7 @@
           "400" : {
             "description" : "Bad Request",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/bad-request"
                 },
@@ -376,19 +363,19 @@
                         "min" : 1
                       },
                       "problems" : [ {
-                        "title" : "This parameter is out of the allowed range of values.",
-                        "name" : "page",
-                        "range" : {
-                          "min" : 1
-                        }
-                      }, {
-                        "title" : "This parameter is out of the allowed range of values.",
-                        "name" : "pageSize",
-                        "range" : {
-                          "min" : 10,
-                          "max" : 100
-                        }
-                      } ]
+                          "title" : "This parameter is out of the allowed range of values.",
+                          "name" : "page",
+                          "range" : {
+                            "min" : 1
+                          }
+                        }, {
+                          "title" : "This parameter is out of the allowed range of values.",
+                          "name" : "pageSize",
+                          "range" : {
+                            "min" : 10,
+                            "max" : 100
+                          }
+                        } ]
                     }
                   }
                 }
@@ -405,11 +392,13 @@
         "summary" : "Create a video",
         "description" : "To create a video, you create its metadata first, before adding the video file (exception - when using an existing HTTP source).\n\nVideos are public by default. Mp4 encoded versions are created at the highest quality (max 1080p) by default.\n ```shell\n$ curl https://ws.api.video/videos \\\n-H 'Authorization: Bearer {access_token} \\\n-d '{\"title\":\"My video\", \n     \"description\":\"so many details\",\n     \"mp4Support\":true\n}'\n```\n\n### Creating a hosted video \n\nYou can also create a video directly from one hosted on a third-party server by giving its URI in `source` parameter:\n\n```shell\n$ curl https://ws.api.video/videos \\\n-H 'Authorization: Bearer {access_token} \\\n-d '{\"source\":\"http://uri/to/video.mp4\", \"title\":\"My video\"}'\n```\n\nIn this case, the service will respond `202 Accepted` and download the video asynchronously.\n\n We have tutorials on:\n* [Creating and uploading videos](https://api.video/blog/tutorials/video-upload-tutorial)\n* [Uploading large videos](https://api.video/blog/tutorials/video-upload-tutorial-large-videos)\n* [Using tags with videos](https://api.video/blog/tutorials/video-tagging-best-practices)\n* [Private videos](https://api.video/blog/tutorials/tutorial-private-videos)\n",
         "operationId" : "POST-video",
+        "x-client-action" : "create",
         "requestBody" : {
+          "description" : "video to create",
           "content" : {
             "application/json" : {
               "schema" : {
-                "$ref" : "#/components/schemas/body_2"
+                "$ref" : "#/components/schemas/video-create-payload"
               }
             }
           }
@@ -418,7 +407,7 @@
           "201" : {
             "description" : "Created",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/video"
                 },
@@ -434,12 +423,12 @@
                       "playerId" : "pl4k0jvEUuaTdRAEjQ4Jfrgz",
                       "tags" : [ "maths", "string theory", "video" ],
                       "metadata" : [ {
-                        "key" : "Author",
-                        "value" : "John Doe"
-                      }, {
-                        "key" : "Format",
-                        "value" : "Tutorial"
-                      } ],
+                          "key" : "Author",
+                          "value" : "John Doe"
+                        }, {
+                          "key" : "Format",
+                          "value" : "Tutorial"
+                        } ],
                       "publishedAt" : "4665-07-14T23:36:18.598Z",
                       "source" : {
                         "uri" : "/videos/vi4k0jvEUuaTdRAEjQ4Jfrgz/source"
@@ -460,7 +449,7 @@
           "202" : {
             "description" : "Accepted",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/video"
                 }
@@ -470,7 +459,7 @@
           "400" : {
             "description" : "Bad Request",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/bad-request"
                 },
@@ -482,22 +471,22 @@
                       "name" : "title",
                       "status" : 400,
                       "problems" : [ {
-                        "type" : "https://docs.api.video/docs/attributerequired",
-                        "title" : "This attribute is required.",
-                        "name" : "title"
-                      }, {
-                        "type" : "https://docs.api.video/docs/attributeinvalid",
-                        "title" : "This attribute must be a ISO8601 date.",
-                        "name" : "scheduledAt"
-                      }, {
-                        "type" : "https://docs.api.video/docs/attributeinvalid",
-                        "title" : "This attribute must be an array.",
-                        "name" : "tags"
-                      }, {
-                        "type" : "https://docs.api.video/docs/attributeinvalid",
-                        "title" : "This attribute must be an array.",
-                        "name" : "metadata"
-                      } ]
+                          "type" : "https://docs.api.video/docs/attributerequired",
+                          "title" : "This attribute is required.",
+                          "name" : "title"
+                        }, {
+                          "type" : "https://docs.api.video/docs/attributeinvalid",
+                          "title" : "This attribute must be a ISO8601 date.",
+                          "name" : "scheduledAt"
+                        }, {
+                          "type" : "https://docs.api.video/docs/attributeinvalid",
+                          "title" : "This attribute must be an array.",
+                          "name" : "tags"
+                        }, {
+                          "type" : "https://docs.api.video/docs/attributeinvalid",
+                          "title" : "This attribute must be an array.",
+                          "name" : "metadata"
+                        } ]
                     }
                   }
                 }
@@ -506,8 +495,8 @@
           }
         },
         "security" : [ {
-          "bearerAuth" : [ ]
-        } ]
+            "bearerAuth" : [ ]
+          } ]
       }
     },
     "/videos/{videoId}/source" : {
@@ -516,35 +505,38 @@
         "summary" : "Upload a video",
         "description" : "To upload a video to the videoId you created. Replace {videoId} with the id you'd like to use, {access_token} with your token, and /path/to/video.mp4 with the path to the video you'd like to upload. You can only upload your video to the videoId once.\n\n```bash\ncurl https://ws.api.video/videos/{videoId}/source \\\n  -H 'Authorization: Bearer {access_token}' \\\n  -F file=@/path/to/video.mp4\n  ```",
         "operationId" : "POST_videos-videoId-source",
+        "x-client-action" : "upload",
+        "x-client-chunk-upload" : true,
         "parameters" : [ {
-          "name" : "videoId",
-          "in" : "path",
-          "description" : "Enter the videoId you want to use to upload your video.",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "vi4k0jvEUuaTdRAEjQ4Jfrgz"
-        }, {
-          "name" : "Content-Range",
-          "in" : "header",
-          "description" : "Content-Range represents the range of bytes that will be returned as a result of the request. Byte ranges are inclusive, meaning that bytes 0-999 represents the first 1000 bytes in a file or object.",
-          "required" : false,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "pattern" : "^bytes [0-9]*-[0-9]*\\/[0-9]*$",
-            "type" : "string"
-          },
-          "example" : "Content-Range: bytes 200-100/5000"
-        } ],
+            "name" : "videoId",
+            "in" : "path",
+            "description" : "Enter the videoId you want to use to upload your video.",
+            "required" : true,
+            "style" : "simple",
+            "explode" : false,
+              "schema" : {
+              "type" : "string"
+            },
+            "example" : "vi4k0jvEUuaTdRAEjQ4Jfrgz"
+          }, {
+            "name" : "Content-Range",
+            "in" : "header",
+            "description" : "Content-Range represents the range of bytes that will be returned as a result of the request. Byte ranges are inclusive, meaning that bytes 0-999 represents the first 1000 bytes in a file or object.",
+            "required" : false,
+            "x-client-ignore" : true,
+            "style" : "simple",
+            "explode" : false,
+            "schema" : {
+              "pattern" : "^bytes [0-9]*-[0-9]*\\/[0-9]*$",
+              "type" : "string"
+            },
+            "example" : "Content-Range: bytes 200-100/5000"
+          } ],
         "requestBody" : {
           "content" : {
             "multipart/form-data" : {
               "schema" : {
-                "$ref" : "#/components/schemas/body_3"
+                "$ref" : "#/components/schemas/video-upload-payload"
               }
             }
           }
@@ -553,8 +545,9 @@
           "201" : {
             "description" : "Created",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
+                  "type" : "object",
                   "$ref" : "#/components/schemas/video"
                 },
                 "examples" : {
@@ -569,12 +562,12 @@
                       "playerId" : "pl45KFKdlddgk654dspkze",
                       "tags" : [ "maths", "string theory", "video" ],
                       "metadata" : [ {
-                        "key" : "Author",
-                        "value" : "John Doe"
-                      }, {
-                        "key" : "Format",
-                        "value" : "Tutorial"
-                      } ],
+                          "key" : "Author",
+                          "value" : "John Doe"
+                        }, {
+                          "key" : "Format",
+                          "value" : "Tutorial"
+                        } ],
                       "publishedAt" : "4665-07-14T23:36:18.598Z",
                       "source" : {
                         "uri" : "/videos/vi4k0jvEUuaTdRAEjQ4Jfrgz/source"
@@ -595,7 +588,7 @@
           "400" : {
             "description" : "Bad Request",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/bad-request"
                 },
@@ -607,22 +600,22 @@
                       "name" : "file",
                       "status" : 400,
                       "problems" : [ {
-                        "type" : "https://docs.api.video/docs/filealreadyuploaded",
-                        "title" : "The source of the video is already uploaded.",
-                        "name" : "file"
-                      }, {
-                        "type" : "https://docs.api.video/docs/filealreadyuploaded",
-                        "title" : "The video xxxx has already been uploaded.",
-                        "name" : "video"
-                      }, {
-                        "type" : "https://docs.api.video/docs/filemissing",
-                        "title" : "There is no uploaded file in the request.",
-                        "name" : "file"
-                      }, {
-                        "type" : "https://docs.api.video/docs/multiplefilesuploaded",
-                        "title" : "There is more than one uploaded file in the request.",
-                        "name" : "file"
-                      } ]
+                          "type" : "https://docs.api.video/docs/filealreadyuploaded",
+                          "title" : "The source of the video is already uploaded.",
+                          "name" : "file"
+                        }, {
+                          "type" : "https://docs.api.video/docs/filealreadyuploaded",
+                          "title" : "The video xxxx has already been uploaded.",
+                          "name" : "video"
+                        }, {
+                          "type" : "https://docs.api.video/docs/filemissing",
+                          "title" : "There is no uploaded file in the request.",
+                          "name" : "file"
+                        }, {
+                          "type" : "https://docs.api.video/docs/multiplefilesuploaded",
+                          "title" : "There is more than one uploaded file in the request.",
+                          "name" : "file"
+                        } ]
                     }
                   }
                 }
@@ -632,7 +625,7 @@
           "404" : {
             "description" : "Not Found",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/not-found"
                 },
@@ -651,8 +644,8 @@
           }
         },
         "security" : [ {
-          "bearerAuth" : [ ]
-        } ]
+            "bearerAuth" : [ ]
+          } ]
       }
     },
     "/videos/{videoId}/thumbnail" : {
@@ -661,25 +654,32 @@
         "summary" : "Upload a thumbnail",
         "description" : "In creating a thumbnail, you may either upload an image, or you can pick a time in the video to be used as thumbnail. This endpoint is for uploading an image. Use [Pick a Thumbnail](https://docs.api.video/reference#patch_videos-videoid-thumbnail) to pick a time in the video. There may be a short delay before the new thumbnail is delivered to our CDN.",
         "operationId" : "POST_videos-videoId-thumbnail",
+        "x-client-action" : "uploadThumbnail",
         "parameters" : [ {
-          "name" : "videoId",
-          "in" : "path",
-          "description" : "Unique identifier of the chosen video ",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
+            "name" : "videoId",
+            "in" : "path",
+            "description" : "Unique identifier of the chosen video ",
+            "required" : true,
+            "style" : "simple",
+            "explode" : false,
+            "schema" : {
+              "type" : "string"
+            }
+          } ],
         "requestBody" : {
-          "$ref" : "#/components/requestBodies/POST_videos-videoId-thumbnail"
+          "content" : {
+            "multipart/form-data" : {
+              "schema" : {
+                "$ref": "#/components/schemas/video-thumbnail-upload-payload"
+              }
+            }
+          }
         },
         "responses" : {
           "200" : {
             "description" : "Success",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/video"
                 },
@@ -695,12 +695,12 @@
                       "mp4Support" : true,
                       "tags" : [ "maths", "string theory", "video" ],
                       "metadata" : [ {
-                        "key" : "Author",
-                        "value" : "John Doe"
-                      }, {
-                        "key" : "Format",
-                        "value" : "Tutorial"
-                      } ],
+                          "key" : "Author",
+                          "value" : "John Doe"
+                        }, {
+                          "key" : "Format",
+                          "value" : "Tutorial"
+                        } ],
                       "scheduledAt" : "2020-03-03T12:52:03.085Z",
                       "publishedAt" : "2020-07-14T23:36:18.598Z",
                       "source" : {
@@ -722,7 +722,7 @@
           "400" : {
             "description" : "Bad Request",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/bad-request"
                 },
@@ -742,7 +742,7 @@
           "404" : {
             "description" : "Not Found",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/not-found"
                 },
@@ -769,23 +769,24 @@
         "summary" : "Pick a thumbnail",
         "description" : "Pick a thumbnail from the given time code. If you'd like to upload an image for your thumbnail, use the [Upload a Thumbnail](https://docs.api.video/reference#post_videos-videoid-thumbnail) endpoint. There may be a short delay for the thumbnail to update.",
         "operationId" : "PATCH_videos-videoId-thumbnail",
+        "x-client-action" : "pickThumbnail",
         "parameters" : [ {
-          "name" : "videoId",
-          "in" : "path",
-          "description" : "Unique identifier of the video you want to add a thumbnail to, where you use a section of your video as the thumbnail.",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "vi4k0jvEUuaTdRAEjQ4Jfrgz"
-        } ],
+            "name" : "videoId",
+            "in" : "path",
+            "description" : "Unique identifier of the video you want to add a thumbnail to, where you use a section of your video as the thumbnail.",
+            "required" : true,
+            "style" : "simple",
+            "explode" : false,
+            "schema" : {
+              "type" : "string"
+            },
+            "example" : "vi4k0jvEUuaTdRAEjQ4Jfrgz"
+          } ],
         "requestBody" : {
           "content" : {
             "application/json" : {
               "schema" : {
-                "$ref" : "#/components/schemas/body_4"
+                "$ref" : "#/components/schemas/video-thumbnail-pick-payload"
               }
             }
           }
@@ -794,7 +795,7 @@
           "200" : {
             "description" : "Success",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/video"
                 },
@@ -810,12 +811,12 @@
                       "mp4Support" : true,
                       "tags" : [ "maths", "string theory", "video" ],
                       "metadata" : [ {
-                        "key" : "Author",
-                        "value" : "John Doe"
-                      }, {
-                        "key" : "Format",
-                        "value" : "Tutorial"
-                      } ],
+                          "key" : "Author",
+                          "value" : "John Doe"
+                        }, {
+                          "key" : "Format",
+                          "value" : "Tutorial"
+                        } ],
                       "publishedAt" : "4665-07-14T23:36:18.598Z",
                       "source" : {
                         "uri" : "/videos/vi4k0jvEUuaTdRAEjQ4Jfrgz/source"
@@ -836,7 +837,7 @@
           "404" : {
             "description" : "Not Found",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/not-found"
                 },
@@ -865,23 +866,25 @@
         "summary" : "Show a video",
         "description" : "This call provides the same JSON information provided on video creation. For private videos, it will generate a unique token url. Use this to retrieve any details you need about a video, or set up a private viewing URL.",
         "operationId" : "GET-video",
+        "x-client-action" : "get",
         "parameters" : [ {
-          "name" : "videoId",
-          "in" : "path",
-          "description" : "The unique identifier for the video you want details about.",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
+            "name" : "videoId",
+            "in" : "path",
+            "description" : "The unique identifier for the video you want details about.",
+            "required" : true,
+            "style" : "simple",
+            "explode" : false,
+            "schema" : {
+              "type" : "string"
+            }
+          } ],
         "responses" : {
           "200" : {
             "description" : "Success",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
+                  "type" : "object",
                   "$ref" : "#/components/schemas/video"
                 },
                 "examples" : {
@@ -896,12 +899,12 @@
                       "mp4Support" : true,
                       "tags" : [ "maths", "string theory", "video" ],
                       "metadata" : [ {
-                        "key" : "Author",
-                        "value" : "John Doe"
-                      }, {
-                        "key" : "Format",
-                        "value" : "Tutorial"
-                      } ],
+                          "key" : "Author",
+                          "value" : "John Doe"
+                        }, {
+                          "key" : "Format",
+                          "value" : "Tutorial"
+                        } ],
                       "publishedAt" : "2019-12-16T08:25:51+00:00",
                       "updateddAt" : "2019-12-16T08:48:49+00:00",
                       "source" : {
@@ -923,7 +926,7 @@
           "404" : {
             "description" : "Not Found",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/not-found"
                 },
@@ -950,18 +953,19 @@
         "summary" : "Delete a video",
         "description" : "If you do not need a video any longer, you can send a request to delete it. All you need is the videoId.",
         "operationId" : "DELETE-video",
+        "x-client-action" : "delete",
         "parameters" : [ {
-          "name" : "videoId",
-          "in" : "path",
-          "description" : "The video ID for the video you want to delete.",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "vi4k0jvEUuaTdRAEjQ4Jfrgz"
-        } ],
+            "name" : "videoId",
+            "in" : "path",
+            "description" : "The video ID for the video you want to delete.",
+            "required" : true,
+            "style" : "simple",
+            "explode" : false,
+            "schema" : {
+              "type" : "string"
+            },
+            "example" : "vi4k0jvEUuaTdRAEjQ4Jfrgz"
+          } ],
         "responses" : {
           "204" : {
             "description" : "No Content"
@@ -969,7 +973,7 @@
           "404" : {
             "description" : "Not Found",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/not-found"
                 },
@@ -996,23 +1000,24 @@
         "summary" : "Update a video",
         "description" : "Use this endpoint to update the parameters associated with your video. The video you are updating is determined by the video ID you provide in the path. For each parameter you want to update, include the update in the request body. NOTE: If you are updating an array, you must provide the entire array as what you provide here overwrites what is in the system rather than appending to it.",
         "operationId" : "PATCH-video",
+        "x-client-action" : "update",
         "parameters" : [ {
-          "name" : "videoId",
-          "in" : "path",
-          "description" : "The video ID for the video you want to delete.",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "vi4k0jvEUuaTdRAEjQ4Jfrgz"
-        } ],
+            "name" : "videoId",
+            "in" : "path",
+            "description" : "The video ID for the video you want to delete.",
+            "required" : true,
+            "style" : "simple",
+            "explode" : false,
+            "schema" : {
+              "type" : "string"
+            },
+            "example" : "vi4k0jvEUuaTdRAEjQ4Jfrgz"
+          } ],
         "requestBody" : {
           "content" : {
             "application/json" : {
               "schema" : {
-                "$ref" : "#/components/schemas/body_5"
+                "$ref" : "#/components/schemas/video-update-payload"
               }
             }
           }
@@ -1037,12 +1042,12 @@
                       "mp4Support" : true,
                       "tags" : [ "maths", "string theory", "video" ],
                       "metadata" : [ {
-                        "key" : "Author",
-                        "value" : "John Doe"
-                      }, {
-                        "key" : "Format",
-                        "value" : "Tutorial"
-                      } ],
+                          "key" : "Author",
+                          "value" : "John Doe"
+                        }, {
+                          "key" : "Format",
+                          "value" : "Tutorial"
+                        } ],
                       "publishedAt" : "2019-12-16T08:25:51+00:00",
                       "updatedAt" : "2019-12-16T08:48:49+00:00",
                       "source" : {
@@ -1076,18 +1081,18 @@
                       "name" : "scheduledAt",
                       "status" : 400,
                       "problems" : [ {
-                        "type" : "https://docs.api.video/docs/attributeinvalid",
-                        "title" : "This attribute must be a ISO-8601 date.",
-                        "name" : "scheduledAt"
-                      }, {
-                        "type" : "https://docs.api.video/docs/attributeinvalid",
-                        "title" : "This attribute must be an array.",
-                        "name" : "tags"
-                      }, {
-                        "type" : "https://docs.api.video/docs/attributeinvalid",
-                        "title" : "This attribute must be an array.",
-                        "name" : "metadata"
-                      } ]
+                          "type" : "https://docs.api.video/docs/attributeinvalid",
+                          "title" : "This attribute must be a ISO-8601 date.",
+                          "name" : "scheduledAt"
+                        }, {
+                          "type" : "https://docs.api.video/docs/attributeinvalid",
+                          "title" : "This attribute must be an array.",
+                          "name" : "tags"
+                        }, {
+                          "type" : "https://docs.api.video/docs/attributeinvalid",
+                          "title" : "This attribute must be an array.",
+                          "name" : "metadata"
+                        } ]
                     }
                   }
                 }
@@ -1126,23 +1131,24 @@
         "summary" : "Show video status",
         "description" : "This API provides upload status & encoding status to determine when the video is uploaded or ready to playback.\n\nOnce encoding is completed, the response also lists the available stream qualities.",
         "operationId" : "GET-video-status",
+        "x-client-action" : "getVideoStatus",
         "parameters" : [ {
-          "name" : "videoId",
-          "in" : "path",
-          "description" : "The unique identifier for the video you want the status for.",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "vi4k0jvEUuaTdRAEjQ4Jfrgz"
-        } ],
+            "name" : "videoId",
+            "in" : "path",
+            "description" : "The unique identifier for the video you want the status for.",
+            "required" : true,
+            "style" : "simple",
+            "explode" : false,
+            "schema" : {
+              "type" : "string"
+            },
+            "example" : "vi4k0jvEUuaTdRAEjQ4Jfrgz"
+          } ],
         "responses" : {
           "200" : {
             "description" : "Success",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/videostatus"
                 },
@@ -1153,37 +1159,37 @@
                         "status" : "uploaded",
                         "filesize" : 273579401,
                         "receivedBytes" : [ {
-                          "to" : 134217727,
-                          "from" : 0,
-                          "total" : 273579401
-                        }, {
-                          "to" : 268435455,
-                          "from" : 134217728,
-                          "total" : 273579401
-                        }, {
-                          "to" : 273579400,
-                          "from" : 268435456,
-                          "total" : 273579401
-                        } ]
+                            "to" : 134217727,
+                            "from" : 0,
+                            "total" : 273579401
+                          }, {
+                            "to" : 268435455,
+                            "from" : 134217728,
+                            "total" : 273579401
+                          }, {
+                            "to" : 273579400,
+                            "from" : 268435456,
+                            "total" : 273579401
+                          } ]
                       },
                       "encoding" : {
                         "playable" : true,
                         "qualities" : [ {
-                          "quality" : "360p",
-                          "status" : "encoded"
-                        }, {
-                          "quality" : "480p",
-                          "status" : "encoded"
-                        }, {
-                          "quality" : "720p",
-                          "status" : "encoded"
-                        }, {
-                          "quality" : "1080p",
-                          "status" : "encoding"
-                        }, {
-                          "quality" : "2160p",
-                          "status" : "waiting"
-                        } ],
+                            "quality" : "360p",
+                            "status" : "encoded"
+                          }, {
+                            "quality" : "480p",
+                            "status" : "encoded"
+                          }, {
+                            "quality" : "720p",
+                            "status" : "encoded"
+                          }, {
+                            "quality" : "1080p",
+                            "status" : "encoding"
+                          }, {
+                            "quality" : "2160p",
+                            "status" : "waiting"
+                          } ],
                         "metadata" : {
                           "width" : 424,
                           "height" : 240,
@@ -1205,7 +1211,7 @@
           "404" : {
             "description" : "Not Found",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/not-found"
                 },
@@ -1224,8 +1230,8 @@
           }
         },
         "security" : [ {
-          "bearerAuth" : [ ]
-        } ]
+            "bearerAuth" : [ ]
+          } ]
       }
     },
     "/upload-tokens" : {
@@ -1234,79 +1240,60 @@
         "summary" : "List all active upload tokens.",
         "description" : "A delegated token is used to allow secure uploads without exposing your API key. Use this endpoint to retrieve a list of all currently active delegated tokens.",
         "operationId" : "GET_upload-tokens",
+        "x-group-parameters" : true,
+        "x-client-paginated" : true,
+        "x-client-action" : "listTokens",
         "parameters" : [ {
-          "name" : "sortBy",
-          "in" : "query",
-          "description" : "Allowed: createdAt, ttl. You can use these to sort by when a token was created, or how much longer the token will be active (ttl - time to live). Date and time is presented in ISO-8601 format.",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "enum" : [ "createdAt", "ttl" ]
-          },
-          "example" : "ttl"
-        }, {
-          "name" : "sortOrder",
-          "in" : "query",
-          "description" : "Allowed: asc, desc. Ascending is 0-9 or A-Z. Descending is 9-0 or Z-A.",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "enum" : [ "asc", "desc" ]
-          },
-          "example" : "asc"
-        }, {
-          "name" : "currentPage",
-          "in" : "query",
-          "description" : "Number of the page to display.",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "minimum" : 1,
-            "type" : "integer",
-            "default" : 1
-          },
-          "example" : 3
-        }, {
-          "name" : "pageSize",
-          "in" : "query",
-          "description" : "Expected number of items to display on the page. If there are less items than fill a page, the page will be shorter than the requested number of items.",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "maximum" : 100,
-            "minimum" : 1,
-            "type" : "integer",
-            "default" : 25
-          },
-          "example" : 20
-        } ],
+            "name" : "sortBy",
+            "in" : "query",
+            "description" : "Allowed: createdAt, ttl. You can use these to sort by when a token was created, or how much longer the token will be active (ttl - time to live). Date and time is presented in ISO-8601 format.",
+            "required" : false,
+            "style" : "form",
+            "explode" : true,
+            "schema" : {
+              "type" : "string",
+              "enum" : [ "createdAt", "ttl" ]
+            },
+            "example" : "ttl"
+          }, {
+            "name" : "sortOrder",
+            "in" : "query",
+            "description" : "Allowed: asc, desc. Ascending is 0-9 or A-Z. Descending is 9-0 or Z-A.",
+            "required" : false,
+            "style" : "form",
+            "explode" : true,
+            "schema" : {
+              "type" : "string",
+              "enum" : [ "asc", "desc" ]
+            },
+            "example" : "asc"
+          }, {
+            "$ref" : "#/components/parameters/currentPage"
+          }, {
+            "$ref" : "#/components/parameters/pageSize"
+          } ],
         "responses" : {
           "200" : {
             "description" : "Success",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/inline_response_200_1"
+                  "$ref" : "#/components/schemas/token-list-response"
                 },
                 "examples" : {
                   "response" : {
                     "value" : {
                       "data" : [ {
-                        "token" : "to37YfoPDRR2pcDKa6LsUE0M",
-                        "ttl" : 3600,
-                        "createdAt" : "2020-12-02T10:26:46+00:00",
-                        "expiresAt" : "2020-12-02T11:26:46+00:00"
-                      }, {
-                        "token" : "to1W3ZS9PdUBZWzzTEZr1B79",
-                        "ttl" : 0,
-                        "createdAt" : "2020-12-02T10:26:28+00:00"
-                      } ],
+                          "token" : "to37YfoPDRR2pcDKa6LsUE0M",
+                          "ttl" : 3600,
+                          "createdAt" : "2020-12-02T10:26:46+00:00",
+                          "expiresAt" : "2020-12-02T11:26:46+00:00"
+                        }, {
+                          "token" : "to1W3ZS9PdUBZWzzTEZr1B79",
+                          "ttl" : 0,
+                          "createdAt" : "2020-12-02T10:26:28+00:00",
+                          "expiresAt" : null
+                        } ],
                       "pagination" : {
                         "currentPage" : 1,
                         "currentPageItems" : 2,
@@ -1314,15 +1301,15 @@
                         "pagesTotal" : 1,
                         "itemsTotal" : 2,
                         "links" : [ {
-                          "rel" : "self",
-                          "uri" : "/upload-tokens?currentPage=1&pageSize=25"
-                        }, {
-                          "rel" : "first",
-                          "uri" : "/upload-tokens?currentPage=1&pageSize=25"
-                        }, {
-                          "rel" : "last",
-                          "uri" : "/upload-tokens?currentPage=1&pageSize=25"
-                        } ]
+                            "rel" : "self",
+                            "uri" : "/upload-tokens?currentPage=1&pageSize=25"
+                          }, {
+                            "rel" : "first",
+                            "uri" : "/upload-tokens?currentPage=1&pageSize=25"
+                          }, {
+                            "rel" : "last",
+                            "uri" : "/upload-tokens?currentPage=1&pageSize=25"
+                          } ]
                       }
                     }
                   }
@@ -1332,19 +1319,20 @@
           }
         },
         "security" : [ {
-          "bearerAuth" : [ ]
-        } ]
+            "bearerAuth" : [ ]
+          } ]
       },
       "post" : {
         "tags" : [ "Videos - Delegated upload" ],
         "summary" : "Generate an upload token",
         "description" : "Use this endpoint to generate an upload token. You can use this token to authenticate video uploads while keeping your API key safe.",
         "operationId" : "POST_upload-tokens",
+        "x-client-action" : "createToken",
         "requestBody" : {
           "content" : {
             "application/json" : {
               "schema" : {
-                "$ref" : "#/components/schemas/body_6"
+                "$ref" : "#/components/schemas/token-create-payload"
               }
             }
           }
@@ -1353,7 +1341,7 @@
           "200" : {
             "description" : "Success",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/upload-token"
                 },
@@ -1373,7 +1361,7 @@
           "400" : {
             "description" : "Bad Request",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/bad-request"
                 }
@@ -1382,8 +1370,8 @@
           }
         },
         "security" : [ {
-          "bearerAuth" : [ ]
-        } ]
+            "bearerAuth" : [ ]
+          } ]
       }
     },
     "/upload-tokens/{uploadToken}" : {
@@ -1392,23 +1380,24 @@
         "summary" : "Show upload token",
         "description" : "You can retrieve details about a specific upload token if you have the unique identifier for the upload token. Add it in the path of the endpoint. Details include time-to-live (ttl), when the token was created, and when it will expire.",
         "operationId" : "GET_upload-tokens-uploadToken",
+        "x-client-action" : "getToken",
         "parameters" : [ {
-          "name" : "uploadToken",
-          "in" : "path",
-          "description" : "The unique identifier for the token you want information about.",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "to1tcmSFHeYY5KzyhOqVKMKb"
-        } ],
+            "name" : "uploadToken",
+            "in" : "path",
+            "description" : "The unique identifier for the token you want information about.",
+            "required" : true,
+            "style" : "simple",
+            "explode" : false,
+            "schema" : {
+              "type" : "string"
+            },
+            "example" : "to1tcmSFHeYY5KzyhOqVKMKb"
+          } ],
         "responses" : {
           "200" : {
             "description" : "Success",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/upload-token"
                 },
@@ -1417,7 +1406,8 @@
                     "value" : {
                       "token" : "to1tcmSFHeYY5KzyhOqVKMKb",
                       "ttl" : 0,
-                      "createdAt" : "2020-12-02T10:13:19+00:00"
+                      "createdAt" : "2020-12-02T10:13:19+00:00",
+                      "expiresAt" : null
                     }
                   }
                 }
@@ -1427,7 +1417,7 @@
           "404" : {
             "description" : "Not Found",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/not-found"
                 }
@@ -1436,26 +1426,27 @@
           }
         },
         "security" : [ {
-          "bearerAuth" : [ ]
-        } ]
+            "bearerAuth" : [ ]
+          } ]
       },
       "delete" : {
         "tags" : [ "Videos - Delegated upload" ],
         "summary" : "Delete an upload token",
         "description" : "Delete an existing upload token. This is especially useful for tokens you may have created that do not expire.",
         "operationId" : "DELETE_upload-tokens-uploadToken",
+        "x-client-action" : "deleteToken",
         "parameters" : [ {
-          "name" : "uploadToken",
-          "in" : "path",
-          "description" : "The unique identifier for the upload token you want to delete. Deleting a token will make it so the token can no longer be used for authentication.",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "to1tcmSFHeYY5KzyhOqVKMKb"
-        } ],
+            "name" : "uploadToken",
+            "in" : "path",
+            "description" : "The unique identifier for the upload token you want to delete. Deleting a token will make it so the token can no longer be used for authentication.",
+            "required" : true,
+            "style" : "simple",
+            "explode" : false,
+            "schema" : {
+              "type" : "string"
+            },
+            "example" : "to1tcmSFHeYY5KzyhOqVKMKb"
+          } ],
         "responses" : {
           "204" : {
             "description" : "No Content"
@@ -1463,7 +1454,7 @@
           "404" : {
             "description" : "Not Found",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/not-found"
                 }
@@ -1472,8 +1463,8 @@
           }
         },
         "security" : [ {
-          "bearerAuth" : [ ]
-        } ]
+            "bearerAuth" : [ ]
+          } ]
       }
     },
     "/upload" : {
@@ -1482,35 +1473,38 @@
         "summary" : "Upload with an upload token",
         "description" : "When given a token, anyone can upload a file to the URI `https://ws.api.video/upload?token=<tokenId>`.\n\nExample with cURL:\n\n```curl\n$ curl  --request POST --url 'https://ws.api.video/upload?token=toXXX'\n --header 'content-type: multipart/form-data'\n -F file=@video.mp4\n```\n\nOr in an HTML form, with a little JavaScript to convert the form into JSON:\n```html\n<!--form for user interaction-->\n<form name=\"videoUploadForm\" >\n  <label for=video>Video:</label>\n  <input type=file name=source/><br/>\n  <input value=\"Submit\" type=\"submit\">\n</form>\n<div></div>\n<!--JS takes the form data \n    uses FormData to turn the response into JSON.\n    then uses POST to upload the video file.\n    Update the token parameter in the url to your upload token.\n    -->\n<script>\n   var form = document.forms.namedItem(\"videoUploadForm\");\t\n   form.addEventListener('submit', function(ev) {\n\t ev.preventDefault();\n     var oOutput = document.querySelector(\"div\"),\n         oData = new FormData(form);\n     var oReq = new XMLHttpRequest();\n\t \n     oReq.open(\"POST\", \"https://ws.api.video/upload?token=toXXX\", true);\n     oReq.send(oData);\n\t oReq.onload = function(oEvent) {\n       if (oReq.status ==201) {\n         oOutput.innerHTML = \"Your video is uploaded!<br/>\"  + oReq.response;\n       } else {\n         oOutput.innerHTML = \"Error \" + oReq.status + \" occurred when trying to upload your file.<br \\/>\";\n       }\n     };\n   }, false);\t\n</script>\n```\n\n\n### Dealing with large files\n\nWe have created a <a href='https://api.video/blog/tutorials/uploading-large-files-with-javascript'>tutorial</a> to walk through the steps required.",
         "operationId" : "POST_upload",
+        "x-client-action" : "upload",
+        "x-client-chunk-upload" : true,
         "parameters" : [ {
-          "name" : "token",
-          "in" : "query",
-          "description" : "The unique identifier for the token you want to use to upload a video.",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "to1tcmSFHeYY5KzyhOqVKMKb"
-        }, {
-          "name" : "Content-Range",
-          "in" : "header",
-          "description" : "Content-Range represents the range of bytes that will be returned as a result of the request. Byte ranges are inclusive, meaning that bytes 0-999 represents the first 1000 bytes in a file or object.",
-          "required" : false,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "pattern" : "^bytes [0-9]*-[0-9]*\\/[0-9]*$",
-            "type" : "string"
-          },
-          "example" : "Content-Range: bytes 200-100/5000"
-        } ],
+            "name" : "token",
+            "in" : "query",
+            "description" : "The unique identifier for the token you want to use to upload a video.",
+            "required" : true,
+            "style" : "form",
+            "explode" : true,
+            "schema" : {
+              "type" : "string"
+            },
+            "example" : "to1tcmSFHeYY5KzyhOqVKMKb"
+          }, {
+            "name" : "Content-Range",
+            "in" : "header",
+            "description" : "Content-Range represents the range of bytes that will be returned as a result of the request. Byte ranges are inclusive, meaning that bytes 0-999 represents the first 1000 bytes in a file or object.",
+            "required" : false,
+            "x-client-ignore" : true,
+            "style" : "simple",
+            "explode" : false,
+            "schema" : {
+              "pattern" : "^bytes [0-9]*-[0-9]*\\/[0-9]*$",
+              "type" : "string"
+            },
+            "example" : "Content-Range: bytes 200-100/5000"
+          } ],
         "requestBody" : {
           "content" : {
             "multipart/form-data" : {
               "schema" : {
-                "$ref" : "#/components/schemas/body_7"
+                "$ref" : "#/components/schemas/token-upload-payload"
               }
             }
           }
@@ -1519,7 +1513,7 @@
           "201" : {
             "description" : "Created",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/video"
                 },
@@ -1534,12 +1528,12 @@
                       "panoramic" : false,
                       "tags" : [ "maths", "string theory", "video" ],
                       "metadata" : [ {
-                        "key" : "Author",
-                        "value" : "John Doe"
-                      }, {
-                        "key" : "Format",
-                        "value" : "Tutorial"
-                      } ],
+                          "key" : "Author",
+                          "value" : "John Doe"
+                        }, {
+                          "key" : "Format",
+                          "value" : "Tutorial"
+                        } ],
                       "publishedAt" : "4665-07-14T23:36:18.598Z",
                       "source" : {
                         "uri" : "/videos/vi4k0jvEUuaTdRAEjQ4Jfrgz/source"
@@ -1559,14 +1553,15 @@
           "400" : {
             "description" : "Bad Request",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/bad-request"
                 }
               }
             }
           }
-        }
+        },
+        "security" : [ ]
       }
     },
     "/live-streams" : {
@@ -1575,121 +1570,101 @@
         "summary" : "List all live streams",
         "description" : "With no parameters added to the url, this will return all livestreams. Query by name or key to limit the list.",
         "operationId" : "GET_live-streams",
+        "x-client-action" : "list",
+        "x-group-parameters" : true,
+        "x-client-paginated" : true,
         "parameters" : [ {
-          "name" : "streamKey",
-          "in" : "query",
-          "description" : "The unique stream key that allows you to stream videos.",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "30087931-229e-42cf-b5f9-e91bcc1f7332"
-        }, {
-          "name" : "name",
-          "in" : "query",
-          "description" : "You can filter live streams by their name or a part of their name.",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "My Video"
-        }, {
-          "name" : "sortBy",
-          "in" : "query",
-          "description" : "Allowed: createdAt, publishedAt, name. createdAt - the time a livestream was created using the specified streamKey. publishedAt - the time a livestream was published using the specified streamKey. name - the name of the livestream. If you choose one of the time based options, the time is presented in ISO-8601 format.",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "createdAt"
-        }, {
-          "name" : "sortOrder",
-          "in" : "query",
-          "description" : "Allowed: asc, desc. Ascending for date and time means that earlier values precede later ones. Descending means that later values preced earlier ones. For title, it is 0-9 and A-Z ascending and Z-A, 9-0 descending.",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "enum" : [ "asc", "desc" ]
-          },
-          "example" : "desc"
-        }, {
-          "name" : "currentPage",
-          "in" : "query",
-          "description" : "Number of the page to display.",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "minimum" : 1,
-            "type" : "integer",
-            "default" : 1
-          },
-          "example" : 3
-        }, {
-          "name" : "pageSize",
-          "in" : "query",
-          "description" : "Expected number of items to display on the page. If there are not enough items to fill the last page, it will be partially filled.",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "maximum" : 100,
-            "minimum" : 1,
-            "type" : "integer",
-            "default" : 25
-          },
-          "example" : 30
-        } ],
+            "name" : "streamKey",
+            "in" : "query",
+            "description" : "The unique stream key that allows you to stream videos.",
+            "required" : false,
+            "style" : "form",
+            "explode" : true,
+            "schema" : {
+              "type" : "string"
+            },
+            "example" : "30087931-229e-42cf-b5f9-e91bcc1f7332"
+          }, {
+            "name" : "name",
+            "in" : "query",
+            "description" : "You can filter live streams by their name or a part of their name.",
+            "required" : false,
+            "style" : "form",
+            "explode" : true,
+            "schema" : {
+              "type" : "string"
+            },
+            "example" : "My Video"
+          }, {
+            "name" : "sortBy",
+            "in" : "query",
+            "description" : "Allowed: createdAt, publishedAt, name. createdAt - the time a livestream was created using the specified streamKey. publishedAt - the time a livestream was published using the specified streamKey. name - the name of the livestream. If you choose one of the time based options, the time is presented in ISO-8601 format.",
+            "required" : false,
+            "style" : "form",
+            "explode" : true,
+            "schema" : {
+              "type" : "string"
+            },
+            "example" : "createdAt"
+          }, {
+            "name" : "sortOrder",
+            "in" : "query",
+            "description" : "Allowed: asc, desc. Ascending for date and time means that earlier values precede later ones. Descending means that later values preced earlier ones. For title, it is 0-9 and A-Z ascending and Z-A, 9-0 descending.",
+            "required" : false,
+            "style" : "form",
+            "explode" : true,
+            "schema" : {
+              "type" : "string",
+              "enum" : [ "asc", "desc" ]
+            },
+            "example" : "desc"
+          }, {
+            "$ref" : "#/components/parameters/currentPage"
+          }, {
+            "$ref" : "#/components/parameters/pageSize"
+          } ],
         "responses" : {
           "200" : {
             "description" : "Success",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/inline_response_200_2"
+                  "$ref" : "#/components/schemas/live-stream-list-response"
                 },
                 "examples" : {
                   "response" : {
                     "value" : {
                       "data" : [ {
-                        "liveStreamId" : "li400mYKSgQ6xs7taUeSaEKr",
-                        "createdAt" : "2020-01-31T10:17:47+00:00",
-                        "updatedAt" : "2020-03-09T13:19:43+00:00",
-                        "streamKey" : "30087931-229e-42cf-b5f9-e91bcc1f7332",
-                        "name" : "Live Stream From the browser",
-                        "public" : true,
-                        "record" : true,
-                        "broadcasting" : false,
-                        "assets" : {
-                          "iframe" : "<iframe src=\"https://embed.api.video/live/li400mYKSgQ6xs7taUeSaEKr\" width=\"100%\" height=\"100%\" frameborder=\"0\" scrolling=\"no\" allowfullscreen=\"\"></iframe>",
-                          "player" : "https://embed.api.video/live/li400mYKSgQ6xs7taUeSaEKr",
-                          "hls" : "https://live.api.video/li400mYKSgQ6xs7taUeSaEKr.m3u8",
-                          "thumbnail" : "https://cdn.api.video/live/li400mYKSgQ6xs7taUeSaEKr/thumbnail.jpg"
-                        }
-                      }, {
-                        "liveStreamId" : "li4pqNqGUkhKfWcBGpZVLRY5",
-                        "createdAt" : "2020-07-29T10:45:35+00:00",
-                        "updatedAt" : "2020-07-29T10:45:35+00:00",
-                        "streamKey" : "cc1b4df0-d1c5-4064-a8f9-9f0368385135",
-                        "name" : "Live From New York",
-                        "public" : true,
-                        "record" : true,
-                        "broadcasting" : false,
-                        "assets" : {
-                          "iframe" : "<iframe src=\"https://embed.api.video/live/li4pqNqGUkhKfWcBGpZVLRY5\" width=\"100%\" height=\"100%\" frameborder=\"0\" scrolling=\"no\" allowfullscreen=\"\"></iframe>",
-                          "player" : "https://embed.api.video/live/li4pqNqGUkhKfWcBGpZVLRY5",
-                          "hls" : "https://live.api.video/li4pqNqGUkhKfWcBGpZVLRY5.m3u8",
-                          "thumbnail" : "https://cdn.api.video/live/li4pqNqGUkhKfWcBGpZVLRY5/thumbnail.jpg"
-                        }
-                      } ],
+                          "liveStreamId" : "li400mYKSgQ6xs7taUeSaEKr",
+                          "createdAt" : "2020-01-31T10:17:47+00:00",
+                          "updatedAt" : "2020-03-09T13:19:43+00:00",
+                          "streamKey" : "30087931-229e-42cf-b5f9-e91bcc1f7332",
+                          "name" : "Live Stream From the browser",
+                          "public" : true,
+                          "record" : true,
+                          "broadcasting" : false,
+                          "assets" : {
+                            "iframe" : "<iframe src=\"https://embed.api.video/live/li400mYKSgQ6xs7taUeSaEKr\" width=\"100%\" height=\"100%\" frameborder=\"0\" scrolling=\"no\" allowfullscreen=\"\"></iframe>",
+                            "player" : "https://embed.api.video/live/li400mYKSgQ6xs7taUeSaEKr",
+                            "hls" : "https://live.api.video/li400mYKSgQ6xs7taUeSaEKr.m3u8",
+                            "thumbnail" : "https://cdn.api.video/live/li400mYKSgQ6xs7taUeSaEKr/thumbnail.jpg"
+                          }
+                        }, {
+                          "liveStreamId" : "li4pqNqGUkhKfWcBGpZVLRY5",
+                          "createdAt" : "2020-07-29T10:45:35+00:00",
+                          "updatedAt" : "2020-07-29T10:45:35+00:00",
+                          "streamKey" : "cc1b4df0-d1c5-4064-a8f9-9f0368385135",
+                          "name" : "Live From New York",
+                          "public" : true,
+                          "record" : true,
+                          "broadcasting" : false,
+                          "assets" : {
+                            "iframe" : "<iframe src=\"https://embed.api.video/live/li4pqNqGUkhKfWcBGpZVLRY5\" width=\"100%\" height=\"100%\" frameborder=\"0\" scrolling=\"no\" allowfullscreen=\"\"></iframe>",
+                            "player" : "https://embed.api.video/live/li4pqNqGUkhKfWcBGpZVLRY5",
+                            "hls" : "https://live.api.video/li4pqNqGUkhKfWcBGpZVLRY5.m3u8",
+                            "thumbnail" : "https://cdn.api.video/live/li4pqNqGUkhKfWcBGpZVLRY5/thumbnail.jpg"
+                          }
+                        } ],
                       "pagination" : {
                         "currentPage" : 1,
                         "currentPageItems" : 19,
@@ -1697,15 +1672,15 @@
                         "pagesTotal" : 1,
                         "itemsTotal" : 19,
                         "links" : [ {
-                          "rel" : "self",
-                          "uri" : "/live-streams?currentPage=1&pageSize=25"
-                        }, {
-                          "rel" : "first",
-                          "uri" : "/live-streams?currentPage=1&pageSize=25"
-                        }, {
-                          "rel" : "last",
-                          "uri" : "/live-streams?currentPage=1&pageSize=25"
-                        } ]
+                            "rel" : "self",
+                            "uri" : "/live-streams?currentPage=1&pageSize=25"
+                          }, {
+                            "rel" : "first",
+                            "uri" : "/live-streams?currentPage=1&pageSize=25"
+                          }, {
+                            "rel" : "last",
+                            "uri" : "/live-streams?currentPage=1&pageSize=25"
+                          } ]
                       }
                     }
                   }
@@ -1715,19 +1690,20 @@
           }
         },
         "security" : [ {
-          "bearerAuth" : [ ]
-        } ]
+            "bearerAuth" : [ ]
+          } ]
       },
       "post" : {
         "tags" : [ "Live" ],
         "summary" : "Create live stream",
         "description" : "A live stream will give you the 'connection point' to RTMP your video stream to api.video. It will also give you the details for viewers to watch the same livestream. \nThe public=false 'private livestream' is available as a BETA feature, and should be limited to livestreams of 3,000 viewers or fewer.\n\nSee our [Live Stream Tutorial](https://api.video/blog/tutorials/live-stream-tutorial) for a walkthrough of this API with OBS.\nYour RTMP endpoint for the livestream is rtmp://broadcast.api.video/s/{streamKey}",
         "operationId" : "POST_live-streams",
+        "x-client-action" : "create",
         "requestBody" : {
           "content" : {
             "application/json" : {
               "schema" : {
-                "$ref" : "#/components/schemas/body_8"
+                "$ref" : "#/components/schemas/live-stream-create-payload"
               }
             }
           }
@@ -1736,7 +1712,7 @@
           "200" : {
             "description" : "Success",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/live-stream"
                 },
@@ -1766,7 +1742,7 @@
           "400" : {
             "description" : "Bad Request",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/bad-request"
                 }
@@ -1775,8 +1751,8 @@
           }
         },
         "security" : [ {
-          "bearerAuth" : [ ]
-        } ]
+            "bearerAuth" : [ ]
+          } ]
       }
     },
     "/live-streams/{liveStreamId}" : {
@@ -1785,23 +1761,24 @@
         "summary" : "Show live stream",
         "description" : "Supply a LivestreamId, and you'll get all the details for streaming into, and watching the livestream.",
         "operationId" : "GET_live-streams-liveStreamId",
+        "x-client-action" : "get",
         "parameters" : [ {
-          "name" : "liveStreamId",
-          "in" : "path",
-          "description" : "The unique ID for the live stream you want to watch.",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "li400mYKSgQ6xs7taUeSaEKr"
-        } ],
+            "name" : "liveStreamId",
+            "in" : "path",
+            "description" : "The unique ID for the live stream you want to watch.",
+            "required" : true,
+            "style" : "simple",
+            "explode" : false,
+            "schema" : {
+              "type" : "string"
+            },
+            "example" : "li400mYKSgQ6xs7taUeSaEKr"
+          } ],
         "responses" : {
           "200" : {
             "description" : "Success",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/live-stream"
                 },
@@ -1830,56 +1807,58 @@
           }
         },
         "security" : [ {
-          "bearerAuth" : [ ]
-        } ]
+            "bearerAuth" : [ ]
+          } ]
       },
       "delete" : {
         "tags" : [ "Live" ],
         "summary" : "Delete a live stream",
         "operationId" : "DELETE_live-streams-liveStreamId",
+        "x-client-action" : "delete",
         "parameters" : [ {
-          "name" : "liveStreamId",
-          "in" : "path",
-          "description" : "The unique ID for the live stream that you want to remove.",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "li400mYKSgQ6xs7taUeSaEKr"
-        } ],
+            "name" : "liveStreamId",
+            "in" : "path",
+            "description" : "The unique ID for the live stream that you want to remove.",
+            "required" : true,
+            "style" : "simple",
+            "explode" : false,
+            "schema" : {
+              "type" : "string"
+            },
+            "example" : "li400mYKSgQ6xs7taUeSaEKr"
+          } ],
         "responses" : {
           "204" : {
             "description" : "No Content"
           }
         },
         "security" : [ {
-          "bearerAuth" : [ ]
-        } ]
+            "bearerAuth" : [ ]
+          } ]
       },
       "patch" : {
         "tags" : [ "Live" ],
         "summary" : "Update a live stream",
         "description" : "Use this endpoint to update the player, or to turn recording on/off (saving a copy of the livestream). NOTE: If the livestream is actively streaming, changing the recording status will only affect the NEXT stream.    The public=false 'private livestream' is available as a BETA feature, and should be limited to livestreams of 3,000 viewers or fewer.",
         "operationId" : "PATCH_live-streams-liveStreamId",
+        "x-client-action" : "update",
         "parameters" : [ {
-          "name" : "liveStreamId",
-          "in" : "path",
-          "description" : "The unique ID for the live stream that you want to update information for such as player details, or whether you want the recording on or off.",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "li400mYKSgQ6xs7taUeSaEKr"
-        } ],
+            "name" : "liveStreamId",
+            "in" : "path",
+            "description" : "The unique ID for the live stream that you want to update information for such as player details, or whether you want the recording on or off.",
+            "required" : true,
+            "style" : "simple",
+            "explode" : false,
+            "schema" : {
+              "type" : "string"
+            },
+            "example" : "li400mYKSgQ6xs7taUeSaEKr"
+          } ],
         "requestBody" : {
           "content" : {
             "application/json" : {
               "schema" : {
-                "$ref" : "#/components/schemas/body_9"
+                "$ref" : "#/components/schemas/live-stream-update-payload"
               }
             }
           }
@@ -1888,7 +1867,7 @@
           "200" : {
             "description" : "Success",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/live-stream"
                 },
@@ -1918,7 +1897,7 @@
           "400" : {
             "description" : "Bad Request",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/bad-request"
                 }
@@ -1927,8 +1906,8 @@
           }
         },
         "security" : [ {
-          "bearerAuth" : [ ]
-        } ]
+            "bearerAuth" : [ ]
+          } ]
       }
     },
     "/live-streams/{liveStreamId}/thumbnail" : {
@@ -1937,26 +1916,33 @@
         "summary" : "Upload a thumbnail",
         "description" : "Upload an image to use as a backdrop for your livestream.",
         "operationId" : "POST_live-streams-liveStreamId-thumbnail",
+        "x-client-action" : "uploadThumbnail",
         "parameters" : [ {
-          "name" : "liveStreamId",
-          "in" : "path",
-          "description" : "The unique ID for the live stream you want to upload.",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "vi4k0jvEUuaTdRAEjQ4Jfrgz"
-        } ],
+            "name" : "liveStreamId",
+            "in" : "path",
+            "description" : "The unique ID for the live stream you want to upload.",
+            "required" : true,
+            "style" : "simple",
+            "explode" : false,
+            "schema" : {
+              "type" : "string"
+            },
+            "example" : "vi4k0jvEUuaTdRAEjQ4Jfrgz"
+          } ],
         "requestBody" : {
-          "$ref" : "#/components/requestBodies/POST_videos-videoId-thumbnail"
+          "content" : {
+            "multipart/form-data" : {
+              "schema" : {
+                "$ref" :  "#/components/schemas/live-stream-thumbnail-upload-payload"
+              }
+            }
+          }
         },
         "responses" : {
           "201" : {
             "description" : "Created",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/live-stream"
                 }
@@ -1966,7 +1952,7 @@
           "400" : {
             "description" : "Bad Request",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/bad-request"
                 },
@@ -1986,7 +1972,7 @@
           "404" : {
             "description" : "Not Found",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/not-found"
                 },
@@ -2005,31 +1991,32 @@
           }
         },
         "security" : [ {
-          "bearerAuth" : [ ]
-        } ]
+            "bearerAuth" : [ ]
+          } ]
       },
       "delete" : {
         "tags" : [ "Live" ],
         "summary" : "Delete a thumbnail",
         "description" : "Send the unique identifier for a live stream to delete it from the system.",
         "operationId" : "DELETE_live-streams-liveStreamId-thumbnail",
+        "x-client-action" : "deleteThumbnail",
         "parameters" : [ {
-          "name" : "liveStreamId",
-          "in" : "path",
-          "description" : "The unique identifier for the live stream you want to delete. ",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "li400mYKSgQ6xs7taUeSaEKr"
-        } ],
+            "name" : "liveStreamId",
+            "in" : "path",
+            "description" : "The unique identifier for the live stream you want to delete. ",
+            "required" : true,
+            "style" : "simple",
+            "explode" : false,
+            "schema" : {
+              "type" : "string"
+            },
+            "example" : "li400mYKSgQ6xs7taUeSaEKr"
+          } ],
         "responses" : {
           "200" : {
             "description" : "Success",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/live-stream"
                 }
@@ -2039,7 +2026,7 @@
           "404" : {
             "description" : "Not Found",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/not-found"
                 },
@@ -2058,8 +2045,8 @@
           }
         },
         "security" : [ {
-          "bearerAuth" : [ ]
-        } ]
+            "bearerAuth" : [ ]
+          } ]
       }
     },
     "/videos/{videoId}/captions/{language}" : {
@@ -2068,34 +2055,35 @@
         "summary" : "Show a caption",
         "description" : "Display a caption for a video in a specific language. If the language is available, the caption is returned. Otherwise, you will get a response indicating the caption was not found.",
         "operationId" : "GET_videos-videoId-captions-language",
+        "x-client-action" : "get",
         "parameters" : [ {
-          "name" : "videoId",
-          "in" : "path",
-          "description" : "The unique identifier for the video you want captions for.",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "vi4k0jvEUuaTdRAEjQ4Prklg"
-        }, {
-          "name" : "language",
-          "in" : "path",
-          "description" : "A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "en"
-        } ],
+            "name" : "videoId",
+            "in" : "path",
+            "description" : "The unique identifier for the video you want captions for.",
+            "required" : true,
+            "style" : "simple",
+            "explode" : false,
+            "schema" : {
+              "type" : "string"
+            },
+            "example" : "vi4k0jvEUuaTdRAEjQ4Prklg"
+          }, {
+            "name" : "language",
+            "in" : "path",
+            "description" : "A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation",
+            "required" : true,
+            "style" : "simple",
+            "explode" : false,
+            "schema" : {
+              "type" : "string"
+            },
+            "example" : "en"
+          } ],
         "responses" : {
           "200" : {
             "description" : "Success",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/subtitle"
                 },
@@ -2115,7 +2103,7 @@
           "404" : {
             "description" : "Not Found",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/not-found"
                 }
@@ -2124,42 +2112,43 @@
           }
         },
         "security" : [ {
-          "bearerAuth" : [ ]
-        } ]
+            "bearerAuth" : [ ]
+          } ]
       },
       "post" : {
         "tags" : [ "Captions" ],
         "summary" : "Upload a caption",
         "description" : "Upload a VTT file to add captions to your video.\n Read our [captioning tutorial](https://api.video/blog/tutorials/adding-captions) for more details.",
         "operationId" : "POST_videos-videoId-captions-language",
+        "x-client-action" : "upload",
         "parameters" : [ {
-          "name" : "videoId",
-          "in" : "path",
-          "description" : "The unique identifier for the video you want to add a caption to.",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "vi4k0jvEUuaTdRAEjQ4Prklg"
-        }, {
-          "name" : "language",
-          "in" : "path",
-          "description" : "A valid BCP 47 language representation.",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "en"
-        } ],
+            "name" : "videoId",
+            "in" : "path",
+            "description" : "The unique identifier for the video you want to add a caption to.",
+            "required" : true,
+            "style" : "simple",
+            "explode" : false,
+            "schema" : {
+              "type" : "string"
+            },
+            "example" : "vi4k0jvEUuaTdRAEjQ4Prklg"
+          }, {
+            "name" : "language",
+            "in" : "path",
+            "description" : "A valid BCP 47 language representation.",
+            "required" : true,
+            "style" : "simple",
+            "explode" : false,
+            "schema" : {
+              "type" : "string"
+            },
+            "example" : "en"
+          } ],
         "requestBody" : {
           "content" : {
             "multipart/form-data" : {
               "schema" : {
-                "$ref" : "#/components/schemas/body_10"
+                "$ref" : "#/components/schemas/captions-upload-payload"
               }
             }
           }
@@ -2168,7 +2157,7 @@
           "200" : {
             "description" : "Success",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/subtitle"
                 },
@@ -2188,7 +2177,7 @@
           "400" : {
             "description" : "Bad Request",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/bad-request"
                 }
@@ -2198,7 +2187,7 @@
           "404" : {
             "description" : "Not Found",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/not-found"
                 }
@@ -2207,37 +2196,38 @@
           }
         },
         "security" : [ {
-          "bearerAuth" : [ ]
-        } ]
+            "bearerAuth" : [ ]
+          } ]
       },
       "delete" : {
         "tags" : [ "Captions" ],
         "summary" : "Delete a caption",
         "description" : "Delete a caption in a specific language by providing the video ID for the video you want to delete the caption from and the language the caption is in.",
         "operationId" : "DELETE_videos-videoId-captions-language",
+        "x-client-action" : "delete",
         "parameters" : [ {
-          "name" : "videoId",
-          "in" : "path",
-          "description" : "The unique identifier for the video you want to delete a caption from.",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "vi4k0jvEUuaTdRAEjQ4Prklgc"
-        }, {
-          "name" : "language",
-          "in" : "path",
-          "description" : "A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "en"
-        } ],
+            "name" : "videoId",
+            "in" : "path",
+            "description" : "The unique identifier for the video you want to delete a caption from.",
+            "required" : true,
+            "style" : "simple",
+            "explode" : false,
+            "schema" : {
+              "type" : "string"
+            },
+            "example" : "vi4k0jvEUuaTdRAEjQ4Prklgc"
+          }, {
+            "name" : "language",
+            "in" : "path",
+            "description" : "A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.",
+            "required" : true,
+            "style" : "simple",
+            "explode" : false,
+            "schema" : {
+              "type" : "string"
+            },
+            "example" : "en"
+          } ],
         "responses" : {
           "204" : {
             "description" : "No Content"
@@ -2245,7 +2235,7 @@
           "404" : {
             "description" : "Not Found",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/not-found"
                 }
@@ -2254,42 +2244,43 @@
           }
         },
         "security" : [ {
-          "bearerAuth" : [ ]
-        } ]
+            "bearerAuth" : [ ]
+          } ]
       },
       "patch" : {
         "tags" : [ "Captions" ],
         "summary" : "Update caption",
         "description" : "To have the captions on automatically, use this PATCH to set default: true.",
         "operationId" : "PATCH_videos-videoId-captions-language",
+        "x-client-action" : "update",
         "parameters" : [ {
-          "name" : "videoId",
-          "in" : "path",
-          "description" : "The unique identifier for the video you want to have automatic captions for. ",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "vi4k0jvEUuaTdRAEjQ4Prklg"
-        }, {
-          "name" : "language",
-          "in" : "path",
-          "description" : "A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "en"
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/body_11"
+            "name" : "videoId",
+            "in" : "path",
+            "description" : "The unique identifier for the video you want to have automatic captions for. ",
+            "required" : true,
+            "style" : "simple",
+            "explode" : false,
+            "schema" : {
+              "type" : "string"
+            },
+            "example" : "vi4k0jvEUuaTdRAEjQ4Prklg"
+          }, {
+            "name" : "language",
+            "in" : "path",
+            "description" : "A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.",
+            "required" : true,
+            "style" : "simple",
+            "explode" : false,
+            "schema" : {
+              "type" : "string"
+            },
+            "example" : "en"
+          } ],
+          "requestBody" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/captions-update-payload"
               }
             }
           }
@@ -2298,7 +2289,7 @@
           "200" : {
             "description" : "Success",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/subtitle"
                 },
@@ -2318,7 +2309,7 @@
           "400" : {
             "description" : "Bad Request",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/bad-request"
                 },
@@ -2339,7 +2330,7 @@
           "404" : {
             "description" : "Not Found",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/not-found"
                 },
@@ -2358,8 +2349,8 @@
           }
         },
         "security" : [ {
-          "bearerAuth" : [ ]
-        } ]
+            "bearerAuth" : [ ]
+          } ]
       }
     },
     "/videos/{videoId}/captions" : {
@@ -2368,40 +2359,47 @@
         "summary" : "List video captions",
         "description" : "Retrieve a list of available captions for the videoId you provide.",
         "operationId" : "GET_videos-videoId-captions",
+        "x-client-action" : "list",
+        "x-group-parameters" : true,
+        "x-client-paginated" : true,
         "parameters" : [ {
-          "name" : "videoId",
-          "in" : "path",
-          "description" : "The unique identifier for the video you want to retrieve a list of captions for.",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "vi4k0jvEUuaTdRAEjQ4Prklg"
-        } ],
+            "name" : "videoId",
+            "in" : "path",
+            "description" : "The unique identifier for the video you want to retrieve a list of captions for.",
+            "required" : true,
+            "style" : "simple",
+            "explode" : false,
+            "schema" : {
+              "type" : "string"
+            },
+            "example" : "vi4k0jvEUuaTdRAEjQ4Prklg"
+          }, {
+            "$ref" : "#/components/parameters/currentPage"
+          }, {
+            "$ref" : "#/components/parameters/pageSize"
+          } ],
         "responses" : {
           "200" : {
             "description" : "Success",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/inline_response_200_3"
+                  "$ref" : "#/components/schemas/captions-list-response"
                 },
                 "examples" : {
                   "response" : {
                     "value" : {
                       "data" : [ {
-                        "uri" : "/videos/vi3N6cDinStg3oBbN79GklWS/captions/en",
-                        "src" : "https://cdn.api.video/vod/vi3N6cDinStg3oBbN79GklWS/captions/en.vtt",
-                        "srclang" : "en",
-                        "default" : false
-                      }, {
-                        "uri" : "/videos/vi3N6cDinStg3oBbN79GklWS/captions/fr",
-                        "src" : "https://cdn.api.video/vod/vi3N6cDinStg3oBbN79GklWS/captions/fr.vtt",
-                        "srclang" : "fr",
-                        "default" : false
-                      } ],
+                          "uri" : "/videos/vi3N6cDinStg3oBbN79GklWS/captions/en",
+                          "src" : "https://cdn.api.video/vod/vi3N6cDinStg3oBbN79GklWS/captions/en.vtt",
+                          "srclang" : "en",
+                          "default" : false
+                        }, {
+                          "uri" : "/videos/vi3N6cDinStg3oBbN79GklWS/captions/fr",
+                          "src" : "https://cdn.api.video/vod/vi3N6cDinStg3oBbN79GklWS/captions/fr.vtt",
+                          "srclang" : "fr",
+                          "default" : false
+                        } ],
                       "pagination" : {
                         "currentPage" : 1,
                         "currentPageItems" : 2,
@@ -2409,15 +2407,15 @@
                         "pagesTotal" : 1,
                         "itemsTotal" : 2,
                         "links" : [ {
-                          "rel" : "self",
-                          "uri" : "/videos/vi3N6cDinStg3oBbN79GklWS/captions?currentPage=1&pageSize=25"
-                        }, {
-                          "rel" : "first",
-                          "uri" : "/videos/vi3N6cDinStg3oBbN79GklWS/captions?currentPage=1&pageSize=25"
-                        }, {
-                          "rel" : "last",
-                          "uri" : "/videos/vi3N6cDinStg3oBbN79GklWS/captions?currentPage=1&pageSize=25"
-                        } ]
+                            "rel" : "self",
+                            "uri" : "/videos/vi3N6cDinStg3oBbN79GklWS/captions?currentPage=1&pageSize=25"
+                          }, {
+                            "rel" : "first",
+                            "uri" : "/videos/vi3N6cDinStg3oBbN79GklWS/captions?currentPage=1&pageSize=25"
+                          }, {
+                            "rel" : "last",
+                            "uri" : "/videos/vi3N6cDinStg3oBbN79GklWS/captions?currentPage=1&pageSize=25"
+                          } ]
                       }
                     }
                   }
@@ -2428,7 +2426,7 @@
           "404" : {
             "description" : "Not Found",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/not-found"
                 }
@@ -2437,8 +2435,8 @@
           }
         },
         "security" : [ {
-          "bearerAuth" : [ ]
-        } ]
+            "bearerAuth" : [ ]
+          } ]
       }
     },
     "/videos/{videoId}/chapters/{language}" : {
@@ -2446,34 +2444,35 @@
         "tags" : [ "Chapters" ],
         "summary" : "Show a chapter",
         "operationId" : "GET_videos-videoId-chapters-language",
+        "x-client-action" : "get",
         "parameters" : [ {
-          "name" : "videoId",
-          "in" : "path",
-          "description" : "The unique identifier for the video you want to show a chapter for.",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "vi4k0jvEUuaTdRAEjQ4Jfrgz"
-        }, {
-          "name" : "language",
-          "in" : "path",
-          "description" : "A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "en"
-        } ],
+            "name" : "videoId",
+            "in" : "path",
+            "description" : "The unique identifier for the video you want to show a chapter for.",
+            "required" : true,
+            "style" : "simple",
+            "explode" : false,
+            "schema" : {
+              "type" : "string"
+            },
+            "example" : "vi4k0jvEUuaTdRAEjQ4Jfrgz"
+          }, {
+            "name" : "language",
+            "in" : "path",
+            "description" : "A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.",
+            "required" : true,
+            "style" : "simple",
+            "explode" : false,
+            "schema" : {
+              "type" : "string"
+            },
+            "example" : "en"
+          } ],
         "responses" : {
           "200" : {
             "description" : "Success",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/chapter"
                 },
@@ -2492,7 +2491,7 @@
           "404" : {
             "description" : "Not Found",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/not-found"
                 }
@@ -2501,42 +2500,43 @@
           }
         },
         "security" : [ {
-          "bearerAuth" : [ ]
-        } ]
+            "bearerAuth" : [ ]
+          } ]
       },
       "post" : {
         "tags" : [ "Chapters" ],
         "summary" : "Upload a chapter",
         "description" : "Chapters help break the video into sections. Read our [tutorial](https://api.video/blog/tutorials/adding-chapters-to-your-videos) for more details.",
         "operationId" : "POST_videos-videoId-chapters-language",
+        "x-client-action" : "upload",
         "parameters" : [ {
-          "name" : "videoId",
-          "in" : "path",
-          "description" : "The unique identifier for the video you want to upload a chapter for.",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "vi4k0jvEUuaTdRAEjQ4Jfrgz"
-        }, {
-          "name" : "language",
-          "in" : "path",
-          "description" : "A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "en"
-        } ],
+            "name" : "videoId",
+            "in" : "path",
+            "description" : "The unique identifier for the video you want to upload a chapter for.",
+            "required" : true,
+            "style" : "simple",
+            "explode" : false,
+            "schema" : {
+              "type" : "string"
+            },
+            "example" : "vi4k0jvEUuaTdRAEjQ4Jfrgz"
+          }, {
+            "name" : "language",
+            "in" : "path",
+            "description" : "A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.",
+            "required" : true,
+            "style" : "simple",
+            "explode" : false,
+            "schema" : {
+              "type" : "string"
+            },
+            "example" : "en"
+          } ],
         "requestBody" : {
           "content" : {
             "multipart/form-data" : {
               "schema" : {
-                "$ref" : "#/components/schemas/body_12"
+                "$ref" : "#/components/schemas/chapters-update-payload"
               }
             }
           }
@@ -2545,7 +2545,7 @@
           "200" : {
             "description" : "Success",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/chapter"
                 },
@@ -2564,7 +2564,7 @@
           "400" : {
             "description" : "Bad Request",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/bad-request"
                 }
@@ -2574,7 +2574,7 @@
           "404" : {
             "description" : "Not Found",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/not-found"
                 }
@@ -2583,36 +2583,37 @@
           }
         },
         "security" : [ {
-          "bearerAuth" : [ ]
-        } ]
+            "bearerAuth" : [ ]
+          } ]
       },
       "delete" : {
         "tags" : [ "Chapters" ],
         "summary" : "Delete a chapter",
         "operationId" : "DELETE_videos-videoId-chapters-language",
+        "x-client-action" : "delete",
         "parameters" : [ {
-          "name" : "videoId",
-          "in" : "path",
-          "description" : "The unique identifier for the video you want to delete a chapter from. ",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "vi4k0jvEUuaTdRAEjQ4Jfrgz"
-        }, {
-          "name" : "language",
-          "in" : "path",
-          "description" : "A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "en"
-        } ],
+            "name" : "videoId",
+            "in" : "path",
+            "description" : "The unique identifier for the video you want to delete a chapter from. ",
+            "required" : true,
+            "style" : "simple",
+            "explode" : false,
+            "schema" : {
+              "type" : "string"
+            },
+            "example" : "vi4k0jvEUuaTdRAEjQ4Jfrgz"
+          }, {
+            "name" : "language",
+            "in" : "path",
+            "description" : "A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.",
+            "required" : true,
+            "style" : "simple",
+            "explode" : false,
+            "schema" : {
+              "type" : "string"
+            },
+            "example" : "en"
+          } ],
         "responses" : {
           "204" : {
             "description" : "No Content"
@@ -2620,7 +2621,7 @@
           "404" : {
             "description" : "Not Found",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/not-found"
                 }
@@ -2629,8 +2630,8 @@
           }
         },
         "security" : [ {
-          "bearerAuth" : [ ]
-        } ]
+            "bearerAuth" : [ ]
+          } ]
       }
     },
     "/videos/{videoId}/chapters" : {
@@ -2639,38 +2640,45 @@
         "summary" : "List video chapters",
         "description" : "Retrieve a list of all chapters for a specified video.",
         "operationId" : "GET_videos-videoId-chapters",
+        "x-client-action" : "list",
+        "x-group-parameters" : true,
+        "x-client-paginated" : true,
         "parameters" : [ {
-          "name" : "videoId",
-          "in" : "path",
-          "description" : "The unique identifier for the video you want to retrieve a list of chapters for.",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "vi4k0jvEUuaTdRAEjQ4Jfrgz"
-        } ],
+            "name" : "videoId",
+            "in" : "path",
+            "description" : "The unique identifier for the video you want to retrieve a list of chapters for.",
+            "required" : true,
+            "style" : "simple",
+            "explode" : false,
+            "schema" : {
+              "type" : "string"
+            },
+            "example" : "vi4k0jvEUuaTdRAEjQ4Jfrgz"
+          }, {
+            "$ref" : "#/components/parameters/currentPage"
+          }, {
+            "$ref" : "#/components/parameters/pageSize"
+          } ],
         "responses" : {
           "200" : {
             "description" : "Success",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/inline_response_200_4"
+                  "$ref" : "#/components/schemas/chapters-list-response" 
                 },
                 "examples" : {
                   "response" : {
                     "value" : {
                       "data" : [ {
-                        "uri" : "/videos/vi3N6cDinStg3oBbN79GklWS/chapters/fr",
-                        "src" : "https://cdn.api.video/vod/vi3N6cDinStg3oBbN79GklWS/chapters/fr.vtt",
-                        "language" : "fr"
-                      }, {
-                        "uri" : "/videos/vi3N6cDinStg3oBbN79GklWS/chapters/en",
-                        "src" : "https://cdn.api.video/vod/vi3N6cDinStg3oBbN79GklWS/chapters/en.vtt",
-                        "language" : "en"
-                      } ],
+                          "uri" : "/videos/vi3N6cDinStg3oBbN79GklWS/chapters/fr",
+                          "src" : "https://cdn.api.video/vod/vi3N6cDinStg3oBbN79GklWS/chapters/fr.vtt",
+                          "language" : "fr"
+                        }, {
+                          "uri" : "/videos/vi3N6cDinStg3oBbN79GklWS/chapters/en",
+                          "src" : "https://cdn.api.video/vod/vi3N6cDinStg3oBbN79GklWS/chapters/en.vtt",
+                          "language" : "en"
+                        } ],
                       "pagination" : {
                         "currentPage" : 1,
                         "currentPageItems" : 2,
@@ -2678,15 +2686,15 @@
                         "pagesTotal" : 1,
                         "itemsTotal" : 2,
                         "links" : [ {
-                          "rel" : "self",
-                          "uri" : "/videos/vi3N6cDinStg3oBbN79GklWS/chapters?currentPage=1&pageSize=25"
-                        }, {
-                          "rel" : "first",
-                          "uri" : "/videos/vi3N6cDinStg3oBbN79GklWS/chapters?currentPage=1&pageSize=25"
-                        }, {
-                          "rel" : "last",
-                          "uri" : "/videos/vi3N6cDinStg3oBbN79GklWS/chapters?currentPage=1&pageSize=25"
-                        } ]
+                            "rel" : "self",
+                            "uri" : "/videos/vi3N6cDinStg3oBbN79GklWS/chapters?currentPage=1&pageSize=25"
+                          }, {
+                            "rel" : "first",
+                            "uri" : "/videos/vi3N6cDinStg3oBbN79GklWS/chapters?currentPage=1&pageSize=25"
+                          }, {
+                            "rel" : "last",
+                            "uri" : "/videos/vi3N6cDinStg3oBbN79GklWS/chapters?currentPage=1&pageSize=25"
+                          } ]
                       }
                     }
                   }
@@ -2697,7 +2705,7 @@
           "404" : {
             "description" : "Not Found",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/not-found"
                 }
@@ -2706,8 +2714,8 @@
           }
         },
         "security" : [ {
-          "bearerAuth" : [ ]
-        } ]
+            "bearerAuth" : [ ]
+          } ]
       }
     },
     "/players" : {
@@ -2716,118 +2724,98 @@
         "summary" : "List all players",
         "description" : "Retrieve a list of all the players you created, as well as details about each one.",
         "operationId" : "GET_players",
+        "x-client-action" : "list",
+        "x-group-parameters" : true,
+        "x-client-paginated" : true,
         "parameters" : [ {
-          "name" : "sortBy",
-          "in" : "query",
-          "description" : "createdAt is the time the player was created. updatedAt is the time the player was last updated. The time is presented in ISO-8601 format.",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "enum" : [ "createdAt", "updatedAt" ]
-          },
-          "example" : "createdAt"
-        }, {
-          "name" : "sortOrder",
-          "in" : "query",
-          "description" : "Allowed: asc, desc. Ascending for date and time means that earlier values precede later ones. Descending means that later values preced earlier ones.",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "enum" : [ "asc", "desc" ]
-          },
-          "example" : "asc"
-        }, {
-          "name" : "currentPage",
-          "in" : "query",
-          "description" : "Number of the page to display.",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "minimum" : 1,
-            "type" : "integer",
-            "default" : 1
-          },
-          "example" : 3
-        }, {
-          "name" : "pageSize",
-          "in" : "query",
-          "description" : "Expected number of items to display on the page. Might be lower on the last page.",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "maximum" : 100,
-            "minimum" : 1,
-            "type" : "integer",
-            "default" : 25
-          },
-          "example" : 30
-        } ],
+            "name" : "sortBy",
+            "in" : "query",
+            "description" : "createdAt is the time the player was created. updatedAt is the time the player was last updated. The time is presented in ISO-8601 format.",
+            "required" : false,
+            "style" : "form",
+            "explode" : true,
+            "schema" : {
+              "type" : "string",
+              "enum" : [ "createdAt", "updatedAt" ]
+            },
+            "example" : "createdAt"
+          }, {
+            "name" : "sortOrder",
+            "in" : "query",
+            "description" : "Allowed: asc, desc. Ascending for date and time means that earlier values precede later ones. Descending means that later values preced earlier ones.",
+            "required" : false,
+            "style" : "form",
+            "explode" : true,
+            "schema" : {
+              "type" : "string",
+              "enum" : [ "asc", "desc" ]
+            },
+            "example" : "asc"
+          }, {
+            "$ref" : "#/components/parameters/currentPage"
+          }, {
+            "$ref" : "#/components/parameters/pageSize"
+          } ],
         "responses" : {
           "200" : {
             "description" : "Success",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/inline_response_200_5"
+                  "$ref" : "#/components/schemas/players-list-response"
                 },
                 "examples" : {
                   "response" : {
                     "value" : {
                       "data" : [ {
-                        "playerId" : "pl4fgtjy4tjyKDK545DRdfg",
-                        "createdAt" : "2020-01-13T10:09:17+00:00",
-                        "updatedAt" : "2020-01-13T10:09:17+00:00",
-                        "shapeMargin" : 10,
-                        "shapeRadius" : 3,
-                        "shapeAspect" : "flat",
-                        "shapeBackgroundTop" : "rgba(50, 50, 50, .7)",
-                        "shapeBackgroundBottom" : "rgba(50, 50, 50, .8)",
-                        "text" : "rgba(255, 255, 255, .95)",
-                        "link" : "rgba(255, 0, 0, .95)",
-                        "linkHover" : "rgba(255, 255, 255, .75)",
-                        "linkActive" : "rgba(255, 0, 0, .75)",
-                        "trackPlayed" : "rgba(255, 255, 255, .95)",
-                        "trackUnplayed" : "rgba(255, 255, 255, .1)",
-                        "trackBackground" : "rgba(0, 0, 0, 0)",
-                        "backgroundTop" : "rgba(72, 4, 45, 1)",
-                        "backgroundBottom" : "rgba(94, 95, 89, 1)",
-                        "backgroundText" : "rgba(255, 255, 255, .95)",
-                        "enableApi" : false,
-                        "enableControls" : false,
-                        "forceAutoplay" : false,
-                        "hideTitle" : false,
-                        "forceLoop" : false
-                      }, {
-                        "playerId" : "pl54fgtjy4tjyKDK45DRdfg",
-                        "createdAt" : "2020-01-13T10:09:17+00:00",
-                        "updatedAt" : "2020-01-13T10:09:17+00:00",
-                        "shapeMargin" : 10,
-                        "shapeRadius" : 3,
-                        "shapeAspect" : "flat",
-                        "shapeBackgroundTop" : "rgba(50, 50, 50, .7)",
-                        "shapeBackgroundBottom" : "rgba(50, 50, 50, .8)",
-                        "text" : "rgba(255, 255, 255, .95)",
-                        "link" : "rgba(255, 0, 0, .95)",
-                        "linkHover" : "rgba(255, 255, 255, .75)",
-                        "linkActive" : "rgba(255, 0, 0, .75)",
-                        "trackPlayed" : "rgba(255, 255, 255, .95)",
-                        "trackUnplayed" : "rgba(255, 255, 255, .1)",
-                        "trackBackground" : "rgba(0, 0, 0, 0)",
-                        "backgroundTop" : "rgba(72, 4, 45, 1)",
-                        "backgroundBottom" : "rgba(94, 95, 89, 1)",
-                        "backgroundText" : "rgba(255, 255, 255, .95)",
-                        "enableApi" : true,
-                        "enableControls" : true,
-                        "forceAutoplay" : true,
-                        "hideTitle" : false,
-                        "forceLoop" : false
-                      } ],
+                          "playerId" : "pl4fgtjy4tjyKDK545DRdfg",
+                          "createdAt" : "2020-01-13T10:09:17+00:00",
+                          "updatedAt" : "2020-01-13T10:09:17+00:00",
+                          "shapeMargin" : 10,
+                          "shapeRadius" : 3,
+                          "shapeAspect" : "flat",
+                          "shapeBackgroundTop" : "rgba(50, 50, 50, .7)",
+                          "shapeBackgroundBottom" : "rgba(50, 50, 50, .8)",
+                          "text" : "rgba(255, 255, 255, .95)",
+                          "link" : "rgba(255, 0, 0, .95)",
+                          "linkHover" : "rgba(255, 255, 255, .75)",
+                          "linkActive" : "rgba(255, 0, 0, .75)",
+                          "trackPlayed" : "rgba(255, 255, 255, .95)",
+                          "trackUnplayed" : "rgba(255, 255, 255, .1)",
+                          "trackBackground" : "rgba(0, 0, 0, 0)",
+                          "backgroundTop" : "rgba(72, 4, 45, 1)",
+                          "backgroundBottom" : "rgba(94, 95, 89, 1)",
+                          "backgroundText" : "rgba(255, 255, 255, .95)",
+                          "enableApi" : false,
+                          "enableControls" : false,
+                          "forceAutoplay" : false,
+                          "hideTitle" : false,
+                          "forceLoop" : false
+                        }, {
+                          "playerId" : "pl54fgtjy4tjyKDK45DRdfg",
+                          "createdAt" : "2020-01-13T10:09:17+00:00",
+                          "updatedAt" : "2020-01-13T10:09:17+00:00",
+                          "shapeMargin" : 10,
+                          "shapeRadius" : 3,
+                          "shapeAspect" : "flat",
+                          "shapeBackgroundTop" : "rgba(50, 50, 50, .7)",
+                          "shapeBackgroundBottom" : "rgba(50, 50, 50, .8)",
+                          "text" : "rgba(255, 255, 255, .95)",
+                          "link" : "rgba(255, 0, 0, .95)",
+                          "linkHover" : "rgba(255, 255, 255, .75)",
+                          "linkActive" : "rgba(255, 0, 0, .75)",
+                          "trackPlayed" : "rgba(255, 255, 255, .95)",
+                          "trackUnplayed" : "rgba(255, 255, 255, .1)",
+                          "trackBackground" : "rgba(0, 0, 0, 0)",
+                          "backgroundTop" : "rgba(72, 4, 45, 1)",
+                          "backgroundBottom" : "rgba(94, 95, 89, 1)",
+                          "backgroundText" : "rgba(255, 255, 255, .95)",
+                          "enableApi" : true,
+                          "enableControls" : true,
+                          "forceAutoplay" : true,
+                          "hideTitle" : false,
+                          "forceLoop" : false
+                        } ],
                       "pagination" : {
                         "currentPage" : 1,
                         "pageSize" : 25,
@@ -2835,15 +2823,15 @@
                         "itemsTotal" : 4,
                         "currentPageItems" : 4,
                         "links" : [ {
-                          "rel" : "self",
-                          "uri" : "https://ws.api.video/players?currentPage=1"
-                        }, {
-                          "rel" : "first",
-                          "uri" : "https://ws.api.video/players?currentPage=1"
-                        }, {
-                          "rel" : "last",
-                          "uri" : "https://ws.api.video/players?currentPage=1"
-                        } ]
+                            "rel" : "self",
+                            "uri" : "https://ws.api.video/players?currentPage=1"
+                          }, {
+                            "rel" : "first",
+                            "uri" : "https://ws.api.video/players?currentPage=1"
+                          }, {
+                            "rel" : "last",
+                            "uri" : "https://ws.api.video/players?currentPage=1"
+                          } ]
                       }
                     }
                   }
@@ -2854,7 +2842,7 @@
           "400" : {
             "description" : "Bad Request",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/bad-request"
                 },
@@ -2868,19 +2856,19 @@
                         "min" : 1
                       },
                       "problems" : [ {
-                        "title" : "This parameter is out of the allowed range of values.",
-                        "name" : "page",
-                        "range" : {
-                          "min" : 1
-                        }
-                      }, {
-                        "title" : "This parameter is out of the allowed range of values.",
-                        "name" : "pageSize",
-                        "range" : {
-                          "min" : 10,
-                          "max" : 100
-                        }
-                      } ]
+                          "title" : "This parameter is out of the allowed range of values.",
+                          "name" : "page",
+                          "range" : {
+                            "min" : 1
+                          }
+                        }, {
+                          "title" : "This parameter is out of the allowed range of values.",
+                          "name" : "pageSize",
+                          "range" : {
+                            "min" : 10,
+                            "max" : 100
+                          }
+                        } ]
                     }
                   }
                 }
@@ -2889,22 +2877,30 @@
           }
         },
         "security" : [ {
-          "bearerAuth" : [ ]
-        } ]
+            "bearerAuth" : [ ]
+          } ]
       },
       "post" : {
         "tags" : [ "Players" ],
         "summary" : "Create a player",
         "description" : "Create a player for your video, and customise it.",
         "operationId" : "POST_players",
+        "x-client-action" : "create",
         "requestBody" : {
-          "$ref" : "#/components/requestBodies/playerinput"
+          "required" : true,
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/playerCreationPayload"
+              }
+            }
+          }
         },
         "responses" : {
           "201" : {
             "description" : "Created",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/player"
                 },
@@ -2941,8 +2937,8 @@
           }
         },
         "security" : [ {
-          "bearerAuth" : [ ]
-        } ]
+            "bearerAuth" : [ ]
+          } ]
       }
     },
     "/players/{playerId}" : {
@@ -2951,23 +2947,24 @@
         "summary" : "Show a player",
         "description" : "Use a player ID to retrieve details about the player and display it for viewers.",
         "operationId" : "GET_players-playerId",
+        "x-client-action" : "get",
         "parameters" : [ {
-          "name" : "playerId",
-          "in" : "path",
-          "description" : "The unique identifier for the player you want to retrieve. ",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "pl45d5vFFGrfdsdsd156dGhh"
-        } ],
+            "name" : "playerId",
+            "in" : "path",
+            "description" : "The unique identifier for the player you want to retrieve. ",
+            "required" : true,
+            "style" : "simple",
+            "explode" : false,
+            "schema" : {
+              "type" : "string"
+            },
+            "example" : "pl45d5vFFGrfdsdsd156dGhh"
+          } ],
         "responses" : {
           "200" : {
             "description" : "Success",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/player"
                 },
@@ -3005,7 +3002,7 @@
           "404" : {
             "description" : "Not Found",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/not-found"
                 },
@@ -3024,26 +3021,27 @@
           }
         },
         "security" : [ {
-          "bearerAuth" : [ ]
-        } ]
+            "bearerAuth" : [ ]
+          } ]
       },
       "delete" : {
         "tags" : [ "Players" ],
         "summary" : "Delete a player",
         "description" : "Delete a player if you no longer need it. You can delete any player that you have the player ID for.",
         "operationId" : "DELETE_players-playerId",
+        "x-client-action" : "delete",
         "parameters" : [ {
-          "name" : "playerId",
-          "in" : "path",
-          "description" : "The unique identifier for the player you want to delete.",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "pl45d5vFFGrfdsdsd156dGhh"
-        } ],
+            "name" : "playerId",
+            "in" : "path",
+            "description" : "The unique identifier for the player you want to delete.",
+            "required" : true,
+            "style" : "simple",
+            "explode" : false,
+            "schema" : {
+              "type" : "string"
+            },
+            "example" : "pl45d5vFFGrfdsdsd156dGhh"
+          } ],
         "responses" : {
           "204" : {
             "description" : "No Content"
@@ -3051,7 +3049,7 @@
           "404" : {
             "description" : "Not Found",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/not-found"
                 },
@@ -3070,34 +3068,42 @@
           }
         },
         "security" : [ {
-          "bearerAuth" : [ ]
-        } ]
+            "bearerAuth" : [ ]
+          } ]
       },
       "patch" : {
         "tags" : [ "Players" ],
         "summary" : "Update a player",
         "description" : "Use a player ID to update specific details for a player. NOTE: It may take up to 10 min before the new player configuration is available from our CDN.",
         "operationId" : "PATCH_players-playerId",
+        "x-client-action" : "update",
         "parameters" : [ {
-          "name" : "playerId",
-          "in" : "path",
-          "description" : "The unique identifier for the player.",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "pl45d5vFFGrfdsdsd156dGhh"
-        } ],
+            "name" : "playerId",
+            "in" : "path",
+            "description" : "The unique identifier for the player.",
+            "required" : true,
+            "style" : "simple",
+            "explode" : false,
+            "schema" : {
+              "type" : "string"
+            },
+            "example" : "pl45d5vFFGrfdsdsd156dGhh"
+          } ],
         "requestBody" : {
-          "$ref" : "#/components/requestBodies/playerinput"
+          "required" : true,
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/playerUpdatePayload"
+              }
+            }
+          }
         },
         "responses" : {
           "200" : {
             "description" : "Success",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/player"
                 },
@@ -3135,7 +3141,7 @@
           "404" : {
             "description" : "Not Found",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/not-found"
                 },
@@ -3154,8 +3160,8 @@
           }
         },
         "security" : [ {
-          "bearerAuth" : [ ]
-        } ]
+            "bearerAuth" : [ ]
+          } ]
       }
     },
     "/players/{playerId}/logo" : {
@@ -3164,23 +3170,24 @@
         "summary" : "Upload a logo",
         "description" : "The uploaded image maximum size should be 200x100 and its weight should be 200KB. \nIt will be scaled down to 30px height and converted to PNG to be displayed in the player.",
         "operationId" : "POST_players-playerId-logo",
+        "x-client-action" : "uploadLogo",
         "parameters" : [ {
-          "name" : "playerId",
-          "in" : "path",
-          "description" : "The unique identifier for the player.",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "pl14Db6oMJRH6SRVoOwORacK"
-        } ],
+            "name" : "playerId",
+            "in" : "path",
+            "description" : "The unique identifier for the player.",
+            "required" : true,
+            "style" : "simple",
+            "explode" : false,
+            "schema" : {
+              "type" : "string"
+            },
+            "example" : "pl14Db6oMJRH6SRVoOwORacK"
+          } ],
         "requestBody" : {
           "content" : {
             "multipart/form-data" : {
               "schema" : {
-                "$ref" : "#/components/schemas/body_13"
+                "$ref" : "#/components/schemas/players-upload-logo-payload"
               }
             }
           }
@@ -3189,7 +3196,7 @@
           "201" : {
             "description" : "Created",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/player"
                 }
@@ -3199,7 +3206,7 @@
           "400" : {
             "description" : "Bad Request",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/bad-request"
                 },
@@ -3219,7 +3226,7 @@
           "404" : {
             "description" : "Not Found",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/not-found"
                 },
@@ -3238,30 +3245,31 @@
           }
         },
         "security" : [ {
-          "bearerAuth" : [ ]
-        } ]
+            "bearerAuth" : [ ]
+          } ]
       },
       "delete" : {
         "tags" : [ "Players" ],
         "summary" : "Delete logo",
         "operationId" : "DELETE_players-playerId-logo",
+        "x-client-action" : "deleteLogo",
         "parameters" : [ {
-          "name" : "playerId",
-          "in" : "path",
-          "description" : "The unique identifier for the player.",
-          "required" : true,
-          "style" : "simple",
+            "name" : "playerId",
+            "in" : "path",
+            "description" : "The unique identifier for the player.",
+            "required" : true,
+            "style" : "simple",
           "explode" : false,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "pl14Db6oMJRH6SRVoOwORacK"
-        } ],
+            "schema" : {
+              "type" : "string"
+            },
+            "example" : "pl14Db6oMJRH6SRVoOwORacK"
+          } ],
         "responses" : {
           "204" : {
             "description" : "No Content",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "type" : "object"
                 }
@@ -3271,7 +3279,7 @@
           "404" : {
             "description" : "Not Found",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/not-found"
                 },
@@ -3290,8 +3298,8 @@
           }
         },
         "security" : [ {
-          "bearerAuth" : [ ]
-        } ]
+            "bearerAuth" : [ ]
+          } ]
       }
     },
     "/analytics/videos/{videoId}" : {
@@ -3300,113 +3308,93 @@
         "summary" : "List video player sessions",
         "description" : "Retrieve all available user sessions for a specific video.",
         "operationId" : "GET_analytics-videos-videoId",
+        "x-client-action" : "listSessions",
+        "x-group-parameters" : true,
+        "x-client-paginated" : true,
         "parameters" : [ {
-          "name" : "videoId",
-          "in" : "path",
-          "description" : "The unique identifier for the video you want to retrieve session information for.",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "vi4k0jvEUuaTdRAEjQ4Prklg"
-        }, {
-          "name" : "period",
-          "in" : "query",
-          "description" : "Period must have one of the following formats: \n\n- For a day : 2018-01-01,\n- For a week: 2018-W01, \n- For a month: 2018-01\n- For a year: 2018\n\nFor a range period: \n-  Date range: 2018-01-01/2018-01-15\n",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "format" : "date"
-          }
-        }, {
-          "name" : "metadata",
-          "in" : "query",
-          "description" : "Metadata and Dynamic Metadata filter. Send an array of key value pairs you want to filter sessios with.",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "array",
-            "items" : {
+            "name" : "videoId",
+            "in" : "path",
+            "description" : "The unique identifier for the video you want to retrieve session information for.",
+            "required" : true,
+            "style" : "simple",
+            "explode" : false,
+            "schema" : {
               "type" : "string"
+            },
+            "example" : "vi4k0jvEUuaTdRAEjQ4Prklg"
+          }, {
+            "name" : "period",
+            "in" : "query",
+            "description" : "Period must have one of the following formats: \n\n- For a day : 2018-01-01,\n- For a week: 2018-W01, \n- For a month: 2018-01\n- For a year: 2018\n\nFor a range period: \n-  Date range: 2018-01-01/2018-01-15\n",
+            "required" : false,
+            "style" : "form",
+            "explode" : true,
+            "schema" : {
+              "type" : "string",
+              "format" : "period"
             }
-          },
-          "example" : "[{\"key\": \"Author\", \"value\": \"John Doe\"}, {\"key\": \"Format\", \"value\": \"Tutorial\"}]"
-        }, {
-          "name" : "currentPage",
-          "in" : "query",
-          "description" : "Number of the page to display.",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "minimum" : 1,
-            "type" : "integer",
-            "default" : 1
-          },
-          "example" : 3
-        }, {
-          "name" : "pageSize",
-          "in" : "query",
-          "description" : "Expected number of items to display on the page. Might be lower on the last page.",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "maximum" : 100,
-            "minimum" : 1,
-            "type" : "integer",
-            "default" : 25
-          },
-          "example" : 30
-        } ],
+          }, {
+            "name" : "metadata",
+            "in" : "query",
+            "description" : "Metadata and Dynamic Metadata filter. Send an array of key value pairs you want to filter sessios with.",
+            "required" : false,
+            "style" : "form",
+            "explode" : true,
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            },
+            "example" : "[{\"key\": \"Author\", \"value\": \"John Doe\"}, {\"key\": \"Format\", \"value\": \"Tutorial\"}]"
+          }, {
+            "$ref" : "#/components/parameters/currentPage"
+          }, {
+            "$ref" : "#/components/parameters/pageSize"
+          } ],
         "responses" : {
           "200" : {
             "description" : "Success",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/inline_response_200_6"
+                  "$ref" : "#/components/schemas/raw-statistics-list-sessions-response"
                 },
                 "examples" : {
                   "response" : {
                     "value" : {
                       "data" : [ {
-                        "session" : {
-                          "sessionId" : "psEmFwGQUAXR2lFHj5nDOpy",
-                          "loadedAt" : "2019-06-24T11:45:01.109+00",
-                          "endedAt" : "2019-06-24T11:49:19.243+00"
-                        },
-                        "location" : {
-                          "country" : "France",
-                          "city" : "Paris"
-                        },
-                        "referrer" : {
-                          "url" : "https://api.video",
-                          "medium" : "organic",
-                          "source" : "https://google.com",
-                          "searchTerm" : "video encoding hosting and delivery"
-                        },
-                        "device" : {
-                          "type" : "desktop",
-                          "vendor" : "Dell",
-                          "model" : "unknown"
-                        },
-                        "os" : {
-                          "name" : "Microsoft Windows",
-                          "shortname" : "W10",
-                          "version" : "Windows10"
-                        },
-                        "client" : {
-                          "type" : "browser",
-                          "name" : "Firefox",
-                          "version" : "67.0"
-                        }
-                      } ],
+                          "session" : {
+                            "sessionId" : "psEmFwGQUAXR2lFHj5nDOpy",
+                            "loadedAt" : "2019-06-24T11:45:01.109+00",
+                            "endedAt" : "2019-06-24T11:49:19.243+00"
+                          },
+                          "location" : {
+                            "country" : "France",
+                            "city" : "Paris"
+                          },
+                          "referrer" : {
+                            "url" : "https://api.video",
+                            "medium" : "organic",
+                            "source" : "https://google.com",
+                            "searchTerm" : "video encoding hosting and delivery"
+                          },
+                          "device" : {
+                            "type" : "desktop",
+                            "vendor" : "Dell",
+                            "model" : "unknown"
+                          },
+                          "os" : {
+                            "name" : "Microsoft Windows",
+                            "shortname" : "W10",
+                            "version" : "Windows10"
+                          },
+                          "client" : {
+                            "type" : "browser",
+                            "name" : "Firefox",
+                            "version" : "67.0"
+                          }
+                        } ],
                       "pagination" : {
                         "currentPage" : 1,
                         "currentPageItems" : 1,
@@ -3414,15 +3402,15 @@
                         "pagesTotal" : 1,
                         "itemsTotal" : 1,
                         "links" : [ {
-                          "rel" : "self",
-                          "uri" : "/analytics/sessions/psEmFwGQUAXR2lFHj5nDOpy?currentPage=1&pageSize=25"
-                        }, {
-                          "rel" : "first",
-                          "uri" : "/analytics/sessions/psEmFwGQUAXR2lFHj5nDOpy?currentPage=1&pageSize=25"
-                        }, {
-                          "rel" : "last",
-                          "uri" : "/analytics/sessions/psEmFwGQUAXR2lFHj5nDOpy?currentPage=1&pageSize=25"
-                        } ]
+                            "rel" : "self",
+                            "uri" : "/analytics/sessions/psEmFwGQUAXR2lFHj5nDOpy?currentPage=1&pageSize=25"
+                          }, {
+                            "rel" : "first",
+                            "uri" : "/analytics/sessions/psEmFwGQUAXR2lFHj5nDOpy?currentPage=1&pageSize=25"
+                          }, {
+                            "rel" : "last",
+                            "uri" : "/analytics/sessions/psEmFwGQUAXR2lFHj5nDOpy?currentPage=1&pageSize=25"
+                          } ]
                       }
                     }
                   }
@@ -3433,7 +3421,7 @@
           "404" : {
             "description" : "Not Found",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/not-found"
                 },
@@ -3452,8 +3440,8 @@
           }
         },
         "security" : [ {
-          "bearerAuth" : [ ]
-        } ]
+            "bearerAuth" : [ ]
+          } ]
       }
     },
     "/analytics/live-streams/{liveStreamId}" : {
@@ -3461,99 +3449,80 @@
         "tags" : [ "Raw statistics" ],
         "summary" : "List live stream player sessions",
         "operationId" : "GET_analytics-live-streams-liveStreamId",
+        "x-client-action" : "getLiveStreamAnalytics",
+        "x-group-parameters" : true,
+        "x-client-paginated" : true,
         "parameters" : [ {
-          "name" : "liveStreamId",
-          "in" : "path",
-          "description" : "The unique identifier for the live stream you want to retrieve analytics for.",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "vi4k0jvEUuaTdRAEjQ4Jfrgz"
-        }, {
-          "name" : "period",
-          "in" : "query",
-          "description" : "Period must have one of the following formats: \n\n- For a day : \"2018-01-01\",\n- For a week: \"2018-W01\", \n- For a month: \"2018-01\"\n- For a year: \"2018\"\n\nFor a range period: \n-  Date range: \"2018-01-01/2018-01-15\"\n",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "format" : "date"
-          },
-          "example" : "2019-01-01"
-        }, {
-          "name" : "currentPage",
-          "in" : "query",
-          "description" : "Number of the page to display",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "minimum" : 1,
-            "type" : "integer",
-            "default" : 1
-          },
-          "example" : 2
-        }, {
-          "name" : "pageSize",
-          "in" : "query",
-          "description" : "Expected number of items to display on the page. Might be lower on the last page",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "maximum" : 100,
-            "minimum" : 1,
-            "type" : "integer",
-            "default" : 25
-          }
-        } ],
+            "name" : "liveStreamId",
+            "in" : "path",
+            "description" : "The unique identifier for the live stream you want to retrieve analytics for.",
+            "required" : true,
+            "style" : "simple",
+            "explode" : false,
+            "schema" : {
+              "type" : "string"
+            },
+            "example" : "vi4k0jvEUuaTdRAEjQ4Jfrgz"
+          }, {
+            "name" : "period",
+            "in" : "query",
+            "description" : "Period must have one of the following formats: \n\n- For a day : \"2018-01-01\",\n- For a week: \"2018-W01\", \n- For a month: \"2018-01\"\n- For a year: \"2018\"\n\nFor a range period: \n-  Date range: \"2018-01-01/2018-01-15\"\n",
+            "required" : false,
+            "style" : "form",
+            "explode" : true,
+            "schema" : {
+              "type" : "string",
+              "format" : "period"
+            },
+            "example" : "2019-01-01"
+          }, {
+            "$ref" : "#/components/parameters/currentPage"
+          }, {
+            "$ref" : "#/components/parameters/pageSize"
+          } ],
         "responses" : {
           "200" : {
             "description" : "Success",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/inline_response_200_7"
+                  "$ref" : "#/components/schemas/raw-statistics-list-live-stream-analytics-response"
                 },
                 "examples" : {
                   "response" : {
                     "value" : {
                       "data" : [ {
-                        "session" : {
-                          "sessionId" : "ps4zRWVOv2If2vzKJLMr3jQo",
-                          "loadedAt" : "2018-09-11 13:04:37.89+00",
-                          "endedAt" : "2018-09-11 14:47:22.186+00"
-                        },
-                        "location" : {
-                          "country" : "France",
-                          "city" : "Paris"
-                        },
-                        "referrer" : {
-                          "url" : "unknown",
-                          "medium" : "unknown",
-                          "source" : "unknown",
-                          "searchTerm" : "unknown"
-                        },
-                        "device" : {
-                          "type" : "desktop",
-                          "vendor" : "unknown",
-                          "model" : "unknown"
-                        },
-                        "os" : {
-                          "name" : "unknown",
-                          "shortname" : "unknown",
-                          "version" : "unknown"
-                        },
-                        "client" : {
-                          "type" : "browser",
-                          "name" : "Firefox",
-                          "version" : "61.0"
-                        }
-                      } ],
+                          "session" : {
+                            "sessionId" : "ps4zRWVOv2If2vzKJLMr3jQo",
+                            "loadedAt" : "2018-09-11T13:04:37.89+00",
+                            "endedAt" : "2018-09-11T14:47:22.186+00"
+                          },
+                          "location" : {
+                            "country" : "France",
+                            "city" : "Paris"
+                          },
+                          "referrer" : {
+                            "url" : "unknown",
+                            "medium" : "unknown",
+                            "source" : "unknown",
+                            "searchTerm" : "unknown"
+                          },
+                          "device" : {
+                            "type" : "desktop",
+                            "vendor" : "unknown",
+                            "model" : "unknown"
+                          },
+                          "os" : {
+                            "name" : "unknown",
+                            "shortname" : "unknown",
+                            "version" : "unknown"
+                          },
+                          "client" : {
+                            "type" : "browser",
+                            "name" : "Firefox",
+                            "version" : "61.0"
+                          }
+                        } ],
                       "pagination" : {
                         "currentPage" : 1,
                         "currentPageItems" : 1,
@@ -3561,15 +3530,15 @@
                         "pagesTotal" : 1,
                         "itemsTotal" : 1,
                         "links" : [ {
-                          "rel" : "self",
-                          "uri" : "/analytics/sessions/ps4zRWVOv2If2vzKJLMr3jQo?currentPage=1&pageSize=25"
-                        }, {
-                          "rel" : "first",
-                          "uri" : "/analytics/sessions/ps4zRWVOv2If2vzKJLMr3jQo?currentPage=1&pageSize=25"
-                        }, {
-                          "rel" : "last",
-                          "uri" : "/analytics/sessions/ps4zRWVOv2If2vzKJLMr3jQo?currentPage=1&pageSize=25"
-                        } ]
+                            "rel" : "self",
+                            "uri" : "/analytics/sessions/ps4zRWVOv2If2vzKJLMr3jQo?currentPage=1&pageSize=25"
+                          }, {
+                            "rel" : "first",
+                            "uri" : "/analytics/sessions/ps4zRWVOv2If2vzKJLMr3jQo?currentPage=1&pageSize=25"
+                          }, {
+                            "rel" : "last",
+                            "uri" : "/analytics/sessions/ps4zRWVOv2If2vzKJLMr3jQo?currentPage=1&pageSize=25"
+                          } ]
                       }
                     }
                   }
@@ -3580,7 +3549,7 @@
           "404" : {
             "description" : "Not Found",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/not-found"
                 },
@@ -3599,8 +3568,8 @@
           }
         },
         "security" : [ {
-          "bearerAuth" : [ ]
-        } ]
+            "bearerAuth" : [ ]
+          } ]
       }
     },
     "/analytics/sessions/{sessionId}/events" : {
@@ -3609,162 +3578,142 @@
         "summary" : "List player session events",
         "description" : "Useful to track and measure video's engagement.",
         "operationId" : "GET_analytics-sessions-sessionId-events",
+        "x-client-action" : "listPlayerSessionEvents",
+        "x-group-parameters" : true,
+        "x-client-paginated" : true,
         "parameters" : [ {
-          "name" : "sessionId",
-          "in" : "path",
-          "description" : "A unique identifier you can use to reference and track a session with.",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          },
-          "example" : "psEmFwGQUAXR2lFHj5nDOpy"
-        }, {
-          "name" : "currentPage",
-          "in" : "query",
-          "description" : "Number of the page to display.",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "minimum" : 1,
-            "type" : "integer",
-            "default" : 1
-          },
-          "example" : 4
-        }, {
-          "name" : "pageSize",
-          "in" : "query",
-          "description" : "Expected number of items to display on the page. Might be lower on the last page if there are not enough items.",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "maximum" : 100,
-            "minimum" : 1,
-            "type" : "integer",
-            "default" : 25
-          },
-          "example" : 30
-        } ],
+            "name" : "sessionId",
+            "in" : "path",
+            "description" : "A unique identifier you can use to reference and track a session with.",
+            "required" : true,
+            "style" : "simple",
+            "explode" : false,
+            "schema" : {
+              "type" : "string"
+            },
+            "example" : "psEmFwGQUAXR2lFHj5nDOpy"
+          }, {
+            "$ref" : "#/components/parameters/currentPage"
+          }, {
+            "$ref" : "#/components/parameters/pageSize"
+          } ],
         "responses" : {
           "200" : {
             "description" : "Success",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/inline_response_200_8"
+                  "$ref" : "#/components/schemas/raw-statistics-list-player-session-events-response"
                 },
                 "examples" : {
                   "response" : {
                     "value" : {
                       "data" : [ {
-                        "type" : "ready",
-                        "emittedAt" : "2020-09-15T09:47:42+00:00",
-                        "at" : 0
-                      }, {
-                        "type" : "play",
-                        "emittedAt" : "2020-09-15T21:35:57+00:00",
-                        "at" : 0
-                      }, {
-                        "type" : "pause",
-                        "emittedAt" : "2020-09-15T21:36:05+00:00",
-                        "at" : 7
-                      }, {
-                        "type" : "resume",
-                        "emittedAt" : "2020-09-15T21:36:19+00:00",
-                        "at" : 21
-                      }, {
-                        "type" : "seek.forward",
-                        "emittedAt" : "2020-09-15T21:36:19+00:00",
-                        "from" : 7,
-                        "to" : 21
-                      }, {
-                        "type" : "end",
-                        "emittedAt" : "2020-09-15T21:36:28+00:00",
-                        "at" : 30
-                      }, {
-                        "type" : "play",
-                        "emittedAt" : "2020-09-15T21:36:29+00:00",
-                        "at" : 0
-                      }, {
-                        "type" : "seek.backward",
-                        "emittedAt" : "2020-09-15T21:36:29+00:00",
-                        "from" : 30,
-                        "to" : 0
-                      }, {
-                        "type" : "pause",
-                        "emittedAt" : "2020-09-15T21:36:29+00:00",
-                        "at" : 21
-                      }, {
-                        "type" : "resume",
-                        "emittedAt" : "2020-09-15T21:36:30+00:00",
-                        "at" : 21
-                      }, {
-                        "type" : "seek.forward",
-                        "emittedAt" : "2020-09-15T21:36:30+00:00",
-                        "from" : 0,
-                        "to" : 21
-                      }, {
-                        "type" : "pause",
-                        "emittedAt" : "2020-09-15T21:36:33+00:00",
-                        "at" : 20
-                      }, {
-                        "type" : "resume",
-                        "emittedAt" : "2020-09-15T21:36:33+00:00",
-                        "at" : 20
-                      }, {
-                        "type" : "seek.backward",
-                        "emittedAt" : "2020-09-15T21:36:33+00:00",
-                        "from" : 24,
-                        "to" : 20
-                      }, {
-                        "type" : "pause",
-                        "emittedAt" : "2020-09-15T21:36:39+00:00",
-                        "at" : 17
-                      }, {
-                        "type" : "resume",
-                        "emittedAt" : "2020-09-15T21:36:39+00:00",
-                        "at" : 17
-                      }, {
-                        "type" : "seek.forward",
-                        "emittedAt" : "2020-09-15T21:36:39+00:00",
-                        "from" : 17,
-                        "to" : 17
-                      }, {
-                        "type" : "pause",
-                        "emittedAt" : "2020-09-15T21:36:41+00:00",
-                        "at" : 19
-                      }, {
-                        "type" : "ready",
-                        "emittedAt" : "2020-09-17T09:20:47+00:00",
-                        "at" : 0
-                      }, {
-                        "type" : "ready",
-                        "emittedAt" : "2020-09-17T09:41:01+00:00",
-                        "at" : 0
-                      }, {
-                        "type" : "ready",
-                        "emittedAt" : "2020-09-17T09:41:08+00:00",
-                        "at" : 0
-                      }, {
-                        "type" : "play",
-                        "emittedAt" : "2020-09-17T09:41:10+00:00",
-                        "at" : 0
-                      }, {
-                        "type" : "pause",
-                        "emittedAt" : "2020-09-17T09:41:12+00:00",
-                        "at" : 1
-                      }, {
-                        "type" : "resume",
-                        "emittedAt" : "2020-09-17T09:41:13+00:00",
-                        "at" : 1
-                      }, {
-                        "type" : "pause",
-                        "emittedAt" : "2020-09-17T09:41:15+00:00",
-                        "at" : 3
-                      } ],
+                          "type" : "ready",
+                          "emittedAt" : "2020-09-15T09:47:42+00:00",
+                          "at" : 0
+                        }, {
+                          "type" : "play",
+                          "emittedAt" : "2020-09-15T21:35:57+00:00",
+                          "at" : 0
+                        }, {
+                          "type" : "pause",
+                          "emittedAt" : "2020-09-15T21:36:05+00:00",
+                          "at" : 7
+                        }, {
+                          "type" : "resume",
+                          "emittedAt" : "2020-09-15T21:36:19+00:00",
+                          "at" : 21
+                        }, {
+                          "type" : "seek.forward",
+                          "emittedAt" : "2020-09-15T21:36:19+00:00",
+                          "from" : 7,
+                          "to" : 21
+                        }, {
+                          "type" : "end",
+                          "emittedAt" : "2020-09-15T21:36:28+00:00",
+                          "at" : 30
+                        }, {
+                          "type" : "play",
+                          "emittedAt" : "2020-09-15T21:36:29+00:00",
+                          "at" : 0
+                        }, {
+                          "type" : "seek.backward",
+                          "emittedAt" : "2020-09-15T21:36:29+00:00",
+                          "from" : 30,
+                          "to" : 0
+                        }, {
+                          "type" : "pause",
+                          "emittedAt" : "2020-09-15T21:36:29+00:00",
+                          "at" : 21
+                        }, {
+                          "type" : "resume",
+                          "emittedAt" : "2020-09-15T21:36:30+00:00",
+                          "at" : 21
+                        }, {
+                          "type" : "seek.forward",
+                          "emittedAt" : "2020-09-15T21:36:30+00:00",
+                          "from" : 0,
+                          "to" : 21
+                        }, {
+                          "type" : "pause",
+                          "emittedAt" : "2020-09-15T21:36:33+00:00",
+                          "at" : 20
+                        }, {
+                          "type" : "resume",
+                          "emittedAt" : "2020-09-15T21:36:33+00:00",
+                          "at" : 20
+                        }, {
+                          "type" : "seek.backward",
+                          "emittedAt" : "2020-09-15T21:36:33+00:00",
+                          "from" : 24,
+                          "to" : 20
+                        }, {
+                          "type" : "pause",
+                          "emittedAt" : "2020-09-15T21:36:39+00:00",
+                          "at" : 17
+                        }, {
+                          "type" : "resume",
+                          "emittedAt" : "2020-09-15T21:36:39+00:00",
+                          "at" : 17
+                        }, {
+                          "type" : "seek.forward",
+                          "emittedAt" : "2020-09-15T21:36:39+00:00",
+                          "from" : 17,
+                          "to" : 17
+                        }, {
+                          "type" : "pause",
+                          "emittedAt" : "2020-09-15T21:36:41+00:00",
+                          "at" : 19
+                        }, {
+                          "type" : "ready",
+                          "emittedAt" : "2020-09-17T09:20:47+00:00",
+                          "at" : 0
+                        }, {
+                          "type" : "ready",
+                          "emittedAt" : "2020-09-17T09:41:01+00:00",
+                          "at" : 0
+                        }, {
+                          "type" : "ready",
+                          "emittedAt" : "2020-09-17T09:41:08+00:00",
+                          "at" : 0
+                        }, {
+                          "type" : "play",
+                          "emittedAt" : "2020-09-17T09:41:10+00:00",
+                          "at" : 0
+                        }, {
+                          "type" : "pause",
+                          "emittedAt" : "2020-09-17T09:41:12+00:00",
+                          "at" : 1
+                        }, {
+                          "type" : "resume",
+                          "emittedAt" : "2020-09-17T09:41:13+00:00",
+                          "at" : 1
+                        }, {
+                          "type" : "pause",
+                          "emittedAt" : "2020-09-17T09:41:15+00:00",
+                          "at" : 3
+                        } ],
                       "pagination" : {
                         "currentPage" : 1,
                         "currentPageItems" : 25,
@@ -3772,18 +3721,18 @@
                         "pagesTotal" : 2,
                         "itemsTotal" : 30,
                         "links" : [ {
-                          "rel" : "self",
-                          "uri" : "/analytics/sessions/ps5ltuhfsTOeh6bP03Tq5OWc/events?currentPage=1&pageSize=25"
-                        }, {
-                          "rel" : "first",
-                          "uri" : "/analytics/sessions/ps5ltuhfsTOeh6bP03Tq5OWc/events?currentPage=1&pageSize=25"
-                        }, {
-                          "rel" : "next",
-                          "uri" : "/analytics/sessions/ps5ltuhfsTOeh6bP03Tq5OWc/events?currentPage=2&pageSize=25"
-                        }, {
-                          "rel" : "last",
-                          "uri" : "/analytics/sessions/ps5ltuhfsTOeh6bP03Tq5OWc/events?currentPage=2&pageSize=25"
-                        } ]
+                            "rel" : "self",
+                            "uri" : "/analytics/sessions/ps5ltuhfsTOeh6bP03Tq5OWc/events?currentPage=1&pageSize=25"
+                          }, {
+                            "rel" : "first",
+                            "uri" : "/analytics/sessions/ps5ltuhfsTOeh6bP03Tq5OWc/events?currentPage=1&pageSize=25"
+                          }, {
+                            "rel" : "next",
+                            "uri" : "/analytics/sessions/ps5ltuhfsTOeh6bP03Tq5OWc/events?currentPage=2&pageSize=25"
+                          }, {
+                            "rel" : "last",
+                            "uri" : "/analytics/sessions/ps5ltuhfsTOeh6bP03Tq5OWc/events?currentPage=2&pageSize=25"
+                          } ]
                       }
                     }
                   }
@@ -3794,7 +3743,7 @@
           "404" : {
             "description" : "Not Found",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/not-found"
                 },
@@ -3813,8 +3762,8 @@
           }
         },
         "security" : [ {
-          "bearerAuth" : [ ]
-        } ]
+            "bearerAuth" : [ ]
+          } ]
       }
     },
     "/webhooks" : {
@@ -3823,6 +3772,9 @@
         "summary" : "List all webhooks",
         "description" : "Requests to this endpoint return a list of your webhooks (with all their details). You can filter what the webhook list that the API returns using the parameters described below.",
         "operationId" : "LIST-webhooks",
+        "x-group-parameters" : true,
+        "x-client-paginated" : true,
+        "x-client-action" : "list",
         "parameters" : [ {
           "name" : "events",
           "in" : "query",
@@ -3835,35 +3787,18 @@
           },
           "example" : "video.encoding.quality.completed"
         }, {
-          "name" : "currentPage",
-          "in" : "query",
-          "description" : "Choose the number of search results to return per page. Minimum value: 1",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "integer",
-            "default" : 1
-          },
-          "example" : 2
+          "$ref" : "#/components/parameters/currentPage"
         }, {
-          "name" : "pageSize",
-          "in" : "query",
-          "description" : "Results per page. Allowed values 1-100, default is 25.",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "integer",
-            "default" : 25
-          },
-          "example" : 30
+          "$ref" : "#/components/parameters/pageSize"
         } ],
         "responses" : {
           "200" : {
             "description" : "Success",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/webhooks-list-response"
+                },
                 "examples" : {
                   "response" : {
                     "value" : {
@@ -3909,13 +3844,14 @@
       "post" : {
         "tags" : [ "Webhooks" ],
         "summary" : "Create Webhook",
+        "x-client-action" : "create",
         "description" : "Webhooks can push notifications to your server, rather than polling api.video for changes",
         "operationId" : "POST-webhooks",
         "requestBody" : {
           "content" : {
             "application/json" : {
               "schema" : {
-                "$ref" : "#/components/schemas/body_14"
+                "$ref" : "#/components/schemas/webhooks-create-payload"
               }
             }
           }
@@ -3924,7 +3860,10 @@
           "201" : {
             "description" : "Created",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/webhook"
+                },
                 "examples" : {
                   "response" : {
                     "value" : {
@@ -3941,7 +3880,7 @@
           "400" : {
             "description" : "Bad Request",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/bad-request"
                 },
@@ -3983,6 +3922,7 @@
         "summary" : "Show Webhook details",
         "description" : "This call provides the same JSON information provided on Webjhook creation.",
         "operationId" : "GET-Webhook",
+        "x-client-action" : "get",
         "parameters" : [ {
           "name" : "webhookId",
           "in" : "path",
@@ -3998,7 +3938,10 @@
           "200" : {
             "description" : "Success",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/webhook"
+                },
                 "examples" : {
                   "response" : {
                     "value" : {
@@ -4022,6 +3965,7 @@
         "summary" : "Delete a Webhook",
         "description" : "This endpoint will delete the indicated webhook.",
         "operationId" : "DELETE-webhook",
+        "x-client-action" : "delete",
         "parameters" : [ {
           "name" : "webhookId",
           "in" : "path",
@@ -4040,7 +3984,7 @@
           "404" : {
             "description" : "Not Found",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/not-found"
                 },
@@ -4069,13 +4013,15 @@
         "summary" : "Show account",
         "description" : "Deprecated. Authenticate and get a token, then you can use the bearer token here to retrieve details about your account.",
         "operationId" : "GET_account",
+        "deprecated" : true,
+        "x-client-action" : "get",
         "responses" : {
           "200" : {
             "description" : "Success",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/inline_response_200_9"
+                  "$ref" : "#/components/schemas/account"
                 },
                 "examples" : {
                   "response" : {
@@ -4096,7 +4042,7 @@
           "404" : {
             "description" : "Not Found",
             "content" : {
-              "application/vnd.api.video+json" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/not-found"
                 },
@@ -4115,34 +4061,55 @@
           }
         },
         "security" : [ {
-          "bearerAuth" : [ ]
-        } ]
+            "bearerAuth" : [ ]
+          } ]
       }
     }
   },
+  "x-client-base-paths" : {
+    "production" : "https://ws.api.video",
+    "sandbox" : "https://sandbox.api.video"
+  },
   "components" : {
-    "schemas" : {
-      "video" : {
-        "title" : "Video",
-        "example" : {
-          "videoId" : "vi4k0jvEUuaTdRAEjQ4Jfrgz",
-          "title" : "Maths video",
-          "description" : "An amazing video explaining the string theory",
-          "tags" : [ "maths", "string theory", "video" ],
-          "metadata" : [ {
-            "key" : "Author",
-            "value" : "John Doe"
-          }, {
-            "key" : "Format",
-            "value" : "Tutorial"
-          } ],
-          "scheduledAt" : "4251-03-03T12:52:03.085Z",
-          "publishedAt" : "4665-07-14T23:36:18.598Z",
-          "actions" : [ "video_delete", "video_download", "video_update" ]
+    "parameters" : {
+      "currentPage" : {
+        "name" : "currentPage",
+        "in" : "query",
+        "description" : "Choose the number of search results to return per page. Minimum value: 1",
+        "required" : false,
+        "style" : "form",
+        "explode" : true,
+        "schema" : {
+          "type" : "integer",
+          "default" : 1
         },
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/videooutput"
-        }, { } ]
+        "example" : 2
+      },
+      "pageSize" : {
+         "name" : "pageSize",
+        "in" : "query",
+        "description" : "Results per page. Allowed values 1-100, default is 25.",
+        "required" : false,
+        "style" : "form",
+        "explode" : true,
+        "schema" : {
+          "type" : "integer",
+          "default" : 25
+        },
+        "example" : 30
+      }
+    },
+    "schemas" : {
+      "link" : {
+        "type" : "object",
+        "properties" : {
+          "rel" : {
+            "type" : "string"
+          },
+          "uri" : {
+            "type" : "string"
+          }
+        }
       },
       "access-token" : {
         "title" : "AccessToken",
@@ -4208,7 +4175,7 @@
           "links" : {
             "type" : "array",
             "items" : {
-              "$ref" : "#/components/schemas/pagination_links"
+              "$ref" : "#/components/schemas/pagination_link"
             }
           }
         },
@@ -4281,8 +4248,8 @@
           }
         }
       },
-      "videooutput" : {
-        "title" : "VideoOutput",
+      "video" : {
+        "title" : "video",
         "type" : "object",
         "properties" : {
           "videoId" : {
@@ -4321,13 +4288,15 @@
             "type" : "array",
             "description" : "Metadata you can use to categorise and filter videos. Metadata is a list of dictionaries, where each dictionary represents a key value pair for categorising a video. \n",
             "example" : "[{\"key\":\"Author\", \"value\":\"John Doe\"}, {\"key\":\"Format\", \"value\":\"Tutorial\"}]",
-            "items" : { }
+            "items" : {
+              "$ref" : "#/components/schemas/metadata"
+            }
           },
           "source" : {
-            "$ref" : "#/components/schemas/videooutput_source"
+            "$ref" : "#/components/schemas/videoSource"
           },
           "assets" : {
-            "$ref" : "#/components/schemas/videooutput_assets"
+            "$ref" : "#/components/schemas/videoAssets"
           },
           "playerId" : {
             "type" : "string",
@@ -4349,113 +4318,104 @@
             "description" : "This lets you know whether mp4 is supported. If enabled, an mp4 URL will be provided in the response for the video.\n",
             "example" : true
           }
+        },
+        "example" : {
+          "videoId" : "vi4k0jvEUuaTdRAEjQ4Jfrgz",
+          "title" : "Maths video",
+          "description" : "An amazing video explaining the string theory",
+          "tags" : [ "maths",
+            "string theory",
+            "video"
+          ],
+          "metadata" : [ {
+              "key" : "Author",
+              "value" : "John Doe"
+            }, {
+              "key" : "Format",
+              "value" : "Tutorial"
+            } ],
+          "scheduledAt" : "4251-03-03T12:52:03.085Z",
+          "publishedAt" : "4665-07-14T23:36:18.598Z",
+          "actions" : [ "video_delete",
+            "video_download",
+            "video_update"
+          ]
         }
       },
       "player" : {
-        "title" : "Player",
-        "type" : "object",
-        "properties" : {
-          "playerId" : {
-            "type" : "string",
-            "example" : "pl45KFKdlddgk654dspkze"
-          },
-          "createdAt" : {
-            "type" : "string",
-            "description" : "When the player was created, presented in ISO-8601 format.",
-            "format" : "date-time",
-            "example" : "2020-01-31T10:17:47Z"
-          },
-          "updatedAt" : {
-            "type" : "string",
-            "description" : "When the player was last updated, presented in ISO-8601 format.",
-            "format" : "date-time",
-            "example" : "2020-01-31T10:18:47Z"
-          },
-          "shapeMargin" : {
-            "type" : "integer",
-            "description" : "Deprecated"
-          },
-          "shapeRadius" : {
-            "type" : "integer",
-            "description" : "Deprecated"
-          },
-          "shapeAspect" : {
-            "type" : "string",
-            "description" : "Deprecated"
-          },
-          "shapeBackgroundTop" : {
-            "type" : "string",
-            "description" : "Deprecated"
-          },
-          "shapeBackgroundBottom" : {
-            "type" : "string",
-            "description" : "Deprecated"
-          },
-          "text" : {
-            "type" : "string",
-            "description" : "RGBA color for timer text. Default: rgba(255, 255, 255, 1)"
-          },
-          "link" : {
-            "type" : "string",
-            "description" : "RGBA color for all controls. Default: rgba(255, 255, 255, 1)"
-          },
-          "linkHover" : {
-            "type" : "string",
-            "description" : "RGBA color for all controls when hovered. Default: rgba(255, 255, 255, 1)"
-          },
-          "linkActive" : {
-            "type" : "string",
-            "description" : "Deprecated"
-          },
-          "trackPlayed" : {
-            "type" : "string",
-            "description" : "RGBA color playback bar: played content. Default: rgba(88, 131, 255, .95)"
-          },
-          "trackUnplayed" : {
-            "type" : "string",
-            "description" : "RGBA color playback bar: downloaded but unplayed (buffered) content. Default: rgba(255, 255, 255, .35)"
-          },
-          "trackBackground" : {
-            "type" : "string",
-            "description" : "RGBA color playback bar: background. Default: rgba(255, 255, 255, .2)"
-          },
-          "backgroundTop" : {
-            "type" : "string",
-            "description" : "RGBA color: top 50% of background. Default: rgba(0, 0, 0, .7)"
-          },
-          "backgroundBottom" : {
-            "type" : "string",
-            "description" : "RGBA color: bottom 50% of background. Default: rgba(0, 0, 0, .7)"
-          },
-          "backgroundText" : {
-            "type" : "string",
-            "description" : "RGBA color for title text. Default: rgba(255, 255, 255, 1)"
-          },
-          "enableApi" : {
-            "type" : "boolean",
-            "description" : "enable/disable player SDK access. Default: true"
-          },
-          "enableControls" : {
-            "type" : "boolean",
-            "description" : "enable/disable player controls. Default: true"
-          },
-          "forceAutoplay" : {
-            "type" : "boolean",
-            "description" : "enable/disable player autoplay. Default: false"
-          },
-          "hideTitle" : {
-            "type" : "boolean",
-            "description" : "enable/disable title. Default: false"
-          },
-          "forceLoop" : {
-            "type" : "boolean",
-            "description" : "enable/disable looping. Default: false",
-            "default" : false
-          },
-          "assets" : {
-            "$ref" : "#/components/schemas/player_assets"
-          }
-        }
+        "allOf" : [ {
+            "$ref" : "#/components/schemas/playerinput"
+          }, {
+            "type" : "object",
+            "properties" : {
+              "playerId" : {
+                "type" : "string",
+                "example" : "pl45KFKdlddgk654dspkze"
+              },
+              "createdAt" : {
+                "type" : "string",
+                "description" : "When the player was created, presented in ISO-8601 format.",
+                "format" : "date-time",
+                "example" : "2020-01-31T10:17:47+00:00"
+              },
+              "updatedAt" : {
+                "type" : "string",
+                "description" : "When the player was last updated, presented in ISO-8601 format.",
+                "format" : "date-time",
+                "example" : "2020-01-31T10:18:47+00:00"
+              },
+              "shapeMargin" : {
+                "type" : "integer",
+                "description" : "Deprecated"
+              },
+              "shapeRadius" : {
+                "type" : "integer",
+                "description" : "Deprecated"
+              },
+              "shapeAspect" : {
+                "type" : "string",
+                "description" : "Deprecated"
+              },
+              "shapeBackgroundTop" : {
+                "type" : "string",
+                "description" : "Deprecated"
+              },
+              "shapeBackgroundBottom" : {
+                "type" : "string",
+                "description" : "Deprecated"
+              },
+              "linkActive" : {
+                "type" : "string",
+                "description" : "Deprecated"
+              },
+              "assets" : {
+                "type" : "object",
+                "properties" : {
+                  "logo" : {
+                    "type" : "string",
+                    "description" : "The name of the file containing the logo you want to use.",
+                    "example" : "mylogo.jpg"
+                  },
+                  "link" : {
+                    "type" : "string",
+                    "description" : "The path to the file containing your logo.",
+                    "example" : "path/to/my/logo/mylogo.jpg"
+                  }
+                }
+              }
+            }
+          } ],
+        "title" : "Player"
+      },
+      "playerCreationPayload" : {
+        "allOf" : [ {
+            "$ref" : "#/components/schemas/playerinput"
+          } ]
+      },
+      "playerUpdatePayload" : {
+        "allOf" : [ {
+            "$ref" : "#/components/schemas/playerinput"
+          } ]
       },
       "playerinput" : {
         "title" : "PlayerInput",
@@ -4524,7 +4484,6 @@
           }
         },
         "example" : {
-          "playerId" : "pl14Db6oMJRH6SRVoOwORacK",
           "assets" : {
             "logo" : "https://cdn.api.video/player/pl14Db6oMJRH6SRVoOwORacK/logo.png",
             "link" : "https://api.video"
@@ -4578,22 +4537,22 @@
         "type" : "object",
         "properties" : {
           "session" : {
-            "$ref" : "#/components/schemas/videosession_session"
+            "$ref" : "#/components/schemas/video_session_session"
           },
           "location" : {
-            "$ref" : "#/components/schemas/videosession_location"
+            "$ref" : "#/components/schemas/video_session_location"
           },
           "referrer" : {
-            "$ref" : "#/components/schemas/videosession_referrer"
+            "$ref" : "#/components/schemas/video_session_referrer"
           },
           "device" : {
-            "$ref" : "#/components/schemas/videosession_device"
+            "$ref" : "#/components/schemas/video_session_device"
           },
           "os" : {
-            "$ref" : "#/components/schemas/videosession_os"
+            "$ref" : "#/components/schemas/video_session_os"
           },
           "client" : {
-            "$ref" : "#/components/schemas/videosession_client"
+            "$ref" : "#/components/schemas/video_session_client"
           }
         },
         "example" : {
@@ -4635,7 +4594,7 @@
         "properties" : {
           "liveStreamId" : {
             "type" : "string",
-            "description" : "The unique identifier for the live stream. ",
+            "description" : "The unique identifier for the live stream. Live stream IDs begin with \"li.\"",
             "example" : "li400mYKSgQ6xs7taUeSaEKr"
           },
           "name" : {
@@ -4653,8 +4612,13 @@
             "description" : "Whether you are recording or not.",
             "example" : true
           },
+          "public" : {
+            "type" : "boolean",
+            "description" : "BETA FEATURE Please limit all public = false (\"private\") livestreams to 3,000 users. Whether your video can be viewed by everyone, or requires authentication to see it. A setting of false will require a unique token for each view.",
+            "example": true
+          },
           "assets" : {
-            "$ref" : "#/components/schemas/livestream_assets"
+            "$ref" : "#/components/schemas/live_stream_assets"
           },
           "playerId" : {
             "type" : "string",
@@ -4673,22 +4637,22 @@
         "type" : "object",
         "properties" : {
           "session" : {
-            "$ref" : "#/components/schemas/livestreamsession_session"
+            "$ref" : "#/components/schemas/live_stream_session_session"
           },
           "location" : {
-            "$ref" : "#/components/schemas/livestreamsession_location"
+            "$ref" : "#/components/schemas/live_stream_session_location"
           },
           "referrer" : {
-            "$ref" : "#/components/schemas/livestreamsession_referrer"
+            "$ref" : "#/components/schemas/live_stream_session_referrer"
           },
           "device" : {
-            "$ref" : "#/components/schemas/livestreamsession_device"
+            "$ref" : "#/components/schemas/live_stream_session_device"
           },
           "os" : {
-            "$ref" : "#/components/schemas/videosession_os"
+            "$ref" : "#/components/schemas/video_session_os"
           },
           "client" : {
-            "$ref" : "#/components/schemas/livestreamsession_client"
+            "$ref" : "#/components/schemas/live_stream_session_client"
           }
         }
       },
@@ -4705,7 +4669,7 @@
             "type" : "string",
             "description" : "When an event occurred, presented in ISO-8601 format.",
             "format" : "date-time",
-            "example" : "2019-06-24T11:45:01.109Z"
+            "example" : "2019-06-24T11:45:01.109+00"
           },
           "at" : {
             "type" : "integer"
@@ -4715,6 +4679,36 @@
           },
           "to" : {
             "type" : "integer"
+          }
+        }
+      },
+      "webhook" : {
+        "title" : "Webhook",
+        "type" : "object",
+        "properties" : {
+          "webhookId" : {
+            "type" : "string",
+            "description" : "Unique identifier of the webhook",
+            "example" : "webhook_XXXXXXXXXXXXXXX"
+          },
+          "createdAt" : {
+            "type" : "string",
+            "format" : "date-time",
+            "description" : "When an webhook was created, presented in ISO-8601 format.",
+            "example" : "2019-06-24T11:45:01.109+00"
+          },
+          "events" : {
+            "type" : "array",
+            "description" : "A list of events that will trigger the webhook.",
+            "example" : "[\"video.encoding.quality.completed\"]",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "url" : {
+            "type" : "string",
+            "description" : "URL of the webhook",
+            "example" : "http://clientnotificationserver.com/notif?myquery=query"
           }
         }
       },
@@ -4734,37 +4728,40 @@
             "status" : "uploaded",
             "filesize" : 273579401,
             "receivedBytes" : [ {
-              "to" : 134217727,
-              "from" : 0,
-              "total" : 273579401
-            }, {
-              "to" : 268435455,
-              "from" : 134217728,
-              "total" : 273579401
-            }, {
-              "to" : 273579400,
-              "from" : 268435456,
-              "total" : 273579401
-            } ]
+                "to" : 134217727,
+                "from" : 0,
+                "total" : 273579401
+              }, {
+                "to" : 268435455,
+                "from" : 134217728,
+                "total" : 273579401
+              }, {
+                "to" : 273579400,
+                "from" : 268435456,
+                "total" : 273579401
+              } ]
           },
           "encoding" : {
             "playable" : true,
             "qualities" : [ {
-              "quality" : "360p",
-              "status" : "encoded"
-            }, {
-              "quality" : "480p",
-              "status" : "encoded"
-            }, {
-              "quality" : "720p",
-              "status" : "encoded"
-            }, {
-              "quality" : "1080p",
-              "status" : "encoding"
-            }, {
-              "quality" : "2160p",
-              "status" : "waiting"
-            } ],
+                "quality" : "240p",
+                "status" : "encoded"
+              }, {
+                "quality" : "360p",
+                "status" : "encoded"
+              }, {
+                "quality" : "480p",
+                "status" : "encoded"
+              }, {
+                "quality" : "720p",
+                "status" : "encoded"
+              }, {
+                "quality" : "1080p",
+                "status" : "encoding"
+              }, {
+                "quality" : "2160p",
+                "status" : "waiting"
+              } ],
             "metadata" : {
               "width" : 424,
               "height" : 240,
@@ -4787,7 +4784,7 @@
             "type" : "string",
             "description" : "The quality of the video you have, in pixels. Choices include 360p, 480p, 720p, 1080p, and 2160p.",
             "example" : "720p",
-            "enum" : [ "360p", "480p", "720p", "1080p", "2160p" ]
+            "enum" : [ "240p", "360p", "480p", "720p", "1080p", "2160p" ]
           },
           "status" : {
             "type" : "string",
@@ -4853,17 +4850,18 @@
             "type" : "string",
             "description" : "When the token was created, displayed in ISO-8601 format.",
             "format" : "date-time",
-            "example" : "2019-12-16T08:25:51Z"
+            "example" : "2019-12-16T08:25:51+00:00"
           },
           "expiresAt" : {
             "type" : "string",
             "description" : "When the token expires, displayed in ISO-8601 format.",
             "format" : "date-time",
-            "example" : "2019-12-16T09:25:51Z"
+            "example" : "2019-12-16T09:25:51+00:00"
           }
         }
       },
-      "body" : {
+      "authenticate-payload" : {
+        "title" : "apiKey",
         "required" : [ "apiKey" ],
         "type" : "object",
         "properties" : {
@@ -4876,7 +4874,8 @@
           "apiKey" : "9VxMaPgsaFg7EBqmuspSzF7"
         }
       },
-      "body_1" : {
+      "refresh-token-payload" : {
+        "title" : "refreshToken",
         "required" : [ "refreshToken" ],
         "type" : "object",
         "properties" : {
@@ -4889,7 +4888,8 @@
           "refreshToken" : "def502005346d9cc2bd79a7793ab5bdabfefcaabfbb8c253f14733f1262077e1a3f38c4751d6d20f590c3784e531a82adc11f05fc1949aa46d5575aaa99cb84b9334ba66ac773576b5d7a418937ae337de62811d086dd42ad1164b12f87d67be6ffea18f2d50be9b95697b21c4d3c4372849bdb2287259cb80541570e913691a08b2fa33c85885930de15cebea627fc09f0255562ab3d39d87d4ff8fc02b00e252afcd480421dec7de9d1411176bcf669c527762e22294b453bc9ea06e9fa8ba5b873feb2ee14ce0a6a6ddd4b78c580631e210e9b9387265dc2bec9478a66a09dcdce1c40d2f856689e9d81742c9628a0b87b359e0b218ea1f07427eef89f999e47af89792f598e05847bd008fddc32ee63f4a601ffb4cd2ad08977f1c854ec358238322c918f05aa5a41f8a171dee497218408abc8283473f6112aeed7310815416a0fa36c63667e0ed014fa40b8992891bf58bae400d901c01450101c88f4978938ad138adc19cfe5698d60fd82cb27c586f6a8f70f4393c7c9e579df8739d46d249fb76d7"
         }
       },
-      "inline_response_200" : {
+      "videos-list-response" : {
+        "title" : "Videos",
         "required" : [ "data", "pagination" ],
         "type" : "object",
         "properties" : {
@@ -4904,24 +4904,27 @@
           }
         }
       },
-      "videos_metadata" : {
+      "metadata" : {
+        "title" : "metadata",
         "type" : "object",
+        "x-client-all-args-constructor" : true,
         "properties" : {
           "key" : {
             "type" : "string",
-            "description" : "Part of a key value pair you can use to tag your videos.",
-            "example" : "Dogs"
+            "description" : "The constant that defines the data set.",
+            "example" : "Color"
           },
           "value" : {
             "type" : "string",
-            "description" : "Part of a key value pair you can use to tag your videos.",
-            "example" : "Chihuahhua"
+            "description" : "A variable which belongs to the data set.",
+            "example" : "Green"
           }
         }
       },
-      "body_2" : {
+      "video-create-payload": {
         "required" : [ "title" ],
         "type" : "object",
+        "title" : "videoCreationPayload",
         "properties" : {
           "title" : {
             "type" : "string",
@@ -4974,7 +4977,7 @@
             "description" : "A list of key value pairs that you use to provide metadata for your video. These pairs can be made dynamic, allowing you to segment your audience. You can also just use the pairs as another way to tag and categorize your videos.",
             "example" : "[{\"key\": \"Author\", \"value\": \"John Doe\"}]",
             "items" : {
-              "$ref" : "#/components/schemas/videos_metadata"
+              "$ref" : "#/components/schemas/metadata"
             }
           },
           "publishedAt" : {
@@ -5001,19 +5004,23 @@
           } ]
         }
       },
-      "body_3" : {
+      "video-upload-payload": {
         "required" : [ "file" ],
         "type" : "object",
         "properties" : {
           "file" : {
             "type" : "string",
+            "x-client-chunk-upload" : "true",
+            "format" : "binary",
             "description" : "The path to the video you would like to upload. The path must be local. If you want to use a video from an online source, you must use the \"/videos\" endpoint and add the \"source\" parameter when you create a new video.",
             "example" : "@/path/to/video.mp4"
           }
         }
       },
-      "body_4" : {
+      "video-thumbnail-pick-payload": {
         "type" : "object",
+        "title" : "pickThumbnailPayload",
+        "required" : [ "timecode" ],
         "properties" : {
           "timecode" : {
             "pattern" : "00:00:00.00",
@@ -5025,23 +5032,20 @@
           "timecode" : "00:00:00.000"
         }
       },
-      "videosvideoId_metadata" : {
+      "video-thumbnail-upload-payload": {
+        "required" : [ "file" ],
         "type" : "object",
         "properties" : {
-          "key" : {
+          "file" : {
             "type" : "string",
-            "description" : "The constant that defines the data set.",
-            "example" : "Color"
-          },
-          "value" : {
-            "type" : "string",
-            "description" : "A variable which belongs to the data set.",
-            "example" : "Green"
+            "description" : "The image to be added as a thumbnail.",
+            "format" : "binary"
           }
         }
       },
-      "body_5" : {
+      "video-update-payload": {
         "type" : "object",
+        "title" : "videoUpdatePayload",
         "properties" : {
           "playerId" : {
             "type" : "string",
@@ -5084,7 +5088,7 @@
             "type" : "array",
             "description" : "A list (array) of dictionaries where each dictionary contains a key value pair that describes the video. As with tags, you must send the complete list of metadata you want as whatever you send here will overwrite the existing metadata for the video.",
             "items" : {
-              "$ref" : "#/components/schemas/videosvideoId_metadata"
+              "$ref" : "#/components/schemas/metadata"
             }
           }
         },
@@ -5105,11 +5109,13 @@
           } ]
         }
       },
-      "inline_response_200_1" : {
+      "token-list-response": {
+        "title" : "uploadTokens",
         "required" : [ "data", "pagination" ],
         "type" : "object",
         "properties" : {
           "data" : {
+            "title" : "uploadToken",
             "type" : "array",
             "items" : {
               "$ref" : "#/components/schemas/upload-token"
@@ -5120,7 +5126,8 @@
           }
         }
       },
-      "body_6" : {
+      "token-create-payload": {
+        "title" : "tokenCreationPayload",
         "type" : "object",
         "properties" : {
           "ttl" : {
@@ -5135,22 +5142,27 @@
           "ttl" : 3600
         }
       },
-      "body_7" : {
+      "token-upload-payload": {
         "required" : [ "file" ],
         "type" : "object",
         "properties" : {
           "file" : {
+            "x-client-chunk-upload" : "true",
+            "format" : "binary",
             "type" : "string",
             "description" : "The path to the video you want to upload.",
             "example" : "path/to/video/video.mp4"
           },
           "videoId" : {
+            "x-client-ignore" : true,
+            "x-client-copy-from-response" : true,
             "type" : "string",
             "description" : "The video id returned by the first call to this endpoint in a large video upload scenario."
           }
         }
       },
-      "inline_response_200_2" : {
+      "live-stream-list-response": {
+        "title" : "LiveStreams",
         "required" : [ "data", "pagination" ],
         "type" : "object",
         "properties" : {
@@ -5165,7 +5177,8 @@
           }
         }
       },
-      "body_8" : {
+      "live-stream-create-payload": {
+        "title" : "liveStreamCreationPayload",
         "required" : [ "name" ],
         "type" : "object",
         "properties" : {
@@ -5196,7 +5209,8 @@
           "playerId" : "pl4f4ferf5erfr5zed4fsdd"
         }
       },
-      "body_9" : {
+      "live-stream-update-payload": {
+        "title" : "LiveStreamUpdatePayload",
         "type" : "object",
         "properties" : {
           "name" : {
@@ -5220,18 +5234,31 @@
           }
         }
       },
-      "body_10" : {
+      "captions-upload-payload": {
         "required" : [ "file" ],
         "type" : "object",
         "properties" : {
           "file" : {
             "type" : "string",
             "description" : "The video text track (VTT) you want to upload.",
+            "format" : "binary",
+            "example" : "https://cdn.api.video/vod/vi3N6cDinStg3oBbN79GklWS/captions/en.vtt"
+          }
+        }
+      },
+      "live-stream-thumbnail-upload-payload" : {
+        "required" : [ "file" ],
+        "type" : "object",
+        "properties" : {
+          "file" : {
+            "type" : "string",
+            "description" : "The image to be added as a thumbnail.",
             "format" : "binary"
           }
         }
       },
-      "body_11" : {
+      "captions-update-payload" : {
+        "title" : "UpdateCaptionPayload",
         "type" : "object",
         "properties" : {
           "default" : {
@@ -5239,7 +5266,8 @@
           }
         }
       },
-      "inline_response_200_3" : {
+      "captions-list-response" : {
+        "title" : "VideoCaptions",
         "type" : "object",
         "properties" : {
           "data" : {
@@ -5253,17 +5281,20 @@
           }
         }
       },
-      "body_12" : {
+      "chapters-update-payload": {
+        "title" : "UpdateChapterPayload",
         "required" : [ "file" ],
         "type" : "object",
         "properties" : {
           "file" : {
             "type" : "string",
-            "description" : "The VTT file describing the chapters you want to upload."
+            "description" : "The VTT file describing the chapters you want to upload.",
+            "format" : "binary"
           }
         }
       },
-      "inline_response_200_4" : {
+      "chapters-list-response": {
+        "title" : "VideoChapters",
         "type" : "object",
         "properties" : {
           "data" : {
@@ -5277,7 +5308,8 @@
           }
         }
       },
-      "inline_response_200_5" : {
+      "players-list-response": {
+        "title" : "Players",
         "type" : "object",
         "properties" : {
           "data" : {
@@ -5291,24 +5323,26 @@
           }
         }
       },
-      "body_13" : {
+      "players-upload-logo-payload": {
         "required" : [ "file", "link" ],
         "type" : "object",
         "properties" : {
           "file" : {
             "type" : "string",
+            "format" : "binary",
             "description" : "The name of the file you want to use for your logo.",
             "example" : "mylogo.jpg"
           },
           "link" : {
             "type" : "string",
+            "format" : "string",
             "description" : "The path to the file you want to upload and use as a logo.",
-            "format" : "uri",
             "example" : "path/to/my/logo/mylogo.jpg"
           }
         }
       },
-      "inline_response_200_6" : {
+      "raw-statistics-list-sessions-response": {
+        "title" : "VideoSessions",
         "type" : "object",
         "properties" : {
           "data" : {
@@ -5322,7 +5356,8 @@
           }
         }
       },
-      "inline_response_200_7" : {
+      "raw-statistics-list-live-stream-analytics-response": {
+        "title" : "LiveStreamSessions",
         "type" : "object",
         "properties" : {
           "data" : {
@@ -5336,7 +5371,8 @@
           }
         }
       },
-      "inline_response_200_8" : {
+      "raw-statistics-list-player-session-events-response": {
+        "title" : "PlayerSessionEvents",
         "type" : "object",
         "properties" : {
           "data" : {
@@ -5350,7 +5386,22 @@
           }
         }
       },
-      "body_14" : {
+      "webhooks-list-response": {
+        "title" : "Webhooks",
+        "type" : "object",
+        "properties" : {
+          "data" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/webhook"
+            }
+          },
+          "pagination" : {
+            "$ref" : "#/components/schemas/pagination"
+          }
+        }
+      },
+      "webhooks-create-payload" : {
         "required" : [ "events", "url" ],
         "type" : "object",
         "properties" : {
@@ -5373,32 +5424,13 @@
           "url" : "http://clientnotificationserver.com/notif?myquery=query"
         }
       },
-      "inline_response_200_9" : {
+      "pagination_link" : {
         "type" : "object",
-        "properties" : {
-          "quota" : {
-            "$ref" : "#/components/schemas/inline_response_200_9_quota"
-          },
-          "features" : {
-            "type" : "array",
-            "description" : "Deprecated. What features are enabled for your account. Choices include: app.dynamic_metadata - the ability to dynamically tag videos to better segment and understand your audiences, app.event_log - the ability to create and retrieve a log detailing how your videos were interacted with, player.white_label - the ability to customise your player, stats.player_events - the ability to see statistics about how your player is being used, transcode.mp4_support - the ability to reformat content into mp4 using the H264 codec.",
-            "example" : "[\"app.dynamic_metadata, app.event_log\"]",
-            "items" : {
-              "type" : "string"
-            }
-          },
-          "environment" : {
-            "type" : "string",
-            "description" : "Deprecated. Whether you are using your production or sandbox API key will impact what environment is displayed here, as well as stats and features information. If you use your sandbox key, the environment is \"sandbox.\" If you use your production key, the environment is \"production.\""
-          }
-        }
-      },
-      "pagination_" : {
-        "type" : "object",
+        "title" : "PaginationLink",
         "properties" : {
           "rel" : {
-            "pattern" : "^self$",
-            "type" : "string"
+            "type" : "string",
+            "pattern" : "^self$"
           },
           "uri" : {
             "type" : "string",
@@ -5406,15 +5438,7 @@
           }
         }
       },
-      "pagination_links" : {
-        "type" : "object",
-        "properties" : {
-          "" : {
-            "$ref" : "#/components/schemas/pagination_"
-          }
-        }
-      },
-      "videooutput_source_liveStream_links" : {
+      "video_source_live_stream_link": {
         "type" : "object",
         "properties" : {
           "rel" : {
@@ -5423,9 +5447,9 @@
           "uri" : {
             "type" : "string"
           }
-        }
+        }      
       },
-      "videooutput_source_liveStream" : {
+      "video_source_live_stream": {
         "type" : "object",
         "properties" : {
           "liveStreamId" : {
@@ -5436,13 +5460,13 @@
           "links" : {
             "type" : "array",
             "items" : {
-              "$ref" : "#/components/schemas/videooutput_source_liveStream_links"
+              "$ref" : "#/components/schemas/video_source_live_stream_link"
             }
           }
         },
         "description" : "This appears if the video is from a Live Record."
       },
-      "videooutput_source" : {
+      "videoSource": {
         "type" : "object",
         "properties" : {
           "uri" : {
@@ -5454,12 +5478,12 @@
             "type" : "string"
           },
           "liveStream" : {
-            "$ref" : "#/components/schemas/videooutput_source_liveStream"
+            "$ref" : "#/components/schemas/video_source_live_stream"
           }
         },
         "description" : "Source information about the video."
       },
-      "videooutput_assets" : {
+      "videoAssets": {
         "type" : "object",
         "properties" : {
           "hls" : {
@@ -5493,22 +5517,7 @@
         },
         "description" : "Collection of details about the video object that you can use to work with the video object."
       },
-      "player_assets" : {
-        "type" : "object",
-        "properties" : {
-          "logo" : {
-            "type" : "string",
-            "description" : "The name of the file containing the logo you want to use.",
-            "example" : "mylogo.jpg"
-          },
-          "link" : {
-            "type" : "string",
-            "description" : "The path to the file containing your logo.",
-            "example" : "path/to/my/logo/mylogo.jpg"
-          }
-        }
-      },
-      "videosession_session" : {
+      "video_session_session": {
         "type" : "object",
         "properties" : {
           "sessionId" : {
@@ -5520,17 +5529,17 @@
             "type" : "string",
             "description" : "When the video session started, presented in ISO-8601 format.",
             "format" : "date-time",
-            "example" : "2019-06-24T11:45:01.109Z"
+            "example" : "2019-06-24T11:45:01.109+00"
           },
           "endedAt" : {
             "type" : "string",
             "description" : "When the video session ended, presented in ISO-8601 format.",
             "format" : "date-time",
-            "example" : "2019-06-24T12:45:01.109Z"
+            "example" : "2019-06-24T12:45:01.109+00"
           }
         }
       },
-      "videosession_location" : {
+      "video_session_location": {
         "type" : "object",
         "properties" : {
           "country" : {
@@ -5546,7 +5555,7 @@
         },
         "description" : "The location of the viewer."
       },
-      "videosession_referrer" : {
+      "video_session_referrer": {
         "type" : "object",
         "properties" : {
           "url" : {
@@ -5570,7 +5579,7 @@
           }
         }
       },
-      "videosession_device" : {
+      "video_session_device": {
         "type" : "object",
         "properties" : {
           "type" : {
@@ -5591,7 +5600,7 @@
         },
         "description" : "What type of device the user is on when in the video session."
       },
-      "videosession_os" : {
+      "video_session_os": {
         "type" : "object",
         "properties" : {
           "name" : {
@@ -5612,7 +5621,7 @@
         },
         "description" : "The operating system the viewer is on."
       },
-      "videosession_client" : {
+      "video_session_client": {
         "type" : "object",
         "properties" : {
           "name" : {
@@ -5624,11 +5633,16 @@
             "type" : "string",
             "description" : "The version of the browser used to view the video session.",
             "example" : "67.0"
+          },
+          "type" : {
+            "type" : "string",
+            "description" : "The type of client used to view the video session.",
+            "example" : "browser"
           }
         },
         "description" : "What kind of browser the viewer is using for the video session."
       },
-      "livestream_assets" : {
+      "live_stream_assets" : {
         "type" : "object",
         "properties" : {
           "hls" : {
@@ -5656,7 +5670,7 @@
           }
         }
       },
-      "livestreamsession_session" : {
+      "live_stream_session_session" : {
         "type" : "object",
         "properties" : {
           "sessionId" : {
@@ -5667,17 +5681,17 @@
             "type" : "string",
             "description" : "When the session started, with the date and time presented in ISO-8601 format.",
             "format" : "date-time",
-            "example" : "2019-06-24T11:45:01.109Z"
+            "example" : "2019-06-24T11:45:01.109+00"
           },
           "endedAt" : {
             "type" : "string",
             "description" : "When the session ended, with the date and time presented in ISO-8601 format.",
             "format" : "date-time",
-            "example" : "2019-06-24T12:45:01.109Z"
+            "example" : "2019-06-24T12:45:01.109+00"
           }
         }
       },
-      "livestreamsession_location" : {
+      "live_stream_session_location" : {
         "type" : "object",
         "properties" : {
           "country" : {
@@ -5693,7 +5707,7 @@
         },
         "description" : "The location of the viewer of the live stream."
       },
-      "livestreamsession_referrer" : {
+      "live_stream_session_referrer" : {
         "type" : "object",
         "properties" : {
           "url" : {
@@ -5718,7 +5732,7 @@
           }
         }
       },
-      "livestreamsession_device" : {
+      "live_stream_session_device" : {
         "type" : "object",
         "properties" : {
           "type" : {
@@ -5739,7 +5753,7 @@
         },
         "description" : "What type of device the user is on when in the live stream session."
       },
-      "livestreamsession_client" : {
+      "live_stream_session_client" : {
         "type" : "object",
         "properties" : {
           "name" : {
@@ -5751,6 +5765,11 @@
             "type" : "string",
             "description" : "The version of the browser used to view the live stream session.",
             "example" : "67.0"
+          },
+          "type" : {
+            "type" : "string",
+            "description" : "The type of client used to view the live stream session.",
+            "example" : "browser"
           }
         },
         "description" : "What kind of browser the viewer is using for the live stream session."
@@ -5841,440 +5860,58 @@
           }
         }
       },
-      "inline_response_200_9_quota" : {
+      "account": {
         "type" : "object",
+        "title" : "Account",
+        "deprecated": true,
         "properties" : {
-          "quotaUsed" : {
-            "type" : "number",
-            "description" : "Deprecated"
+          "quota" : {
+            "type" : "object",
+            "description" : "Deprecated",
+            "properties" : {
+              "quotaUsed" : {
+                "type" : "number",
+                "description" : "Deprecated"
+              },
+              "quotaRemaining" : {
+                "type" : "number",
+                "description" : "Deprecated"
+              },
+              "quotaTotal" : {
+                "type" : "number",
+                "description" : "Deprecated"
+              }
+            }
           },
-          "quotaRemaining" : {
-            "type" : "number",
-            "description" : "Deprecated"
+          "features" : {
+            "type" : "array",
+            "description" : "Deprecated. What features are enabled for your account. Choices include: app.dynamic_metadata - the ability to dynamically tag videos to better segment and understand your audiences, app.event_log - the ability to create and retrieve a log detailing how your videos were interacted with, player.white_label - the ability to customise your player, stats.player_events - the ability to see statistics about how your player is being used, transcode.mp4_support - the ability to reformat content into mp4 using the H264 codec.",
+            "example" : "[\"app.dynamic_metadata, app.event_log\"]",
+            "items" : {
+              "type" : "string"
+            }
           },
-          "quotaTotal" : {
-            "type" : "number",
-            "description" : "Deprecated"
-          }
-        },
-        "description" : "Deprecated"
-      }
-    },
-    "responses" : {
-      "trait_paginatedListVideo_200" : {
-        "description" : "",
-        "content" : {
-          "application/vnd.api.video+json" : {
-            "schema" : {
-              "required" : [ "data", "pagination" ],
-              "type" : "object",
-              "properties" : {
-                "data" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "object",
-                    "properties" : { }
-                  }
-                },
-                "pagination" : {
-                  "$ref" : "#/components/schemas/pagination"
-                }
-              }
-            }
-          }
-        }
-      },
-      "trait_paginatedListPlayer_200" : {
-        "description" : "",
-        "content" : {
-          "application/vnd.api.video+json" : {
-            "schema" : {
-              "required" : [ "data", "pagination" ],
-              "type" : "object",
-              "properties" : {
-                "data" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "object",
-                    "properties" : { }
-                  }
-                },
-                "pagination" : {
-                  "$ref" : "#/components/schemas/pagination"
-                }
-              }
-            }
-          }
-        }
-      },
-      "trait_paginatedListVideosStats_200" : {
-        "description" : "",
-        "content" : {
-          "application/vnd.api.video+json" : {
-            "schema" : {
-              "required" : [ "data", "pagination" ],
-              "type" : "object",
-              "properties" : {
-                "data" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/video-session"
-                  }
-                },
-                "pagination" : {
-                  "$ref" : "#/components/schemas/pagination"
-                },
-                "period" : {
-                  "type" : "string",
-                  "format" : "date"
-                }
-              }
-            }
-          }
-        }
-      },
-      "trait_paginatedListLivesStats_200" : {
-        "description" : "",
-        "content" : {
-          "application/vnd.api.video+json" : {
-            "schema" : {
-              "required" : [ "data", "pagination" ],
-              "type" : "object",
-              "properties" : {
-                "data" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/live-stream-session"
-                  }
-                },
-                "pagination" : {
-                  "$ref" : "#/components/schemas/pagination"
-                },
-                "period" : {
-                  "type" : "string",
-                  "format" : "date"
-                }
-              }
-            }
-          }
-        }
-      },
-      "trait_paginatedListSessionEventsStats_200" : {
-        "description" : "",
-        "content" : {
-          "application/vnd.api.video+json" : {
-            "schema" : {
-              "required" : [ "data", "pagination" ],
-              "type" : "object",
-              "properties" : {
-                "data" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/video-session"
-                  }
-                },
-                "pagination" : {
-                  "$ref" : "#/components/schemas/pagination"
-                },
-                "period" : {
-                  "type" : "string",
-                  "format" : "date"
-                }
-              }
-            }
+          "environment" : {
+            "type" : "string",
+            "description" : "Deprecated. Whether you are using your production or sandbox API key will impact what environment is displayed here, as well as stats and features information. If you use your sandbox key, the environment is \"sandbox.\" If you use your production key, the environment is \"production.\""
           }
         }
       }
-    },
-    "parameters" : {
-      "trait_paginatedListVideo_sortBy" : {
-        "name" : "sortBy",
-        "in" : "query",
-        "description" : "Allowed: publishedAt, title. Sort by when a video was published, using the time in ISO-8601 format, or by title. Use sortOrder to choose the order in which these are sorted.",
-        "required" : false,
-        "style" : "form",
-        "explode" : true,
-        "schema" : {
-          "type" : "string"
-        },
-        "example" : "publishedAt"
-      },
-      "trait_paginatedListVideo_sortOrder" : {
-        "name" : "sortOrder",
-        "in" : "query",
-        "description" : "Allowed: asc, desc. Ascending for date and time means that earlier values precede later ones. Descending means that later values preced earlier ones. For title, it is 0-9 and A-Z ascending and Z-A, 9-0 descending.",
-        "required" : false,
-        "style" : "form",
-        "explode" : true,
-        "schema" : {
-          "type" : "string"
-        },
-        "example" : "desc"
-      },
-      "trait_paginatedListVideosStats_currentPage" : {
-        "name" : "currentPage",
-        "in" : "query",
-        "description" : "The number of the page you want to view.",
-        "required" : false,
-        "style" : "form",
-        "explode" : true,
-        "schema" : {
-          "type" : "integer"
-        },
-        "example" : 3
-      },
-      "trait_paginatedListVideosStats_pageSize" : {
-        "name" : "pageSize",
-        "in" : "query",
-        "description" : "How many items will be returned per page. If you do not have enough items for a page, there will be less items than the requested page size.",
-        "required" : false,
-        "style" : "form",
-        "explode" : true,
-        "schema" : {
-          "type" : "integer"
-        },
-        "example" : 30
-      },
-      "trait_paginatedListVideosStats_sortBy" : {
-        "name" : "sortBy",
-        "in" : "query",
-        "description" : "Allowed: emitted_at, title. Sort by when an event occurred, an event is something that happens during a session like ready, play, pause, resume, seek.backward, seek.forward, or end. The date-time format for an event occurrence is ISO-8601. You can also sort by title. Use the sortOrder parameter to choose the order in which information is returned.",
-        "required" : false,
-        "style" : "form",
-        "explode" : true,
-        "schema" : {
-          "type" : "string"
-        }
-      },
-      "trait_paginatedListVideosStats_sortOrder" : {
-        "name" : "sortOrder",
-        "in" : "query",
-        "description" : "Allowed: asc, desc. Ascending for date and time means that earlier values precede later ones. Descending means that later values preced earlier ones. For title, it is 0-9 and A-Z ascending and Z-A, 9-0 descending.",
-        "required" : false,
-        "style" : "form",
-        "explode" : true,
-        "schema" : {
-          "type" : "string"
-        },
-        "example" : "asc"
-      },
-      "trait_paginatedListVideosStats_tags" : {
-        "name" : "tags",
-        "in" : "query",
-        "description" : "Tags can be used to categorise the video.",
-        "required" : false,
-        "style" : "form",
-        "explode" : true,
-        "schema" : {
-          "type" : "array",
-          "items" : {
-            "type" : "string"
-          }
-        },
-        "example" : "[\"maths\", \"string theory\", \"video\"]"
-      },
-      "trait_paginatedListVideosStats_metadata" : {
-        "name" : "metadata",
-        "in" : "query",
-        "description" : "Metadata and Dynamic Metadata filter.",
-        "required" : false,
-        "style" : "form",
-        "explode" : true,
-        "schema" : {
-          "type" : "array",
-          "items" : {
-            "type" : "string"
-          }
-        },
-        "example" : "[{\"key\": \"Author\", \"value\": \"John Doe\"}, {\"key\": \"Format\", \"value\": \"Tutorial\"}]"
-      },
-      "trait_paginatedListLivesStats_currentPage" : {
-        "name" : "currentPage",
-        "in" : "query",
-        "description" : "The number for the page you are currently viewing.",
-        "required" : false,
-        "style" : "form",
-        "explode" : true,
-        "schema" : {
-          "type" : "integer"
-        },
-        "example" : 4
-      },
-      "trait_paginatedListLivesStats_pageSize" : {
-        "name" : "pageSize",
-        "in" : "query",
-        "description" : "The number of items you want to display per page. If there are less items than the page size, the page will be only partially full.",
-        "required" : false,
-        "style" : "form",
-        "explode" : true,
-        "schema" : {
-          "type" : "integer"
-        },
-        "example" : 30
-      },
-      "trait_paginatedListLivesStats_sortBy" : {
-        "name" : "sortBy",
-        "in" : "query",
-        "description" : "Allowed: emitted_at, title. Allowed: emitted_at, title. Sort by when an event occurred, an event is something that happens during a session like ready, play, pause, resume, seek.backward, seek.forward, or end. The date-time format for an event occurrence is ISO-8601. You can also sort by title. Use the sortOrder parameter to choose the order in which information is returned.",
-        "required" : false,
-        "style" : "form",
-        "explode" : true,
-        "schema" : {
-          "type" : "string"
-        }
-      },
-      "trait_paginatedListLivesStats_sortOrder" : {
-        "name" : "sortOrder",
-        "in" : "query",
-        "description" : "Allowed: asc, desc. Ascending for date and time means that earlier values precede later ones. Descending means that later values preced earlier ones. For title, it is 0-9 and A-Z ascending and Z-A, 9-0 descending.",
-        "required" : false,
-        "style" : "form",
-        "explode" : true,
-        "schema" : {
-          "type" : "string"
-        },
-        "example" : "desc"
-      },
-      "trait_paginatedListSessionEventsStats_currentPage" : {
-        "name" : "currentPage",
-        "in" : "query",
-        "description" : "The number for the page you are currently on.",
-        "required" : false,
-        "style" : "form",
-        "explode" : true,
-        "schema" : {
-          "type" : "integer"
-        },
-        "example" : 3
-      },
-      "trait_paginatedListSessionEventsStats_pageSize" : {
-        "name" : "pageSize",
-        "in" : "query",
-        "description" : "The number of items returned per page. If there are not enough items for a page, the page will be partially filled.",
-        "required" : false,
-        "style" : "form",
-        "explode" : true,
-        "schema" : {
-          "type" : "integer"
-        },
-        "example" : 30
-      },
-      "trait_paginatedListSessionEventsStats_sortBy" : {
-        "name" : "sortBy",
-        "in" : "query",
-        "description" : "Allowed: emitted_at, title. Allowed: emitted_at, title. Sort by when an event occurred, an event is something that happens during a session like ready, play, pause, resume, seek.backward, seek.forward, or end. The date-time format for an event occurrence is ISO-8601. You can also sort by title. Use the sortOrder parameter to choose the order in which information is returned.",
-        "required" : false,
-        "style" : "form",
-        "explode" : true,
-        "schema" : {
-          "type" : "string"
-        },
-        "example" : "My Movie"
-      },
-      "trait_paginatedListSessionEventsStats_sortOrder" : {
-        "name" : "sortOrder",
-        "in" : "query",
-        "description" : "Allowed: asc, desc. Ascending for date and time means that earlier values precede later ones. Descending means that later values preced earlier ones. For title, it is 0-9 and A-Z ascending and Z-A, 9-0 descending.",
-        "required" : false,
-        "style" : "form",
-        "explode" : true,
-        "schema" : {
-          "type" : "string"
-        },
-        "example" : "asc"
-      },
-      "trait_paginatedListSessionEventsStats_tags" : {
-        "name" : "tags",
-        "in" : "query",
-        "required" : false,
-        "style" : "form",
-        "explode" : true,
-        "schema" : {
-          "type" : "array",
-          "items" : {
-            "type" : "string"
-          }
-        }
-      },
-      "trait_paginatedListSessionEventsStats_metadata" : {
-        "name" : "metadata",
-        "in" : "query",
-        "description" : "Metadata and Dynamic Metadata filter.",
-        "required" : false,
-        "style" : "form",
-        "explode" : true,
-        "schema" : {
-          "type" : "array",
-          "items" : {
-            "type" : "string"
-          }
-        }
-      },
-      "trait_pageQueryTrait_currentPage" : {
-        "name" : "currentPage",
-        "in" : "query",
-        "description" : "Number of the page to display",
-        "required" : false,
-        "style" : "form",
-        "explode" : true,
-        "schema" : {
-          "minimum" : 1,
-          "type" : "integer",
-          "default" : 1
-        }
-      },
-      "trait_pageQueryTrait_pageSize" : {
-        "name" : "pageSize",
-        "in" : "query",
-        "description" : "Expected number of items to display on the page. Might be lower on the last page",
-        "required" : false,
-        "style" : "form",
-        "explode" : true,
-        "schema" : {
-          "maximum" : 100,
-          "minimum" : 1,
-          "type" : "integer",
-          "default" : 25
-        }
-      }
-    },
-    "requestBodies" : {
-      "playerinput" : {
-        "content" : {
-          "application/json" : {
-            "schema" : {
-              "$ref" : "#/components/schemas/playerinput"
-            }
-          }
-        }
-      },
-      "POST_videos-videoId-thumbnail" : {
-        "content" : {
-          "multipart/form-data" : {
-            "schema" : {
-              "required" : [ "file" ],
-              "type" : "object",
-              "properties" : {
-                "file" : {
-                  "type" : "string",
-                  "description" : "The image to be added as a thumbnail."
-                }
-              }
-            }
-          }
-        }
-      }
-    },
+  },
     "securitySchemes" : {
       "bearerAuth" : {
         "type" : "http",
-        "scheme" : "bearer",
-        "bearerFormat" : "JWT"
+        "scheme" : "bearer"
       }
     }
   },
   "x-explorer-enabled" : true,
   "x-proxy-enabled" : true,
   "x-samples-enabled" : true,
-  "x-samples-languages" : [ "curl", "node", "ruby", "javascript", "python" ]
+  "x-samples-languages" : [ "curl",
+    "node",
+    "ruby",
+    "javascript",
+    "python"
+  ]
 }

--- a/oas_apivideo.yaml
+++ b/oas_apivideo.yaml
@@ -1,0 +1,5084 @@
+openapi: 3.0.0
+info:
+  title: api.video
+  description: >-
+    api.video is an API that encodes on the go to facilitate immediate playback,
+    enhancing viewer streaming experiences across multiple devices and
+    platforms. You can stream live or on-demand online videos within minutes.
+  version: '1'
+servers:
+  - url: 'https://ws.api.video'
+paths:
+  /auth/api-key:
+    post:
+      tags:
+        - Authentication
+      summary: Authenticate
+      description: >-
+        To get started, submit your API key in the body of your request.
+        api.video returns an access token that is valid for one hour (3600
+        seconds). A refresh token is also returned. View a
+        [tutorial](https://api.video/blog/tutorials/authentication-tutorial) on
+        authentication.
+      operationId: POST_auth-api-key
+      x-client-action: authenticate
+      x-client-hidden: true
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/authenticate-payload'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/access-token'
+              examples:
+                response:
+                  value:
+                    token_type: Bearer
+                    expires_in: 3600
+                    access_token: >-
+                      eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImp0aSI6IjUyZWM4NWUyMjFkODZjOWI0NDQ5NzBhMjQwMzUyOWQ4MDQyNGQ3ZmJjYjFlYWM2MjVlM2VkMjI2YWRlNTcxMDY2NDUyZDc0NjdhN2E4NjI0In0.eyJhdWQiOiJsaWJjYXN0IiwianRpIjoiNTJlYzg1ZTIyMWQ4NmM5YjQ0NDk3MGEyNDAzNTI5ZDgwNDI0ZDdmYmNiMWVhYzYyNWUzZWQyMjZhZGU1NzEwNjY0NTJkNzQ2N2E3YTg2MjQiLCJpYXQiOjE1MjUyNzYxNDcsIm5iZiI6MTUyNTI3NjE0NywiZXhwIjoxNTI1Mjc5NzQ3LCJzdWIiOiJ1c01vbml0b3IiLCJzY29wZXMiOlsibW9uaXRvci5saWJjYXN0LmNvbSJdLCJjb250ZXh0Ijp7InVzZXIiOiJ1c01vbml0b3IiLCJwcm9qZWN0IjoicHJNb25pdG9yIiwibWVtYmVyIjoibWVNb25pdG9yIn19.rUvishDNyJLNlI4W5VmguNecm5KD2uZgPkKJQbaqw-cJbSrVxkSbiKYtk_E3cz3WT7-IS2yFTsYN3uIo5Rbit8_HftweyEp2bdBRI8yjR6oZZ1sNJJXswISN1i2kk4r-aaxu7Xxf_LtsjOMUj_YZsvcc2nqBXPKjHbJCJryx3DDJaIcymOqao7nhQaCCQyrQooAXNTYs4E9fWN1dC_x2O-zok5TuG-xhEW-umwxfSUMWNgSTkz38ACceQ0PCJSgB3jqjDH4MwC7B3ppEPZuK5E6JhKeyRlalswRyYq3UQPnVeMTam7YQHsuTgbehF6WySW8i44o7V_MCe9hjPdp-WA
+                    refresh_token: >-
+                      def50200a28d88fb9aaa921be78eeb5604b071101a334899a7d5fc7492cf8ea752962ddc8961fe5c126101d4ecacd980396eb2fd494995b812dffcb98256c4277f790d1f658fc2d2e34f350740544e5232d69d68d34c648271d706c5e7049adac0b1832d0fdf71809715cc7e97fa63f65966deadb501a55ff469b0fd23a637cb6acbe9d9b8594a17f09efc2efeed82984764a0065d5e29c950c7b081a61ba2aaa192be3085c400ee37eac50fa9320ce2cfe8916c8165418d23e9f91b6a5c8515e1d74ee193a5a1ca01954fbff27361c20184240be2359e0afbed0bf1c762cf872450b5e8b5d4704f4fd9583e4470adc98409dd42965709712806bd9019378a72eea0b4912ce684ffd833db5806ab84174f905db2a75380071d004615c944bb8f8c4045cce7234c2be9a2330522cf7f067b8e58f57cffb6edb4b7ef91313e12bcde47e5e76ceee7fa52990132288f345d33ed917ae4fd54b7284f8964d898e97e1ee3bc4157f75d7fee63976e4be66ac1ec32ef74afa533f0eb593523f226cbec57d196ac8962
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/bad-request'
+              examples:
+                response:
+                  value:
+                    type: >-
+                      https://docs.api.video/docs/authenticationinvalid_credentials
+                    title: The user credentials were incorrect.
+                    name: ''
+                    status: 400
+  /auth/refresh:
+    post:
+      tags:
+        - Authentication
+      summary: Refresh token
+      description: >
+        Use the refresh endpoint with the refresh token you received when you
+        first authenticated using the api-key endpoint. Send the refresh token
+        in the body of your request. The api.video API returns a new access
+        token that is valid for one hour (3600 seconds) and a new refresh
+        token. 
+      operationId: POST_auth-refresh
+      x-client-action: refresh
+      x-client-hidden: true
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/refresh-token-payload'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/access-token'
+              examples:
+                response:
+                  value:
+                    token_type: Bearer
+                    expires_in: 3600
+                    access_token: >-
+                      eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImp0aSI6IjUyZWM4NWUyMjFkODZjOWI0NDQ5NzBhMjQwMzUyOWQ4MDQyNGQ3ZmJjYjFlYWM2MjVlM2VkMjI2YWRlNTcxMDY2NDUyZDc0NjdhN2E4NjI0In0.eyJhdWQiOiJsaWJjYXN0IiwianRpIjoiNTJlYzg1ZTIyMWQ4NmM5YjQ0NDk3MGEyNDAzNTI5ZDgwNDI0ZDdmYmNiMWVhYzYyNWUzZWQyMjZhZGU1NzEwNjY0NTJkNzQ2N2E3YTg2MjQiLCJpYXQiOjE1MjUyNzYxNDcsIm5iZiI6MTUyNTI3NjE0NywiZXhwIjoxNTI1Mjc5NzQ3LCJzdWIiOiJ1c01vbml0b3IiLCJzY29wZXMiOlsibW9uaXRvci5saWJjYXN0LmNvbSJdLCJjb250ZXh0Ijp7InVzZXIiOiJ1c01vbml0b3IiLCJwcm9qZWN0IjoicHJNb25pdG9yIiwibWVtYmVyIjoibWVNb25pdG9yIn19.rUvishDNyJLNlI4W5VmguNecm5KD2uZgPkKJQbaqw-cJbSrVxkSbiKYtk_E3cz3WT7-IS2yFTsYN3uIo5Rbit8_HftweyEp2bdBRI8yjR6oZZ1sNJJXswISN1i2kk4r-aaxu7Xxf_LtsjOMUj_YZsvcc2nqBXPKjHbJCJryx3DDJaIcymOqao7nhQaCCQyrQooAXNTYs4E9fWN1dC_x2O-zok5TuG-xhEW-umwxfSUMWNgSTkz38ACceQ0PCJSgB3jqjDH4MwC7B3ppEPZuK5E6JhKeyRlalswRyYq3UQPnVeMTam7YQHsuTgbehF6WySW8i44o7V_MCe9hjPdp-WA
+                    refresh_token: >-
+                      def50200a28d88fb9aaa921be78eeb5604b071101a334899a7d5fc7492cf8ea752962ddc8961fe5c126101d4ecacd980396eb2fd494995b812dffcb98256c4277f790d1f658fc2d2e34f350740544e5232d69d68d34c648271d706c5e7049adac0b1832d0fdf71809715cc7e97fa63f65966deadb501a55ff469b0fd23a637cb6acbe9d9b8594a17f09efc2efeed82984764a0065d5e29c950c7b081a61ba2aaa192be3085c400ee37eac50fa9320ce2cfe8916c8165418d23e9f91b6a5c8515e1d74ee193a5a1ca01954fbff27361c20184240be2359e0afbed0bf1c762cf872450b5e8b5d4704f4fd9583e4470adc98409dd42965709712806bd9019378a72eea0b4912ce684ffd833db5806ab84174f905db2a75380071d004615c944bb8f8c4045cce7234c2be9a2330522cf7f067b8e58f57cffb6edb4b7ef91313e12bcde47e5e76ceee7fa52990132288f345d33ed917ae4fd54b7284f8964d898e97e1ee3bc4157f75d7fee63976e4be66ac1ec32ef74afa533f0eb593523f226cbec57d196ac8962
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/bad-request'
+              examples:
+                response:
+                  value:
+                    status: 400
+                    type: >-
+                      https://docs.api.video/docs/authenticationinvalid_credentials
+                    title: The user credentials were incorrect.
+                    name: ''
+  /videos:
+    get:
+      tags:
+        - Videos
+      summary: List all videos
+      description: >-
+        Requests to this endpoint return a list of your videos (with all their
+        details). With no parameters added to this query, the API returns all
+        videos. You can filter what videos the API returns using the parameters
+        described below.
+      operationId: LIST-videos
+      x-client-action: list
+      x-group-parameters: true
+      x-client-paginated: true
+      parameters:
+        - name: title
+          in: query
+          description: >-
+            The title of a specific video you want to find. The search will
+            match exactly to what term you provide and return any videos that
+            contain the same term as part of their titles.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+          example: My Video.mp4
+        - name: tags
+          in: query
+          description: >-
+            A tag is a category you create and apply to videos. You can search
+            for videos with particular tags by listing one or more here. Only
+            videos that have all the tags you list will be returned.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+          example: '"tags": ["captions", "dialogue"]'
+        - name: metadata
+          in: query
+          description: >-
+            Videos can be tagged with metadata tags in key:value pairs. You can
+            search for videos with specific key value pairs using this
+            parameter.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+          example: >-
+            [{"key":"Author", "value":"John Doe"}, {"key":"Format",
+            "value":"Tutorial"}]
+        - name: description
+          in: query
+          description: >-
+            If you described a video with a term or sentence, you can add it
+            here to return videos containing this string.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+          example: New Zealand
+        - name: liveStreamId
+          in: query
+          description: >-
+            If you know the ID for a live stream, you can retrieve the stream by
+            adding the ID for it here.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+          example: li400mYKSgQ6xs7taUeSaEKr
+        - name: sortBy
+          in: query
+          description: >-
+            Allowed: publishedAt, title. You can search by the time videos were
+            published at, or by title.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+          example: publishedAt
+        - name: sortOrder
+          in: query
+          description: >-
+            Allowed: asc, desc. asc is ascending and sorts from A to Z. desc is
+            descending and sorts from Z to A.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+          example: asc
+        - $ref: '#/components/parameters/currentPage'
+        - $ref: '#/components/parameters/pageSize'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/videos-list-response'
+              examples:
+                response:
+                  value:
+                    data:
+                      - videoId: vi4k0jvEUuaTdRAEjQ4Prklg
+                        playerId: pl45KFKdlddgk654dspkze
+                        title: Maths video
+                        description: An amazing video explaining the string theory
+                        public: false
+                        panoramic: false
+                        mp4Support: true
+                        tags:
+                          - maths
+                          - string theory
+                          - video
+                        metadata:
+                          - key: Author
+                            value: John Doe
+                          - key: Format
+                            value: Tutorial
+                        publishedAt: '2019-12-16T08:25:51+00:00'
+                        updateddAt: '2019-12-16T08:48:49+00:00'
+                        source:
+                          uri: /videos/c188ed58-3403-46a2-b91b-44603d10b2c9/source
+                        assets:
+                          iframe: >-
+                            <iframe
+                            src="//embed.api.video/c188ed58-3403-46a2-b91b-44603d10b2c9?token=831a9bd9-9f50-464c-a369-8e9d914371ae"
+                            width="100%" height="100%" frameborder="0"
+                            scrolling="no" allowfullscreen=""></iframe>
+                          player: >-
+                            https://embed.api.video/c188ed58-3403-46a2-b91b-44603d10b2c9?token=831a9bd9-9f50-464c-a369-8e9d914371ae
+                          hls: >-
+                            https://cdn.api.video/stream/831a9bd9-9f50-464c-a369-8e9d914371ae/hls/manifest.m3u8
+                          thumbnail: >-
+                            https://cdn.api.video/stream/831a9bd9-9f50-464c-a369-8e9d914371ae/thumbnail.jpg
+                          mp4: >-
+                            https://cdn.api.video/vod/vi4k0jvEUuaTdRAEjQ4Jfrgz/token/8fd70443-d9f0-45d2-b01c-12c8cfc707c9/mp4/720/source.mp4
+                      - videoId: vi4k0jvEUuaTdRAEjQ4Jfrgz
+                        title: Video Title
+                        description: A description for your video.
+                        public: false
+                        panoramic: false
+                        mp4Support: true
+                        tags:
+                          - books
+                          - short stories
+                        metadata:
+                          - key: Author
+                            value: John Doe
+                          - key: Science Fiction
+                            value: Cyberpunk
+                          - key: Technology
+                            value: Computers
+                        publishedAt: '2019-12-16T08:25:51+00:00'
+                        updateddAt: '2019-12-16T08:48:49+00:00'
+                        source:
+                          uri: /videos/1b9d6ae8-8f57-4b6d-8552-d636926b4f5f/source
+                        assets:
+                          iframe: >-
+                            <iframe
+                            src="//embed.api.video/1b9d6ae8-8f57-4b6d-8552-d636926b4f5f?token=831a9bd9-9f50-464c-a369-8e9d914371ae"
+                            width="100%" height="100%" frameborder="0"
+                            scrolling="no" allowfullscreen=""></iframe>
+                          player: >-
+                            https://embed.api.video/1b9d6ae8-8f57-4b6d-8552-d636926b4f5f?token=831a9bd9-9f50-464c-a369-8e9d914371ae
+                          hls: >-
+                            https://cdn.api.video/stream/831a9bd9-9f50-464c-a369-8e9d914371ae/hls/manifest.m3u8
+                          thumbnail: >-
+                            https://cdn.api.video/stream/831a9bd9-9f50-464c-a369-8e9d914371ae/thumbnail.jpg
+                      - videoId: vi4k0jvEUuaTdRAEjQ4Jfrgz
+                        playerId: pl45KFKdlddgk654dspkze
+                        title: My Video Title
+                        description: A brief description of the video.
+                        public: false
+                        panoramic: false
+                        mp4Support: true
+                        tags:
+                          - General
+                          - Videos
+                        metadata:
+                          - key: Length
+                            value: Short
+                        publishedAt: '2019-12-16T08:25:51+00:00'
+                        updateddAt: '2019-12-16T08:48:49+00:00'
+                        source:
+                          uri: /videos/73129412-e320-4b93-99f6-59a85e3cedcd/source
+                        assets:
+                          iframe: >-
+                            <iframe
+                            src="//embed.api.video/73129412-e320-4b93-99f6-59a85e3cedcd?token=831a9bd9-9f50-464c-a369-8e9d914371ae"
+                            width="100%" height="100%" frameborder="0"
+                            scrolling="no" allowfullscreen=""></iframe>
+                          player: >-
+                            https://embed.api.video/73129412-e320-4b93-99f6-59a85e3cedcd?token=831a9bd9-9f50-464c-a369-8e9d914371ae
+                          hls: >-
+                            https://cdn.api.video/stream/831a9bd9-9f50-464c-a369-8e9d914371ae/hls/manifest.m3u8
+                          thumbnail: >-
+                            https://cdn.api.video/stream/831a9bd9-9f50-464c-a369-8e9d914371ae/thumbnail.jpg
+                    pagination:
+                      currentPage: 1
+                      pageSize: 25
+                      pagesTotal: 1
+                      itemsTotal: 11
+                      currentPageItems: 11
+                      links:
+                        - rel: self
+                          uri: 'https://ws.api.video/videos?currentPage=1'
+                        - rel: first
+                          uri: 'https://ws.api.video/videos?currentPage=1'
+                        - rel: last
+                          uri: 'https://ws.api.video/videos?currentPage=1'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/bad-request'
+              examples:
+                response:
+                  value:
+                    title: This parameter is out of the allowed range of values.
+                    name: page
+                    status: 400
+                    range:
+                      min: 1
+                    problems:
+                      - title: This parameter is out of the allowed range of values.
+                        name: page
+                        range:
+                          min: 1
+                      - title: This parameter is out of the allowed range of values.
+                        name: pageSize
+                        range:
+                          min: 10
+                          max: 100
+      security:
+        - bearerAuth: []
+    post:
+      tags:
+        - Videos
+      summary: Create a video
+      description: >
+        To create a video, you create its metadata first, before adding the
+        video file (exception - when using an existing HTTP source).
+
+
+        Videos are public by default. Mp4 encoded versions are created at the
+        highest quality (max 1080p) by default.
+         ```shell
+        $ curl https://ws.api.video/videos \
+
+        -H 'Authorization: Bearer {access_token} \
+
+        -d '{"title":"My video", 
+             "description":"so many details",
+             "mp4Support":true
+        }'
+
+        ```
+
+
+        ### Creating a hosted video 
+
+
+        You can also create a video directly from one hosted on a third-party
+        server by giving its URI in `source` parameter:
+
+
+        ```shell
+
+        $ curl https://ws.api.video/videos \
+
+        -H 'Authorization: Bearer {access_token} \
+
+        -d '{"source":"http://uri/to/video.mp4", "title":"My video"}'
+
+        ```
+
+
+        In this case, the service will respond `202 Accepted` and download the
+        video asynchronously.
+
+         We have tutorials on:
+        * [Creating and uploading
+        videos](https://api.video/blog/tutorials/video-upload-tutorial)
+
+        * [Uploading large
+        videos](https://api.video/blog/tutorials/video-upload-tutorial-large-videos)
+
+        * [Using tags with
+        videos](https://api.video/blog/tutorials/video-tagging-best-practices)
+
+        * [Private
+        videos](https://api.video/blog/tutorials/tutorial-private-videos)
+      operationId: POST-video
+      x-client-action: create
+      requestBody:
+        description: video to create
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/video-create-payload'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/video'
+              examples:
+                response:
+                  value:
+                    videoId: vi4k0jvEUuaTdRAEjQ4Jfrgz
+                    title: Maths video
+                    description: An amazing video explaining the string theory
+                    public: false
+                    panoramic: false
+                    mp4Support: true
+                    playerId: pl4k0jvEUuaTdRAEjQ4Jfrgz
+                    tags:
+                      - maths
+                      - string theory
+                      - video
+                    metadata:
+                      - key: Author
+                        value: John Doe
+                      - key: Format
+                        value: Tutorial
+                    publishedAt: '4665-07-14T23:36:18.598Z'
+                    source:
+                      uri: /videos/vi4k0jvEUuaTdRAEjQ4Jfrgz/source
+                    assets:
+                      iframe: >-
+                        <iframe
+                        src="//embed.api.video/vi4k0jvEUuaTdRAEjQ4Jfrgz?token=831a9bd9-9f50-464c-a369-8e9d914371ae"
+                        width="100%" height="100%" frameborder="0"
+                        scrolling="no" allowfullscreen=""></iframe>
+                      player: >-
+                        https://embed.api.video/vi4k0jvEUuaTdRAEjQ4Jfrgz?token=831a9bd9-9f50-464c-a369-8e9d914371ae
+                      hls: >-
+                        https://cdn.api.video/stream/831a9bd9-9f50-464c-a369-8e9d914371ae/hls/manifest.m3u8
+                      thumbnail: >-
+                        https://cdn.api.video/stream/831a9bd9-9f50-464c-a369-8e9d914371ae/thumbnail.jpg
+                      mp4: >-
+                        https://cdn.api.video/vod/vi4k0jvEUuaTdRAEjQ4Jfrgz/token/8fd70443-d9f0-45d2-b01c-12c8cfc707c9/mp4/720/source.mp4
+        '202':
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/video'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/bad-request'
+              examples:
+                response:
+                  value:
+                    type: 'https://docs.api.video/docs/attributerequired'
+                    title: This attribute is required.
+                    name: title
+                    status: 400
+                    problems:
+                      - type: 'https://docs.api.video/docs/attributerequired'
+                        title: This attribute is required.
+                        name: title
+                      - type: 'https://docs.api.video/docs/attributeinvalid'
+                        title: This attribute must be a ISO8601 date.
+                        name: scheduledAt
+                      - type: 'https://docs.api.video/docs/attributeinvalid'
+                        title: This attribute must be an array.
+                        name: tags
+                      - type: 'https://docs.api.video/docs/attributeinvalid'
+                        title: This attribute must be an array.
+                        name: metadata
+      security:
+        - bearerAuth: []
+  '/videos/{videoId}/source':
+    post:
+      tags:
+        - Videos
+      summary: Upload a video
+      description: >-
+        To upload a video to the videoId you created. Replace {videoId} with the
+        id you'd like to use, {access_token} with your token, and
+        /path/to/video.mp4 with the path to the video you'd like to upload. You
+        can only upload your video to the videoId once.
+
+
+        ```bash
+
+        curl https://ws.api.video/videos/{videoId}/source \
+          -H 'Authorization: Bearer {access_token}' \
+          -F file=@/path/to/video.mp4
+          ```
+      operationId: POST_videos-videoId-source
+      x-client-action: upload
+      x-client-chunk-upload: true
+      parameters:
+        - name: videoId
+          in: path
+          description: Enter the videoId you want to use to upload your video.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: vi4k0jvEUuaTdRAEjQ4Jfrgz
+        - name: Content-Range
+          in: header
+          description: >-
+            Content-Range represents the range of bytes that will be returned as
+            a result of the request. Byte ranges are inclusive, meaning that
+            bytes 0-999 represents the first 1000 bytes in a file or object.
+          required: false
+          x-client-ignore: true
+          style: simple
+          explode: false
+          schema:
+            pattern: '^bytes [0-9]*-[0-9]*\/[0-9]*$'
+            type: string
+          example: 'Content-Range: bytes 200-100/5000'
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/video-upload-payload'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                $ref: '#/components/schemas/video'
+              examples:
+                response:
+                  value:
+                    videoId: vi4k0jvEUuaTdRAEjQ4Jfrgz
+                    title: Maths video
+                    description: An amazing video explaining the string theory.
+                    public: false
+                    panoramic: false
+                    mp4Support: true
+                    playerId: pl45KFKdlddgk654dspkze
+                    tags:
+                      - maths
+                      - string theory
+                      - video
+                    metadata:
+                      - key: Author
+                        value: John Doe
+                      - key: Format
+                        value: Tutorial
+                    publishedAt: '4665-07-14T23:36:18.598Z'
+                    source:
+                      uri: /videos/vi4k0jvEUuaTdRAEjQ4Jfrgz/source
+                    assets:
+                      iframe: >-
+                        <iframe
+                        src="//embed.api.video/vi4k0jvEUuaTdRAEjQ4Jfrgz?token=831a9bd9-9f50-464c-a369-8e9d914371ae"
+                        width="100%" height="100%" frameborder="0"
+                        scrolling="no" allowfullscreen=""></iframe>
+                      player: >-
+                        https://embed.api.video/vi4k0jvEUuaTdRAEjQ4Jfrgz?token=831a9bd9-9f50-464c-a369-8e9d914371ae
+                      hls: >-
+                        https://cdn.api.video/stream/831a9bd9-9f50-464c-a369-8e9d914371ae/hls/manifest.m3u8
+                      thumbnail: >-
+                        https://cdn.api.video/stream/831a9bd9-9f50-464c-a369-8e9d914371ae/thumbnail.jpg
+                      mp4: >-
+                        https://cdn.api.video/vod/vi4k0jvEUuaTdRAEjQ4Jfrgz/token/8fd70443-d9f0-45d2-b01c-12c8cfc707c9/mp4/720/source.mp4
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/bad-request'
+              examples:
+                response:
+                  value:
+                    type: 'https://docs.api.video/docs/filealreadyuploaded'
+                    title: The source of the video is already uploaded.
+                    name: file
+                    status: 400
+                    problems:
+                      - type: 'https://docs.api.video/docs/filealreadyuploaded'
+                        title: The source of the video is already uploaded.
+                        name: file
+                      - type: 'https://docs.api.video/docs/filealreadyuploaded'
+                        title: The video xxxx has already been uploaded.
+                        name: video
+                      - type: 'https://docs.api.video/docs/filemissing'
+                        title: There is no uploaded file in the request.
+                        name: file
+                      - type: 'https://docs.api.video/docs/multiplefilesuploaded'
+                        title: There is more than one uploaded file in the request.
+                        name: file
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/not-found'
+              examples:
+                response:
+                  value:
+                    type: 'https://docs.api.video/docs/resourcenot_found'
+                    title: The requested resource was not found.
+                    name: videoId
+                    status: 404
+      security:
+        - bearerAuth: []
+  '/videos/{videoId}/thumbnail':
+    post:
+      tags:
+        - Videos
+      summary: Upload a thumbnail
+      description: >-
+        In creating a thumbnail, you may either upload an image, or you can pick
+        a time in the video to be used as thumbnail. This endpoint is for
+        uploading an image. Use [Pick a
+        Thumbnail](https://docs.api.video/reference#patch_videos-videoid-thumbnail)
+        to pick a time in the video. There may be a short delay before the new
+        thumbnail is delivered to our CDN.
+      operationId: POST_videos-videoId-thumbnail
+      x-client-action: uploadThumbnail
+      parameters:
+        - name: videoId
+          in: path
+          description: 'Unique identifier of the chosen video '
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/video-thumbnail-upload-payload'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/video'
+              examples:
+                response:
+                  value:
+                    videoId: vi4k0jvEUuaTdRAEjQ4Jfrgz
+                    playerId: pl45KFKdlddgk654dspkze
+                    title: Maths video
+                    description: An amazing video explaining the string theory
+                    public: false
+                    panoramic: false
+                    mp4Support: true
+                    tags:
+                      - maths
+                      - string theory
+                      - video
+                    metadata:
+                      - key: Author
+                        value: John Doe
+                      - key: Format
+                        value: Tutorial
+                    scheduledAt: '2020-03-03T12:52:03.085Z'
+                    publishedAt: '2020-07-14T23:36:18.598Z'
+                    source:
+                      uri: /videos/vi4k0jvEUuaTdRAEjQ4Jfrgz/source
+                    assets:
+                      iframe: >-
+                        <iframe
+                        src="//embed.api.video/vi4k0jvEUuaTdRAEjQ4Jfrgz?token=831a9bd9-9f50-464c-a369-8e9d914371ae"
+                        width="100%" height="100%" frameborder="0"
+                        scrolling="no" allowfullscreen=""></iframe>
+                      player: >-
+                        https://embed.api.video/vi4k0jvEUuaTdRAEjQ4Jfrgz?token=831a9bd9-9f50-464c-a369-8e9d914371ae
+                      hls: >-
+                        https://cdn.api.video/stream/831a9bd9-9f50-464c-a369-8e9d914371ae/hls/manifest.m3u8
+                      thumbnail: >-
+                        https://cdn.api.video/stream/831a9bd9-9f50-464c-a369-8e9d914371ae/thumbnail.jpg
+                      mp4: >-
+                        https://cdn.api.video/vod/vi4k0jvEUuaTdRAEjQ4Jfrgz/token/8fd70443-d9f0-45d2-b01c-12c8cfc707c9/mp4/720/source.mp4
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/bad-request'
+              examples:
+                response:
+                  value:
+                    status: 400
+                    type: 'https://docs.api.video/docs/fileextension'
+                    title: 'Only [jpeg, jpg, JPG, JPEG] extensions are supported.'
+                    name: file
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/not-found'
+              examples:
+                response:
+                  value:
+                    type: 'https://docs.api.video/docs/resourcenot_found'
+                    title: The requested resource was not found.
+                    name: videoId
+                    status: 404
+      security:
+        - bearerAuth: []
+    patch:
+      tags:
+        - Videos
+      summary: Pick a thumbnail
+      description: >-
+        Pick a thumbnail from the given time code. If you'd like to upload an
+        image for your thumbnail, use the [Upload a
+        Thumbnail](https://docs.api.video/reference#post_videos-videoid-thumbnail)
+        endpoint. There may be a short delay for the thumbnail to update.
+      operationId: PATCH_videos-videoId-thumbnail
+      x-client-action: pickThumbnail
+      parameters:
+        - name: videoId
+          in: path
+          description: >-
+            Unique identifier of the video you want to add a thumbnail to, where
+            you use a section of your video as the thumbnail.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: vi4k0jvEUuaTdRAEjQ4Jfrgz
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/video-thumbnail-pick-payload'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/video'
+              examples:
+                response:
+                  value:
+                    videoId: vi4k0jvEUuaTdRAEjQ4Jfrgz
+                    playerId: pl45KFKdlddgk654dspkze
+                    title: Maths video
+                    description: An amazing video explaining string theory
+                    public: false
+                    panoramic: false
+                    mp4Support: true
+                    tags:
+                      - maths
+                      - string theory
+                      - video
+                    metadata:
+                      - key: Author
+                        value: John Doe
+                      - key: Format
+                        value: Tutorial
+                    publishedAt: '4665-07-14T23:36:18.598Z'
+                    source:
+                      uri: /videos/vi4k0jvEUuaTdRAEjQ4Jfrgz/source
+                    assets:
+                      iframe: >-
+                        <iframe
+                        src="//embed.api.video/vi4k0jvEUuaTdRAEjQ4Jfrgz?token=831a9bd9-9f50-464c-a369-8e9d914371ae"
+                        width="100%" height="100%" frameborder="0"
+                        scrolling="no" allowfullscreen=""></iframe>
+                      player: >-
+                        https://embed.api.video/vi4k0jvEUuaTdRAEjQ4Jfrgz?token=831a9bd9-9f50-464c-a369-8e9d914371ae
+                      hls: >-
+                        https://cdn.api.video/stream/831a9bd9-9f50-464c-a369-8e9d914371ae/hls/manifest.m3u8
+                      thumbnail: >-
+                        https://cdn.api.video/stream/831a9bd9-9f50-464c-a369-8e9d914371ae/thumbnail.jpg
+                      mp4: >-
+                        https://cdn.api.video/vod/vi4k0jvEUuaTdRAEjQ4Jfrgz/token/8fd70443-d9f0-45d2-b01c-12c8cfc707c9/mp4/720/source.mp4
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/not-found'
+              examples:
+                response:
+                  value:
+                    type: 'https://docs.api.video/docs/resourcenot_found'
+                    title: The requested resource was not found.
+                    name: videoId
+                    status: 404
+      security:
+        - bearerAuth: []
+  '/videos/{videoId}':
+    get:
+      tags:
+        - Videos
+      summary: Show a video
+      description: >-
+        This call provides the same JSON information provided on video creation.
+        For private videos, it will generate a unique token url. Use this to
+        retrieve any details you need about a video, or set up a private viewing
+        URL.
+      operationId: GET-video
+      x-client-action: get
+      parameters:
+        - name: videoId
+          in: path
+          description: The unique identifier for the video you want details about.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                $ref: '#/components/schemas/video'
+              examples:
+                response:
+                  value:
+                    videoId: vi4k0jvEUuaTdRAEjQ4Jfrgz
+                    playerId: pl45KFKdlddgk654dspkze
+                    title: Maths video
+                    description: An amazing video explaining string theory
+                    public: false
+                    panoramic: false
+                    mp4Support: true
+                    tags:
+                      - maths
+                      - string theory
+                      - video
+                    metadata:
+                      - key: Author
+                        value: John Doe
+                      - key: Format
+                        value: Tutorial
+                    publishedAt: '2019-12-16T08:25:51+00:00'
+                    updateddAt: '2019-12-16T08:48:49+00:00'
+                    source:
+                      uri: /videos/vi4k0jvEUuaTdRAEjQ4Jfrgz/source
+                    assets:
+                      iframe: >-
+                        <iframe
+                        src="//embed.api.video/vi4k0jvEUuaTdRAEjQ4Jfrgz?token=831a9bd9-9f50-464c-a369-8e9d914371ae"
+                        width="100%" height="100%" frameborder="0"
+                        scrolling="no" allowfullscreen=""></iframe>
+                      player: >-
+                        https://embed.api.video/vi4k0jvEUuaTdRAEjQ4Jfrgz?token=831a9bd9-9f50-464c-a369-8e9d914371ae
+                      hls: >-
+                        https://cdn.api.video/stream/831a9bd9-9f50-464c-a369-8e9d914371ae/hls/manifest.m3u8
+                      thumbnail: >-
+                        https://cdn.api.video/stream/831a9bd9-9f50-464c-a369-8e9d914371ae/thumbnail.jpg
+                      mp4: >-
+                        https://cdn.api.video/vod/vi4k0jvEUuaTdRAEjQ4Jfrgz/token/8fd70443-d9f0-45d2-b01c-12c8cfc707c9/mp4/720/source.mp4
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/not-found'
+              examples:
+                response:
+                  value:
+                    type: 'https://docs.api.video/docs/resourcenot_found'
+                    title: The requested resource was not found.
+                    name: videoId
+                    status: 404
+      security:
+        - bearerAuth: []
+    delete:
+      tags:
+        - Videos
+      summary: Delete a video
+      description: >-
+        If you do not need a video any longer, you can send a request to delete
+        it. All you need is the videoId.
+      operationId: DELETE-video
+      x-client-action: delete
+      parameters:
+        - name: videoId
+          in: path
+          description: The video ID for the video you want to delete.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: vi4k0jvEUuaTdRAEjQ4Jfrgz
+      responses:
+        '204':
+          description: No Content
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/not-found'
+              examples:
+                response:
+                  value:
+                    type: 'https://docs.api.video/docs/resourcenot_found'
+                    title: The requested resource was not found.
+                    name: videoId
+                    status: 404
+      security:
+        - bearerAuth: []
+    patch:
+      tags:
+        - Videos
+      summary: Update a video
+      description: >-
+        Use this endpoint to update the parameters associated with your video.
+        The video you are updating is determined by the video ID you provide in
+        the path. For each parameter you want to update, include the update in
+        the request body. NOTE: If you are updating an array, you must provide
+        the entire array as what you provide here overwrites what is in the
+        system rather than appending to it.
+      operationId: PATCH-video
+      x-client-action: update
+      parameters:
+        - name: videoId
+          in: path
+          description: The video ID for the video you want to delete.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: vi4k0jvEUuaTdRAEjQ4Jfrgz
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/video-update-payload'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/video'
+              examples:
+                response:
+                  value:
+                    videoId: vi4k0jvEUuaTdRAEjQ4Jfrgz
+                    playerId: pl45KFKdlddgk654dspkze
+                    title: Maths video
+                    description: An amazing video explaining the string theory
+                    public: false
+                    panoramic: false
+                    mp4Support: true
+                    tags:
+                      - maths
+                      - string theory
+                      - video
+                    metadata:
+                      - key: Author
+                        value: John Doe
+                      - key: Format
+                        value: Tutorial
+                    publishedAt: '2019-12-16T08:25:51+00:00'
+                    updatedAt: '2019-12-16T08:48:49+00:00'
+                    source:
+                      uri: /videos/vi4k0jvEUuaTdRAEjQ4Jfrgz/source
+                    assets:
+                      iframe: >-
+                        <iframe
+                        src="//embed.api.video/vi4k0jvEUuaTdRAEjQ4Jfrgz?token=831a9bd9-9f50-464c-a369-8e9d914371ae"
+                        width="100%" height="100%" frameborder="0"
+                        scrolling="no" allowfullscreen=""></iframe>
+                      player: >-
+                        https://embed.api.video/vi4k0jvEUuaTdRAEjQ4Jfrgz?token=831a9bd9-9f50-464c-a369-8e9d914371ae
+                      hls: >-
+                        https://cdn.api.video/stream/831a9bd9-9f50-464c-a369-8e9d914371ae/hls/manifest.m3u8
+                      thumbnail: >-
+                        https://cdn.api.video/stream/831a9bd9-9f50-464c-a369-8e9d914371ae/thumbnail.jpg
+                      mp4: >-
+                        https://cdn.api.video/vod/vi4k0jvEUuaTdRAEjQ4Jfrgz/token/8fd70443-d9f0-45d2-b01c-12c8cfc707c9/mp4/720/source.mp4
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/bad-request'
+              examples:
+                response:
+                  value:
+                    type: 'https://docs.api.video/docs/attributeinvalid'
+                    title: This attribute must be a ISO-8601 date.
+                    name: scheduledAt
+                    status: 400
+                    problems:
+                      - type: 'https://docs.api.video/docs/attributeinvalid'
+                        title: This attribute must be a ISO-8601 date.
+                        name: scheduledAt
+                      - type: 'https://docs.api.video/docs/attributeinvalid'
+                        title: This attribute must be an array.
+                        name: tags
+                      - type: 'https://docs.api.video/docs/attributeinvalid'
+                        title: This attribute must be an array.
+                        name: metadata
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/not-found'
+              examples:
+                response:
+                  value:
+                    type: 'https://docs.api.video/docs/resourcenot_found'
+                    title: The requested resource was not found.
+                    name: videoId
+                    status: 404
+      security:
+        - bearerAuth: []
+  '/videos/{videoId}/status':
+    get:
+      tags:
+        - Videos
+      summary: Show video status
+      description: >-
+        This API provides upload status & encoding status to determine when the
+        video is uploaded or ready to playback.
+
+
+        Once encoding is completed, the response also lists the available stream
+        qualities.
+      operationId: GET-video-status
+      x-client-action: getVideoStatus
+      parameters:
+        - name: videoId
+          in: path
+          description: The unique identifier for the video you want the status for.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: vi4k0jvEUuaTdRAEjQ4Jfrgz
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/videostatus'
+              examples:
+                response:
+                  value:
+                    ingest:
+                      status: uploaded
+                      filesize: 273579401
+                      receivedBytes:
+                        - to: 134217727
+                          from: 0
+                          total: 273579401
+                        - to: 268435455
+                          from: 134217728
+                          total: 273579401
+                        - to: 273579400
+                          from: 268435456
+                          total: 273579401
+                    encoding:
+                      playable: true
+                      qualities:
+                        - quality: 360p
+                          status: encoded
+                        - quality: 480p
+                          status: encoded
+                        - quality: 720p
+                          status: encoded
+                        - quality: 1080p
+                          status: encoding
+                        - quality: 2160p
+                          status: waiting
+                      metadata:
+                        width: 424
+                        height: 240
+                        bitrate: 411.218
+                        duration: 4176
+                        framerate: 24
+                        samplerate: 48000
+                        videoCodec: h264
+                        audioCodec: aac
+                        aspectRatio: 16/9
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/not-found'
+              examples:
+                response:
+                  value:
+                    type: 'https://docs.api.video/docs/resourcenot_found'
+                    title: The requested resource was not found.
+                    name: videoId
+                    status: 404
+      security:
+        - bearerAuth: []
+  /upload-tokens:
+    get:
+      tags:
+        - Videos - Delegated upload
+      summary: List all active upload tokens.
+      description: >-
+        A delegated token is used to allow secure uploads without exposing your
+        API key. Use this endpoint to retrieve a list of all currently active
+        delegated tokens.
+      operationId: GET_upload-tokens
+      x-group-parameters: true
+      x-client-paginated: true
+      x-client-action: listTokens
+      parameters:
+        - name: sortBy
+          in: query
+          description: >-
+            Allowed: createdAt, ttl. You can use these to sort by when a token
+            was created, or how much longer the token will be active (ttl - time
+            to live). Date and time is presented in ISO-8601 format.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+            enum:
+              - createdAt
+              - ttl
+          example: ttl
+        - name: sortOrder
+          in: query
+          description: >-
+            Allowed: asc, desc. Ascending is 0-9 or A-Z. Descending is 9-0 or
+            Z-A.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+            enum:
+              - asc
+              - desc
+          example: asc
+        - $ref: '#/components/parameters/currentPage'
+        - $ref: '#/components/parameters/pageSize'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/token-list-response'
+              examples:
+                response:
+                  value:
+                    data:
+                      - token: to37YfoPDRR2pcDKa6LsUE0M
+                        ttl: 3600
+                        createdAt: '2020-12-02T10:26:46+00:00'
+                        expiresAt: '2020-12-02T11:26:46+00:00'
+                      - token: to1W3ZS9PdUBZWzzTEZr1B79
+                        ttl: 0
+                        createdAt: '2020-12-02T10:26:28+00:00'
+                        expiresAt: null
+                    pagination:
+                      currentPage: 1
+                      currentPageItems: 2
+                      pageSize: 25
+                      pagesTotal: 1
+                      itemsTotal: 2
+                      links:
+                        - rel: self
+                          uri: /upload-tokens?currentPage=1&pageSize=25
+                        - rel: first
+                          uri: /upload-tokens?currentPage=1&pageSize=25
+                        - rel: last
+                          uri: /upload-tokens?currentPage=1&pageSize=25
+      security:
+        - bearerAuth: []
+    post:
+      tags:
+        - Videos - Delegated upload
+      summary: Generate an upload token
+      description: >-
+        Use this endpoint to generate an upload token. You can use this token to
+        authenticate video uploads while keeping your API key safe.
+      operationId: POST_upload-tokens
+      x-client-action: createToken
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/token-create-payload'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/upload-token'
+              examples:
+                response:
+                  value:
+                    token: to1tcmSFHeYY5KzyhOqVKMKb
+                    ttl: 3600
+                    createdAt: '2020-12-02T10:13:19+00:00'
+                    expiresAt: '2020-12-02T11:13:19+00:00'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/bad-request'
+      security:
+        - bearerAuth: []
+  '/upload-tokens/{uploadToken}':
+    get:
+      tags:
+        - Videos - Delegated upload
+      summary: Show upload token
+      description: >-
+        You can retrieve details about a specific upload token if you have the
+        unique identifier for the upload token. Add it in the path of the
+        endpoint. Details include time-to-live (ttl), when the token was
+        created, and when it will expire.
+      operationId: GET_upload-tokens-uploadToken
+      x-client-action: getToken
+      parameters:
+        - name: uploadToken
+          in: path
+          description: The unique identifier for the token you want information about.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: to1tcmSFHeYY5KzyhOqVKMKb
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/upload-token'
+              examples:
+                response:
+                  value:
+                    token: to1tcmSFHeYY5KzyhOqVKMKb
+                    ttl: 0
+                    createdAt: '2020-12-02T10:13:19+00:00'
+                    expiresAt: null
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/not-found'
+      security:
+        - bearerAuth: []
+    delete:
+      tags:
+        - Videos - Delegated upload
+      summary: Delete an upload token
+      description: >-
+        Delete an existing upload token. This is especially useful for tokens
+        you may have created that do not expire.
+      operationId: DELETE_upload-tokens-uploadToken
+      x-client-action: deleteToken
+      parameters:
+        - name: uploadToken
+          in: path
+          description: >-
+            The unique identifier for the upload token you want to delete.
+            Deleting a token will make it so the token can no longer be used for
+            authentication.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: to1tcmSFHeYY5KzyhOqVKMKb
+      responses:
+        '204':
+          description: No Content
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/not-found'
+      security:
+        - bearerAuth: []
+  /upload:
+    post:
+      tags:
+        - Videos - Delegated upload
+      summary: Upload with an upload token
+      description: "When given a token, anyone can upload a file to the URI `https://ws.api.video/upload?token=<tokenId>`.\n\nExample with cURL:\n\n```curl\n$ curl  --request POST --url 'https://ws.api.video/upload?token=toXXX'\n --header 'content-type: multipart/form-data'\n -F file=@video.mp4\n```\n\nOr in an HTML form, with a little JavaScript to convert the form into JSON:\n```html\n<!--form for user interaction-->\n<form name=\"videoUploadForm\" >\n  <label for=video>Video:</label>\n  <input type=file name=source/><br/>\n  <input value=\"Submit\" type=\"submit\">\n</form>\n<div></div>\n<!--JS takes the form data \n    uses FormData to turn the response into JSON.\n    then uses POST to upload the video file.\n    Update the token parameter in the url to your upload token.\n    -->\n<script>\n   var form = document.forms.namedItem(\"videoUploadForm\");\t\n   form.addEventListener('submit', function(ev) {\n\t ev.preventDefault();\n     var oOutput = document.querySelector(\"div\"),\n         oData = new FormData(form);\n     var oReq = new XMLHttpRequest();\n\t \n     oReq.open(\"POST\", \"https://ws.api.video/upload?token=toXXX\", true);\n     oReq.send(oData);\n\t oReq.onload = function(oEvent) {\n       if (oReq.status ==201) {\n         oOutput.innerHTML = \"Your video is uploaded!<br/>\"  + oReq.response;\n       } else {\n         oOutput.innerHTML = \"Error \" + oReq.status + \" occurred when trying to upload your file.<br \\/>\";\n       }\n     };\n   }, false);\t\n</script>\n```\n\n\n### Dealing with large files\n\nWe have created a <a href='https://api.video/blog/tutorials/uploading-large-files-with-javascript'>tutorial</a> to walk through the steps required."
+      operationId: POST_upload
+      x-client-action: upload
+      x-client-chunk-upload: true
+      parameters:
+        - name: token
+          in: query
+          description: >-
+            The unique identifier for the token you want to use to upload a
+            video.
+          required: true
+          style: form
+          explode: true
+          schema:
+            type: string
+          example: to1tcmSFHeYY5KzyhOqVKMKb
+        - name: Content-Range
+          in: header
+          description: >-
+            Content-Range represents the range of bytes that will be returned as
+            a result of the request. Byte ranges are inclusive, meaning that
+            bytes 0-999 represents the first 1000 bytes in a file or object.
+          required: false
+          x-client-ignore: true
+          style: simple
+          explode: false
+          schema:
+            pattern: '^bytes [0-9]*-[0-9]*\/[0-9]*$'
+            type: string
+          example: 'Content-Range: bytes 200-100/5000'
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/token-upload-payload'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/video'
+              examples:
+                response:
+                  value:
+                    videoId: vi4k0jvEUuaTdRAEjQ4Jfrgz
+                    playerId: pl45KFKdlddgk654dspkze
+                    title: Maths video
+                    description: An amazing video explaining the string theory
+                    public: false
+                    panoramic: false
+                    tags:
+                      - maths
+                      - string theory
+                      - video
+                    metadata:
+                      - key: Author
+                        value: John Doe
+                      - key: Format
+                        value: Tutorial
+                    publishedAt: '4665-07-14T23:36:18.598Z'
+                    source:
+                      uri: /videos/vi4k0jvEUuaTdRAEjQ4Jfrgz/source
+                    assets:
+                      iframe: >-
+                        <iframe
+                        src="//embed.api.video/vi4k0jvEUuaTdRAEjQ4Jfrgz?token=831a9bd9-9f50-464c-a369-8e9d914371ae"
+                        width="100%" height="100%" frameborder="0"
+                        scrolling="no" allowfullscreen=""></iframe>
+                      player: >-
+                        https://embed.api.video/vi4k0jvEUuaTdRAEjQ4Jfrgz?token=831a9bd9-9f50-464c-a369-8e9d914371ae
+                      hls: >-
+                        https://cdn.api.video/stream/831a9bd9-9f50-464c-a369-8e9d914371ae/hls/manifest.m3u8
+                      thumbnail: >-
+                        https://cdn.api.video/stream/831a9bd9-9f50-464c-a369-8e9d914371ae/thumbnail.jpg
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/bad-request'
+      security: []
+  /live-streams:
+    get:
+      tags:
+        - Live
+      summary: List all live streams
+      description: >-
+        With no parameters added to the url, this will return all livestreams.
+        Query by name or key to limit the list.
+      operationId: GET_live-streams
+      x-client-action: list
+      x-group-parameters: true
+      x-client-paginated: true
+      parameters:
+        - name: streamKey
+          in: query
+          description: The unique stream key that allows you to stream videos.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+          example: 30087931-229e-42cf-b5f9-e91bcc1f7332
+        - name: name
+          in: query
+          description: You can filter live streams by their name or a part of their name.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+          example: My Video
+        - name: sortBy
+          in: query
+          description: >-
+            Allowed: createdAt, publishedAt, name. createdAt - the time a
+            livestream was created using the specified streamKey. publishedAt -
+            the time a livestream was published using the specified streamKey.
+            name - the name of the livestream. If you choose one of the time
+            based options, the time is presented in ISO-8601 format.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+          example: createdAt
+        - name: sortOrder
+          in: query
+          description: >-
+            Allowed: asc, desc. Ascending for date and time means that earlier
+            values precede later ones. Descending means that later values preced
+            earlier ones. For title, it is 0-9 and A-Z ascending and Z-A, 9-0
+            descending.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+            enum:
+              - asc
+              - desc
+          example: desc
+        - $ref: '#/components/parameters/currentPage'
+        - $ref: '#/components/parameters/pageSize'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/live-stream-list-response'
+              examples:
+                response:
+                  value:
+                    data:
+                      - liveStreamId: li400mYKSgQ6xs7taUeSaEKr
+                        createdAt: '2020-01-31T10:17:47+00:00'
+                        updatedAt: '2020-03-09T13:19:43+00:00'
+                        streamKey: 30087931-229e-42cf-b5f9-e91bcc1f7332
+                        name: Live Stream From the browser
+                        public: true
+                        record: true
+                        broadcasting: false
+                        assets:
+                          iframe: >-
+                            <iframe
+                            src="https://embed.api.video/live/li400mYKSgQ6xs7taUeSaEKr"
+                            width="100%" height="100%" frameborder="0"
+                            scrolling="no" allowfullscreen=""></iframe>
+                          player: >-
+                            https://embed.api.video/live/li400mYKSgQ6xs7taUeSaEKr
+                          hls: 'https://live.api.video/li400mYKSgQ6xs7taUeSaEKr.m3u8'
+                          thumbnail: >-
+                            https://cdn.api.video/live/li400mYKSgQ6xs7taUeSaEKr/thumbnail.jpg
+                      - liveStreamId: li4pqNqGUkhKfWcBGpZVLRY5
+                        createdAt: '2020-07-29T10:45:35+00:00'
+                        updatedAt: '2020-07-29T10:45:35+00:00'
+                        streamKey: cc1b4df0-d1c5-4064-a8f9-9f0368385135
+                        name: Live From New York
+                        public: true
+                        record: true
+                        broadcasting: false
+                        assets:
+                          iframe: >-
+                            <iframe
+                            src="https://embed.api.video/live/li4pqNqGUkhKfWcBGpZVLRY5"
+                            width="100%" height="100%" frameborder="0"
+                            scrolling="no" allowfullscreen=""></iframe>
+                          player: >-
+                            https://embed.api.video/live/li4pqNqGUkhKfWcBGpZVLRY5
+                          hls: 'https://live.api.video/li4pqNqGUkhKfWcBGpZVLRY5.m3u8'
+                          thumbnail: >-
+                            https://cdn.api.video/live/li4pqNqGUkhKfWcBGpZVLRY5/thumbnail.jpg
+                    pagination:
+                      currentPage: 1
+                      currentPageItems: 19
+                      pageSize: 25
+                      pagesTotal: 1
+                      itemsTotal: 19
+                      links:
+                        - rel: self
+                          uri: /live-streams?currentPage=1&pageSize=25
+                        - rel: first
+                          uri: /live-streams?currentPage=1&pageSize=25
+                        - rel: last
+                          uri: /live-streams?currentPage=1&pageSize=25
+      security:
+        - bearerAuth: []
+    post:
+      tags:
+        - Live
+      summary: Create live stream
+      description: >-
+        A live stream will give you the 'connection point' to RTMP your video
+        stream to api.video. It will also give you the details for viewers to
+        watch the same livestream. 
+
+        The public=false 'private livestream' is available as a BETA feature,
+        and should be limited to livestreams of 3,000 viewers or fewer.
+
+
+        See our [Live Stream
+        Tutorial](https://api.video/blog/tutorials/live-stream-tutorial) for a
+        walkthrough of this API with OBS.
+
+        Your RTMP endpoint for the livestream is
+        rtmp://broadcast.api.video/s/{streamKey}
+      operationId: POST_live-streams
+      x-client-action: create
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/live-stream-create-payload'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/live-stream'
+              examples:
+                response:
+                  value:
+                    liveStreamId: li4pqNqGUkhKfWcBGpZVLRY5
+                    createdAt: '2020-07-29T10:45:35+00:00'
+                    updatedAt: '2020-07-29T10:45:35+00:00'
+                    streamKey: cc1b4df0-d1c5-4064-a8f9-9f0368385135
+                    name: Live From New York
+                    public: true
+                    record: true
+                    broadcasting: false
+                    assets:
+                      iframe: >-
+                        <iframe
+                        src="https://embed.api.video/live/li4pqNqGUkhKfWcBGpZVLRY5"
+                        width="100%" height="100%" frameborder="0"
+                        scrolling="no" allowfullscreen=""></iframe>
+                      player: 'https://embed.api.video/live/li4pqNqGUkhKfWcBGpZVLRY5'
+                      hls: 'https://live.api.video/li4pqNqGUkhKfWcBGpZVLRY5.m3u8'
+                      thumbnail: >-
+                        https://cdn.api.video/live/li4pqNqGUkhKfWcBGpZVLRY5/thumbnail.jpg
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/bad-request'
+      security:
+        - bearerAuth: []
+  '/live-streams/{liveStreamId}':
+    get:
+      tags:
+        - Live
+      summary: Show live stream
+      description: >-
+        Supply a LivestreamId, and you'll get all the details for streaming
+        into, and watching the livestream.
+      operationId: GET_live-streams-liveStreamId
+      x-client-action: get
+      parameters:
+        - name: liveStreamId
+          in: path
+          description: The unique ID for the live stream you want to watch.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: li400mYKSgQ6xs7taUeSaEKr
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/live-stream'
+              examples:
+                response:
+                  value:
+                    liveStreamId: li400mYKSgQ6xs7taUeSaEKr
+                    createdAt: '2020-01-31T10:17:47+00:00'
+                    updatedAt: '2020-03-09T13:19:43+00:00'
+                    streamKey: 30087931-229e-42cf-b5f9-e91bcc1f7332
+                    name: Live Stream From the browser
+                    public: true
+                    record: true
+                    broadcasting: false
+                    assets:
+                      iframe: >-
+                        <iframe
+                        src="https://embed.api.video/live/li400mYKSgQ6xs7taUeSaEKr"
+                        width="100%" height="100%" frameborder="0"
+                        scrolling="no" allowfullscreen=""></iframe>
+                      player: 'https://embed.api.video/live/li400mYKSgQ6xs7taUeSaEKr'
+                      hls: 'https://live.api.video/li400mYKSgQ6xs7taUeSaEKr.m3u8'
+                      thumbnail: >-
+                        https://cdn.api.video/live/li400mYKSgQ6xs7taUeSaEKr/thumbnail.jpg
+      security:
+        - bearerAuth: []
+    delete:
+      tags:
+        - Live
+      summary: Delete a live stream
+      operationId: DELETE_live-streams-liveStreamId
+      x-client-action: delete
+      parameters:
+        - name: liveStreamId
+          in: path
+          description: The unique ID for the live stream that you want to remove.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: li400mYKSgQ6xs7taUeSaEKr
+      responses:
+        '204':
+          description: No Content
+      security:
+        - bearerAuth: []
+    patch:
+      tags:
+        - Live
+      summary: Update a live stream
+      description: >-
+        Use this endpoint to update the player, or to turn recording on/off
+        (saving a copy of the livestream). NOTE: If the livestream is actively
+        streaming, changing the recording status will only affect the NEXT
+        stream.    The public=false 'private livestream' is available as a BETA
+        feature, and should be limited to livestreams of 3,000 viewers or fewer.
+      operationId: PATCH_live-streams-liveStreamId
+      x-client-action: update
+      parameters:
+        - name: liveStreamId
+          in: path
+          description: >-
+            The unique ID for the live stream that you want to update
+            information for such as player details, or whether you want the
+            recording on or off.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: li400mYKSgQ6xs7taUeSaEKr
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/live-stream-update-payload'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/live-stream'
+              examples:
+                response:
+                  value:
+                    liveStreamId: li400mYKSgQ6xs7taUeSaEKr
+                    createdAt: '2020-01-31T10:17:47+00:00'
+                    updatedAt: '2020-03-09T13:19:43+00:00'
+                    streamKey: 30087931-229e-42cf-b5f9-e91bcc1f7332
+                    name: Live Stream From the browser
+                    public: true
+                    record: true
+                    broadcasting: false
+                    assets:
+                      iframe: >-
+                        <iframe
+                        src="https://embed.api.video/live/li400mYKSgQ6xs7taUeSaEKr"
+                        width="100%" height="100%" frameborder="0"
+                        scrolling="no" allowfullscreen=""></iframe>
+                      player: 'https://embed.api.video/live/li400mYKSgQ6xs7taUeSaEKr'
+                      hls: 'https://live.api.video/li400mYKSgQ6xs7taUeSaEKr.m3u8'
+                      thumbnail: >-
+                        https://cdn.api.video/live/li400mYKSgQ6xs7taUeSaEKr/thumbnail.jpg
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/bad-request'
+      security:
+        - bearerAuth: []
+  '/live-streams/{liveStreamId}/thumbnail':
+    post:
+      tags:
+        - Live
+      summary: Upload a thumbnail
+      description: Upload an image to use as a backdrop for your livestream.
+      operationId: POST_live-streams-liveStreamId-thumbnail
+      x-client-action: uploadThumbnail
+      parameters:
+        - name: liveStreamId
+          in: path
+          description: The unique ID for the live stream you want to upload.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: vi4k0jvEUuaTdRAEjQ4Jfrgz
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/live-stream-thumbnail-upload-payload'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/live-stream'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/bad-request'
+              examples:
+                response:
+                  value:
+                    status: 400
+                    type: 'https://docs.api.video/docs/fileextension'
+                    title: 'Only [jpeg, jpg, JPG, JPEG] extensions are supported.'
+                    name: file
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/not-found'
+              examples:
+                response:
+                  value:
+                    type: 'https://docs.api.video/docs/resourcenot_found'
+                    title: The requested resource was not found.
+                    name: liveStreamId
+                    status: 404
+      security:
+        - bearerAuth: []
+    delete:
+      tags:
+        - Live
+      summary: Delete a thumbnail
+      description: >-
+        Send the unique identifier for a live stream to delete it from the
+        system.
+      operationId: DELETE_live-streams-liveStreamId-thumbnail
+      x-client-action: deleteThumbnail
+      parameters:
+        - name: liveStreamId
+          in: path
+          description: 'The unique identifier for the live stream you want to delete. '
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: li400mYKSgQ6xs7taUeSaEKr
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/live-stream'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/not-found'
+              examples:
+                response:
+                  value:
+                    type: 'https://docs.api.video/docs/resourcenot_found'
+                    title: The requested resource was not found.
+                    name: liveStreamId
+                    status: 404
+      security:
+        - bearerAuth: []
+  '/videos/{videoId}/captions/{language}':
+    get:
+      tags:
+        - Captions
+      summary: Show a caption
+      description: >-
+        Display a caption for a video in a specific language. If the language is
+        available, the caption is returned. Otherwise, you will get a response
+        indicating the caption was not found.
+      operationId: GET_videos-videoId-captions-language
+      x-client-action: get
+      parameters:
+        - name: videoId
+          in: path
+          description: The unique identifier for the video you want captions for.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: vi4k0jvEUuaTdRAEjQ4Prklg
+        - name: language
+          in: path
+          description: >-
+            A valid [BCP
+            47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers)
+            language representation
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: en
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/subtitle'
+              examples:
+                response:
+                  value:
+                    uri: /videos/vi3N6cDinStg3oBbN79GklWS/captions/en
+                    src: >-
+                      https://cdn.api.video/vod/vi3N6cDinStg3oBbN79GklWS/captions/en.vtt
+                    srclang: en
+                    default: false
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/not-found'
+      security:
+        - bearerAuth: []
+    post:
+      tags:
+        - Captions
+      summary: Upload a caption
+      description: |-
+        Upload a VTT file to add captions to your video.
+         Read our [captioning tutorial](https://api.video/blog/tutorials/adding-captions) for more details.
+      operationId: POST_videos-videoId-captions-language
+      x-client-action: upload
+      parameters:
+        - name: videoId
+          in: path
+          description: The unique identifier for the video you want to add a caption to.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: vi4k0jvEUuaTdRAEjQ4Prklg
+        - name: language
+          in: path
+          description: A valid BCP 47 language representation.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: en
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/captions-upload-payload'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/subtitle'
+              examples:
+                response:
+                  value:
+                    uri: /videos/vi3N6cDinStg3oBbN79GklWS/captions/en
+                    src: >-
+                      https://cdn.api.video/vod/vi3N6cDinStg3oBbN79GklWS/captions/en.vtt
+                    srclang: en
+                    default: false
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/bad-request'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/not-found'
+      security:
+        - bearerAuth: []
+    delete:
+      tags:
+        - Captions
+      summary: Delete a caption
+      description: >-
+        Delete a caption in a specific language by providing the video ID for
+        the video you want to delete the caption from and the language the
+        caption is in.
+      operationId: DELETE_videos-videoId-captions-language
+      x-client-action: delete
+      parameters:
+        - name: videoId
+          in: path
+          description: >-
+            The unique identifier for the video you want to delete a caption
+            from.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: vi4k0jvEUuaTdRAEjQ4Prklgc
+        - name: language
+          in: path
+          description: >-
+            A valid [BCP
+            47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers)
+            language representation.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: en
+      responses:
+        '204':
+          description: No Content
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/not-found'
+      security:
+        - bearerAuth: []
+    patch:
+      tags:
+        - Captions
+      summary: Update caption
+      description: >-
+        To have the captions on automatically, use this PATCH to set default:
+        true.
+      operationId: PATCH_videos-videoId-captions-language
+      x-client-action: update
+      parameters:
+        - name: videoId
+          in: path
+          description: >-
+            The unique identifier for the video you want to have automatic
+            captions for. 
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: vi4k0jvEUuaTdRAEjQ4Prklg
+        - name: language
+          in: path
+          description: >-
+            A valid [BCP
+            47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers)
+            language representation.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: en
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/captions-update-payload'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/subtitle'
+              examples:
+                response:
+                  value:
+                    uri: /videos/vi3N6cDinStg3oBbN79GklWS/captions/en
+                    src: >-
+                      https://cdn.api.video/vod/vi3N6cDinStg3oBbN79GklWS/captions/en.vtt
+                    srclang: en
+                    default: true
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/bad-request'
+              examples:
+                response:
+                  value:
+                    type: string (required)
+                    title: string (required)
+                    name: string (required)
+                    status: integer (required)
+                    problems:
+                      - null
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/not-found'
+              examples:
+                response:
+                  value:
+                    type: Lorem sit culpa non
+                    title: sunt do fugiat tempor
+                    name: irure mollit aute
+                    status: 85925135
+      security:
+        - bearerAuth: []
+  '/videos/{videoId}/captions':
+    get:
+      tags:
+        - Captions
+      summary: List video captions
+      description: Retrieve a list of available captions for the videoId you provide.
+      operationId: GET_videos-videoId-captions
+      x-client-action: list
+      x-group-parameters: true
+      x-client-paginated: true
+      parameters:
+        - name: videoId
+          in: path
+          description: >-
+            The unique identifier for the video you want to retrieve a list of
+            captions for.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: vi4k0jvEUuaTdRAEjQ4Prklg
+        - $ref: '#/components/parameters/currentPage'
+        - $ref: '#/components/parameters/pageSize'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/captions-list-response'
+              examples:
+                response:
+                  value:
+                    data:
+                      - uri: /videos/vi3N6cDinStg3oBbN79GklWS/captions/en
+                        src: >-
+                          https://cdn.api.video/vod/vi3N6cDinStg3oBbN79GklWS/captions/en.vtt
+                        srclang: en
+                        default: false
+                      - uri: /videos/vi3N6cDinStg3oBbN79GklWS/captions/fr
+                        src: >-
+                          https://cdn.api.video/vod/vi3N6cDinStg3oBbN79GklWS/captions/fr.vtt
+                        srclang: fr
+                        default: false
+                    pagination:
+                      currentPage: 1
+                      currentPageItems: 2
+                      pageSize: 25
+                      pagesTotal: 1
+                      itemsTotal: 2
+                      links:
+                        - rel: self
+                          uri: >-
+                            /videos/vi3N6cDinStg3oBbN79GklWS/captions?currentPage=1&pageSize=25
+                        - rel: first
+                          uri: >-
+                            /videos/vi3N6cDinStg3oBbN79GklWS/captions?currentPage=1&pageSize=25
+                        - rel: last
+                          uri: >-
+                            /videos/vi3N6cDinStg3oBbN79GklWS/captions?currentPage=1&pageSize=25
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/not-found'
+      security:
+        - bearerAuth: []
+  '/videos/{videoId}/chapters/{language}':
+    get:
+      tags:
+        - Chapters
+      summary: Show a chapter
+      operationId: GET_videos-videoId-chapters-language
+      x-client-action: get
+      parameters:
+        - name: videoId
+          in: path
+          description: The unique identifier for the video you want to show a chapter for.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: vi4k0jvEUuaTdRAEjQ4Jfrgz
+        - name: language
+          in: path
+          description: >-
+            A valid [BCP
+            47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers)
+            language representation.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: en
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/chapter'
+              examples:
+                response:
+                  value:
+                    uri: /videos/vi3N6cDinStg3oBbN79GklWS/chapters/fr
+                    src: >-
+                      https://cdn.api.video/vod/vi3N6cDinStg3oBbN79GklWS/chapters/fr.vtt
+                    language: fr
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/not-found'
+      security:
+        - bearerAuth: []
+    post:
+      tags:
+        - Chapters
+      summary: Upload a chapter
+      description: >-
+        Chapters help break the video into sections. Read our
+        [tutorial](https://api.video/blog/tutorials/adding-chapters-to-your-videos)
+        for more details.
+      operationId: POST_videos-videoId-chapters-language
+      x-client-action: upload
+      parameters:
+        - name: videoId
+          in: path
+          description: >-
+            The unique identifier for the video you want to upload a chapter
+            for.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: vi4k0jvEUuaTdRAEjQ4Jfrgz
+        - name: language
+          in: path
+          description: >-
+            A valid [BCP
+            47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers)
+            language representation.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: en
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/chapters-update-payload'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/chapter'
+              examples:
+                response:
+                  value:
+                    uri: /videos/vi3N6cDinStg3oBbN79GklWS/chapters/fr
+                    src: >-
+                      https://cdn.api.video/vod/vi3N6cDinStg3oBbN79GklWS/chapters/fr.vtt
+                    language: fr
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/bad-request'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/not-found'
+      security:
+        - bearerAuth: []
+    delete:
+      tags:
+        - Chapters
+      summary: Delete a chapter
+      operationId: DELETE_videos-videoId-chapters-language
+      x-client-action: delete
+      parameters:
+        - name: videoId
+          in: path
+          description: >-
+            The unique identifier for the video you want to delete a chapter
+            from. 
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: vi4k0jvEUuaTdRAEjQ4Jfrgz
+        - name: language
+          in: path
+          description: >-
+            A valid [BCP
+            47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers)
+            language representation.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: en
+      responses:
+        '204':
+          description: No Content
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/not-found'
+      security:
+        - bearerAuth: []
+  '/videos/{videoId}/chapters':
+    get:
+      tags:
+        - Chapters
+      summary: List video chapters
+      description: Retrieve a list of all chapters for a specified video.
+      operationId: GET_videos-videoId-chapters
+      x-client-action: list
+      x-group-parameters: true
+      x-client-paginated: true
+      parameters:
+        - name: videoId
+          in: path
+          description: >-
+            The unique identifier for the video you want to retrieve a list of
+            chapters for.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: vi4k0jvEUuaTdRAEjQ4Jfrgz
+        - $ref: '#/components/parameters/currentPage'
+        - $ref: '#/components/parameters/pageSize'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/chapters-list-response'
+              examples:
+                response:
+                  value:
+                    data:
+                      - uri: /videos/vi3N6cDinStg3oBbN79GklWS/chapters/fr
+                        src: >-
+                          https://cdn.api.video/vod/vi3N6cDinStg3oBbN79GklWS/chapters/fr.vtt
+                        language: fr
+                      - uri: /videos/vi3N6cDinStg3oBbN79GklWS/chapters/en
+                        src: >-
+                          https://cdn.api.video/vod/vi3N6cDinStg3oBbN79GklWS/chapters/en.vtt
+                        language: en
+                    pagination:
+                      currentPage: 1
+                      currentPageItems: 2
+                      pageSize: 25
+                      pagesTotal: 1
+                      itemsTotal: 2
+                      links:
+                        - rel: self
+                          uri: >-
+                            /videos/vi3N6cDinStg3oBbN79GklWS/chapters?currentPage=1&pageSize=25
+                        - rel: first
+                          uri: >-
+                            /videos/vi3N6cDinStg3oBbN79GklWS/chapters?currentPage=1&pageSize=25
+                        - rel: last
+                          uri: >-
+                            /videos/vi3N6cDinStg3oBbN79GklWS/chapters?currentPage=1&pageSize=25
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/not-found'
+      security:
+        - bearerAuth: []
+  /players:
+    get:
+      tags:
+        - Players
+      summary: List all players
+      description: >-
+        Retrieve a list of all the players you created, as well as details about
+        each one.
+      operationId: GET_players
+      x-client-action: list
+      x-group-parameters: true
+      x-client-paginated: true
+      parameters:
+        - name: sortBy
+          in: query
+          description: >-
+            createdAt is the time the player was created. updatedAt is the time
+            the player was last updated. The time is presented in ISO-8601
+            format.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+            enum:
+              - createdAt
+              - updatedAt
+          example: createdAt
+        - name: sortOrder
+          in: query
+          description: >-
+            Allowed: asc, desc. Ascending for date and time means that earlier
+            values precede later ones. Descending means that later values preced
+            earlier ones.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+            enum:
+              - asc
+              - desc
+          example: asc
+        - $ref: '#/components/parameters/currentPage'
+        - $ref: '#/components/parameters/pageSize'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/players-list-response'
+              examples:
+                response:
+                  value:
+                    data:
+                      - playerId: pl4fgtjy4tjyKDK545DRdfg
+                        createdAt: '2020-01-13T10:09:17+00:00'
+                        updatedAt: '2020-01-13T10:09:17+00:00'
+                        shapeMargin: 10
+                        shapeRadius: 3
+                        shapeAspect: flat
+                        shapeBackgroundTop: 'rgba(50, 50, 50, .7)'
+                        shapeBackgroundBottom: 'rgba(50, 50, 50, .8)'
+                        text: 'rgba(255, 255, 255, .95)'
+                        link: 'rgba(255, 0, 0, .95)'
+                        linkHover: 'rgba(255, 255, 255, .75)'
+                        linkActive: 'rgba(255, 0, 0, .75)'
+                        trackPlayed: 'rgba(255, 255, 255, .95)'
+                        trackUnplayed: 'rgba(255, 255, 255, .1)'
+                        trackBackground: 'rgba(0, 0, 0, 0)'
+                        backgroundTop: 'rgba(72, 4, 45, 1)'
+                        backgroundBottom: 'rgba(94, 95, 89, 1)'
+                        backgroundText: 'rgba(255, 255, 255, .95)'
+                        enableApi: false
+                        enableControls: false
+                        forceAutoplay: false
+                        hideTitle: false
+                        forceLoop: false
+                      - playerId: pl54fgtjy4tjyKDK45DRdfg
+                        createdAt: '2020-01-13T10:09:17+00:00'
+                        updatedAt: '2020-01-13T10:09:17+00:00'
+                        shapeMargin: 10
+                        shapeRadius: 3
+                        shapeAspect: flat
+                        shapeBackgroundTop: 'rgba(50, 50, 50, .7)'
+                        shapeBackgroundBottom: 'rgba(50, 50, 50, .8)'
+                        text: 'rgba(255, 255, 255, .95)'
+                        link: 'rgba(255, 0, 0, .95)'
+                        linkHover: 'rgba(255, 255, 255, .75)'
+                        linkActive: 'rgba(255, 0, 0, .75)'
+                        trackPlayed: 'rgba(255, 255, 255, .95)'
+                        trackUnplayed: 'rgba(255, 255, 255, .1)'
+                        trackBackground: 'rgba(0, 0, 0, 0)'
+                        backgroundTop: 'rgba(72, 4, 45, 1)'
+                        backgroundBottom: 'rgba(94, 95, 89, 1)'
+                        backgroundText: 'rgba(255, 255, 255, .95)'
+                        enableApi: true
+                        enableControls: true
+                        forceAutoplay: true
+                        hideTitle: false
+                        forceLoop: false
+                    pagination:
+                      currentPage: 1
+                      pageSize: 25
+                      pagesTotal: 1
+                      itemsTotal: 4
+                      currentPageItems: 4
+                      links:
+                        - rel: self
+                          uri: 'https://ws.api.video/players?currentPage=1'
+                        - rel: first
+                          uri: 'https://ws.api.video/players?currentPage=1'
+                        - rel: last
+                          uri: 'https://ws.api.video/players?currentPage=1'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/bad-request'
+              examples:
+                response:
+                  value:
+                    title: This parameter is out of the allowed range of values.
+                    name: page
+                    status: 400
+                    range:
+                      min: 1
+                    problems:
+                      - title: This parameter is out of the allowed range of values.
+                        name: page
+                        range:
+                          min: 1
+                      - title: This parameter is out of the allowed range of values.
+                        name: pageSize
+                        range:
+                          min: 10
+                          max: 100
+      security:
+        - bearerAuth: []
+    post:
+      tags:
+        - Players
+      summary: Create a player
+      description: 'Create a player for your video, and customise it.'
+      operationId: POST_players
+      x-client-action: create
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/playerCreationPayload'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/player'
+              examples:
+                response:
+                  value:
+                    playerId: pl45d5vFFGrfdsdsd156dGhh
+                    createdAt: '2020-01-13T10:09:17+00:00'
+                    updatedAt: '2020-01-13T10:09:17+00:00'
+                    shapeRadius: 3
+                    shapeAspect: flat
+                    shapeBackgroundTop: 'rgba(50, 50, 50, .7)'
+                    shapeBackgroundBottom: 'rgba(50, 50, 50, .8)'
+                    text: 'rgba(255, 255, 255, .95)'
+                    link: 'rgba(255, 0, 0, .95)'
+                    linkHover: 'rgba(255, 255, 255, .75)'
+                    linkActive: 'rgba(255, 0, 0, .75)'
+                    trackPlayed: 'rgba(255, 255, 255, .95)'
+                    trackUnplayed: 'rgba(255, 255, 255, .1)'
+                    trackBackground: 'rgba(0, 0, 0, 0)'
+                    backgroundTop: 'rgba(72, 4, 45, 1)'
+                    backgroundBottom: 'rgba(94, 95, 89, 1)'
+                    backgroundText: 'rgba(255, 255, 255, .95)'
+                    enableApi: false
+                    enableControls: false
+                    forceAutoplay: false
+                    hideTitle: false
+                    forceLoop: false
+      security:
+        - bearerAuth: []
+  '/players/{playerId}':
+    get:
+      tags:
+        - Players
+      summary: Show a player
+      description: >-
+        Use a player ID to retrieve details about the player and display it for
+        viewers.
+      operationId: GET_players-playerId
+      x-client-action: get
+      parameters:
+        - name: playerId
+          in: path
+          description: 'The unique identifier for the player you want to retrieve. '
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: pl45d5vFFGrfdsdsd156dGhh
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/player'
+              examples:
+                response:
+                  value:
+                    playerId: pl45d5vFFGrfdsdsd156dGhh
+                    createdAt: '2020-01-13T10:09:17+00:00'
+                    updatedAt: '2020-01-13T11:12:14+00:00'
+                    shapeRadius: 3
+                    shapeAspect: flat
+                    shapeBackgroundTop: 'rgba(50, 50, 50, .7)'
+                    shapeBackgroundBottom: 'rgba(50, 50, 50, .8)'
+                    text: 'rgba(255, 255, 255, .95)'
+                    link: 'rgba(255, 0, 0, .95)'
+                    linkHover: 'rgba(255, 255, 255, .75)'
+                    linkActive: 'rgba(255, 0, 0, .75)'
+                    trackPlayed: 'rgba(255, 255, 255, .95)'
+                    trackUnplayed: 'rgba(255, 255, 255, .1)'
+                    trackBackground: 'rgba(0, 0, 0, 0)'
+                    backgroundTop: 'rgba(72, 4, 45, 1)'
+                    backgroundBottom: 'rgba(94, 95, 89, 1)'
+                    backgroundText: 'rgba(255, 255, 255, .95)'
+                    enableApi: false
+                    enableControls: false
+                    forceAutoplay: false
+                    hideTitle: false
+                    forceLoop: false
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/not-found'
+              examples:
+                response:
+                  value:
+                    type: 'https://docs.api.video/docs/resourcenot_found'
+                    title: The requested resource was not found.
+                    name: playerId
+                    status: 404
+      security:
+        - bearerAuth: []
+    delete:
+      tags:
+        - Players
+      summary: Delete a player
+      description: >-
+        Delete a player if you no longer need it. You can delete any player that
+        you have the player ID for.
+      operationId: DELETE_players-playerId
+      x-client-action: delete
+      parameters:
+        - name: playerId
+          in: path
+          description: The unique identifier for the player you want to delete.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: pl45d5vFFGrfdsdsd156dGhh
+      responses:
+        '204':
+          description: No Content
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/not-found'
+              examples:
+                response:
+                  value:
+                    type: 'https://docs.api.video/docs/resourcenot_found'
+                    title: The requested resource was not found.
+                    name: playerId
+                    status: 404
+      security:
+        - bearerAuth: []
+    patch:
+      tags:
+        - Players
+      summary: Update a player
+      description: >-
+        Use a player ID to update specific details for a player. NOTE: It may
+        take up to 10 min before the new player configuration is available from
+        our CDN.
+      operationId: PATCH_players-playerId
+      x-client-action: update
+      parameters:
+        - name: playerId
+          in: path
+          description: The unique identifier for the player.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: pl45d5vFFGrfdsdsd156dGhh
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/playerUpdatePayload'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/player'
+              examples:
+                response:
+                  value:
+                    playerId: pl45d5vFFGrfdsdsd156dGhh
+                    createdAt: '2020-01-13T10:09:17+00:00'
+                    updatedAt: '2020-01-13T11:12:14+00:00'
+                    shapeRadius: 3
+                    shapeAspect: flat
+                    shapeBackgroundTop: 'rgba(50, 50, 50, .7)'
+                    shapeBackgroundBottom: 'rgba(50, 50, 50, .8)'
+                    text: 'rgba(255, 255, 255, .95)'
+                    link: 'rgba(255, 0, 0, .95)'
+                    linkHover: 'rgba(255, 255, 255, .75)'
+                    linkActive: 'rgba(255, 0, 0, .75)'
+                    trackPlayed: 'rgba(255, 255, 255, .95)'
+                    trackUnplayed: 'rgba(255, 255, 255, .1)'
+                    trackBackground: 'rgba(0, 0, 0, 0)'
+                    backgroundTop: 'rgba(72, 4, 45, 1)'
+                    backgroundBottom: 'rgba(94, 95, 89, 1)'
+                    backgroundText: 'rgba(255, 255, 255, .95)'
+                    enableApi: false
+                    enableControls: false
+                    forceAutoplay: false
+                    hideTitle: false
+                    forceLoop: false
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/not-found'
+              examples:
+                response:
+                  value:
+                    type: 'https://docs.api.video/docs/resourcenot_found'
+                    title: The requested resource was not found.
+                    name: playerId
+                    status: 404
+      security:
+        - bearerAuth: []
+  '/players/{playerId}/logo':
+    post:
+      tags:
+        - Players
+      summary: Upload a logo
+      description: >-
+        The uploaded image maximum size should be 200x100 and its weight should
+        be 200KB. 
+
+        It will be scaled down to 30px height and converted to PNG to be
+        displayed in the player.
+      operationId: POST_players-playerId-logo
+      x-client-action: uploadLogo
+      parameters:
+        - name: playerId
+          in: path
+          description: The unique identifier for the player.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: pl14Db6oMJRH6SRVoOwORacK
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/players-upload-logo-payload'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/player'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/bad-request'
+              examples:
+                response:
+                  value:
+                    status: 400
+                    type: 'https://docs.api.video/docs/fileextension'
+                    title: >-
+                      Only ['jpg', 'JPG', 'jpeg', 'JPEG', 'png', 'PNG']
+                      extensions are supported.
+                    name: file
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/not-found'
+              examples:
+                response:
+                  value:
+                    type: 'https://docs.api.video/docs/resourcenot_found'
+                    title: The requested resource was not found.
+                    name: playerId
+                    status: 404
+      security:
+        - bearerAuth: []
+    delete:
+      tags:
+        - Players
+      summary: Delete logo
+      operationId: DELETE_players-playerId-logo
+      x-client-action: deleteLogo
+      parameters:
+        - name: playerId
+          in: path
+          description: The unique identifier for the player.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: pl14Db6oMJRH6SRVoOwORacK
+      responses:
+        '204':
+          description: No Content
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/not-found'
+              examples:
+                response:
+                  value:
+                    type: 'https://docs.api.video/docs/resourcenot_found'
+                    title: The requested resource was not found.
+                    name: playerId
+                    status: 404
+      security:
+        - bearerAuth: []
+  '/analytics/videos/{videoId}':
+    get:
+      tags:
+        - Raw statistics
+      summary: List video player sessions
+      description: Retrieve all available user sessions for a specific video.
+      operationId: GET_analytics-videos-videoId
+      x-client-action: listSessions
+      x-group-parameters: true
+      x-client-paginated: true
+      parameters:
+        - name: videoId
+          in: path
+          description: >-
+            The unique identifier for the video you want to retrieve session
+            information for.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: vi4k0jvEUuaTdRAEjQ4Prklg
+        - name: period
+          in: query
+          description: |
+            Period must have one of the following formats: 
+
+            - For a day : 2018-01-01,
+            - For a week: 2018-W01, 
+            - For a month: 2018-01
+            - For a year: 2018
+
+            For a range period: 
+            -  Date range: 2018-01-01/2018-01-15
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+            format: period
+        - name: metadata
+          in: query
+          description: >-
+            Metadata and Dynamic Metadata filter. Send an array of key value
+            pairs you want to filter sessios with.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+          example: >-
+            [{"key": "Author", "value": "John Doe"}, {"key": "Format", "value":
+            "Tutorial"}]
+        - $ref: '#/components/parameters/currentPage'
+        - $ref: '#/components/parameters/pageSize'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/raw-statistics-list-sessions-response'
+              examples:
+                response:
+                  value:
+                    data:
+                      - session:
+                          sessionId: psEmFwGQUAXR2lFHj5nDOpy
+                          loadedAt: '2019-06-24T11:45:01.109+00'
+                          endedAt: '2019-06-24T11:49:19.243+00'
+                        location:
+                          country: France
+                          city: Paris
+                        referrer:
+                          url: 'https://api.video'
+                          medium: organic
+                          source: 'https://google.com'
+                          searchTerm: video encoding hosting and delivery
+                        device:
+                          type: desktop
+                          vendor: Dell
+                          model: unknown
+                        os:
+                          name: Microsoft Windows
+                          shortname: W10
+                          version: Windows10
+                        client:
+                          type: browser
+                          name: Firefox
+                          version: '67.0'
+                    pagination:
+                      currentPage: 1
+                      currentPageItems: 1
+                      pageSize: 25
+                      pagesTotal: 1
+                      itemsTotal: 1
+                      links:
+                        - rel: self
+                          uri: >-
+                            /analytics/sessions/psEmFwGQUAXR2lFHj5nDOpy?currentPage=1&pageSize=25
+                        - rel: first
+                          uri: >-
+                            /analytics/sessions/psEmFwGQUAXR2lFHj5nDOpy?currentPage=1&pageSize=25
+                        - rel: last
+                          uri: >-
+                            /analytics/sessions/psEmFwGQUAXR2lFHj5nDOpy?currentPage=1&pageSize=25
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/not-found'
+              examples:
+                response:
+                  value:
+                    type: 'https://docs.api.video/docs/resourcenot_found'
+                    title: The requested resource was not found.
+                    name: videoId
+                    status: 404
+      security:
+        - bearerAuth: []
+  '/analytics/live-streams/{liveStreamId}':
+    get:
+      tags:
+        - Raw statistics
+      summary: List live stream player sessions
+      operationId: GET_analytics-live-streams-liveStreamId
+      x-client-action: getLiveStreamAnalytics
+      x-group-parameters: true
+      x-client-paginated: true
+      parameters:
+        - name: liveStreamId
+          in: path
+          description: >-
+            The unique identifier for the live stream you want to retrieve
+            analytics for.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: vi4k0jvEUuaTdRAEjQ4Jfrgz
+        - name: period
+          in: query
+          description: |
+            Period must have one of the following formats: 
+
+            - For a day : "2018-01-01",
+            - For a week: "2018-W01", 
+            - For a month: "2018-01"
+            - For a year: "2018"
+
+            For a range period: 
+            -  Date range: "2018-01-01/2018-01-15"
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+            format: period
+          example: '2019-01-01'
+        - $ref: '#/components/parameters/currentPage'
+        - $ref: '#/components/parameters/pageSize'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: >-
+                  #/components/schemas/raw-statistics-list-live-stream-analytics-response
+              examples:
+                response:
+                  value:
+                    data:
+                      - session:
+                          sessionId: ps4zRWVOv2If2vzKJLMr3jQo
+                          loadedAt: '2018-09-11T13:04:37.89+00'
+                          endedAt: '2018-09-11T14:47:22.186+00'
+                        location:
+                          country: France
+                          city: Paris
+                        referrer:
+                          url: unknown
+                          medium: unknown
+                          source: unknown
+                          searchTerm: unknown
+                        device:
+                          type: desktop
+                          vendor: unknown
+                          model: unknown
+                        os:
+                          name: unknown
+                          shortname: unknown
+                          version: unknown
+                        client:
+                          type: browser
+                          name: Firefox
+                          version: '61.0'
+                    pagination:
+                      currentPage: 1
+                      currentPageItems: 1
+                      pageSize: 25
+                      pagesTotal: 1
+                      itemsTotal: 1
+                      links:
+                        - rel: self
+                          uri: >-
+                            /analytics/sessions/ps4zRWVOv2If2vzKJLMr3jQo?currentPage=1&pageSize=25
+                        - rel: first
+                          uri: >-
+                            /analytics/sessions/ps4zRWVOv2If2vzKJLMr3jQo?currentPage=1&pageSize=25
+                        - rel: last
+                          uri: >-
+                            /analytics/sessions/ps4zRWVOv2If2vzKJLMr3jQo?currentPage=1&pageSize=25
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/not-found'
+              examples:
+                response:
+                  value:
+                    type: 'https://docs.api.video/docs/resourcenot_found'
+                    title: The requested resource was not found.
+                    name: liveStreamId
+                    status: 404
+      security:
+        - bearerAuth: []
+  '/analytics/sessions/{sessionId}/events':
+    get:
+      tags:
+        - Raw statistics
+      summary: List player session events
+      description: Useful to track and measure video's engagement.
+      operationId: GET_analytics-sessions-sessionId-events
+      x-client-action: listPlayerSessionEvents
+      x-group-parameters: true
+      x-client-paginated: true
+      parameters:
+        - name: sessionId
+          in: path
+          description: >-
+            A unique identifier you can use to reference and track a session
+            with.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: psEmFwGQUAXR2lFHj5nDOpy
+        - $ref: '#/components/parameters/currentPage'
+        - $ref: '#/components/parameters/pageSize'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: >-
+                  #/components/schemas/raw-statistics-list-player-session-events-response
+              examples:
+                response:
+                  value:
+                    data:
+                      - type: ready
+                        emittedAt: '2020-09-15T09:47:42+00:00'
+                        at: 0
+                      - type: play
+                        emittedAt: '2020-09-15T21:35:57+00:00'
+                        at: 0
+                      - type: pause
+                        emittedAt: '2020-09-15T21:36:05+00:00'
+                        at: 7
+                      - type: resume
+                        emittedAt: '2020-09-15T21:36:19+00:00'
+                        at: 21
+                      - type: seek.forward
+                        emittedAt: '2020-09-15T21:36:19+00:00'
+                        from: 7
+                        to: 21
+                      - type: end
+                        emittedAt: '2020-09-15T21:36:28+00:00'
+                        at: 30
+                      - type: play
+                        emittedAt: '2020-09-15T21:36:29+00:00'
+                        at: 0
+                      - type: seek.backward
+                        emittedAt: '2020-09-15T21:36:29+00:00'
+                        from: 30
+                        to: 0
+                      - type: pause
+                        emittedAt: '2020-09-15T21:36:29+00:00'
+                        at: 21
+                      - type: resume
+                        emittedAt: '2020-09-15T21:36:30+00:00'
+                        at: 21
+                      - type: seek.forward
+                        emittedAt: '2020-09-15T21:36:30+00:00'
+                        from: 0
+                        to: 21
+                      - type: pause
+                        emittedAt: '2020-09-15T21:36:33+00:00'
+                        at: 20
+                      - type: resume
+                        emittedAt: '2020-09-15T21:36:33+00:00'
+                        at: 20
+                      - type: seek.backward
+                        emittedAt: '2020-09-15T21:36:33+00:00'
+                        from: 24
+                        to: 20
+                      - type: pause
+                        emittedAt: '2020-09-15T21:36:39+00:00'
+                        at: 17
+                      - type: resume
+                        emittedAt: '2020-09-15T21:36:39+00:00'
+                        at: 17
+                      - type: seek.forward
+                        emittedAt: '2020-09-15T21:36:39+00:00'
+                        from: 17
+                        to: 17
+                      - type: pause
+                        emittedAt: '2020-09-15T21:36:41+00:00'
+                        at: 19
+                      - type: ready
+                        emittedAt: '2020-09-17T09:20:47+00:00'
+                        at: 0
+                      - type: ready
+                        emittedAt: '2020-09-17T09:41:01+00:00'
+                        at: 0
+                      - type: ready
+                        emittedAt: '2020-09-17T09:41:08+00:00'
+                        at: 0
+                      - type: play
+                        emittedAt: '2020-09-17T09:41:10+00:00'
+                        at: 0
+                      - type: pause
+                        emittedAt: '2020-09-17T09:41:12+00:00'
+                        at: 1
+                      - type: resume
+                        emittedAt: '2020-09-17T09:41:13+00:00'
+                        at: 1
+                      - type: pause
+                        emittedAt: '2020-09-17T09:41:15+00:00'
+                        at: 3
+                    pagination:
+                      currentPage: 1
+                      currentPageItems: 25
+                      pageSize: 25
+                      pagesTotal: 2
+                      itemsTotal: 30
+                      links:
+                        - rel: self
+                          uri: >-
+                            /analytics/sessions/ps5ltuhfsTOeh6bP03Tq5OWc/events?currentPage=1&pageSize=25
+                        - rel: first
+                          uri: >-
+                            /analytics/sessions/ps5ltuhfsTOeh6bP03Tq5OWc/events?currentPage=1&pageSize=25
+                        - rel: next
+                          uri: >-
+                            /analytics/sessions/ps5ltuhfsTOeh6bP03Tq5OWc/events?currentPage=2&pageSize=25
+                        - rel: last
+                          uri: >-
+                            /analytics/sessions/ps5ltuhfsTOeh6bP03Tq5OWc/events?currentPage=2&pageSize=25
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/not-found'
+              examples:
+                response:
+                  value:
+                    type: 'https://docs.api.video/docs/resourcenot_found'
+                    title: The requested resource was not found.
+                    name: videoId
+                    status: 404
+      security:
+        - bearerAuth: []
+  /webhooks:
+    get:
+      tags:
+        - Webhooks
+      summary: List all webhooks
+      description: >-
+        Requests to this endpoint return a list of your webhooks (with all their
+        details). You can filter what the webhook list that the API returns
+        using the parameters described below.
+      operationId: LIST-webhooks
+      x-group-parameters: true
+      x-client-paginated: true
+      x-client-action: list
+      parameters:
+        - name: events
+          in: query
+          description: The webhook event that you wish to filter on.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+          example: video.encoding.quality.completed
+        - $ref: '#/components/parameters/currentPage'
+        - $ref: '#/components/parameters/pageSize'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/webhooks-list-response'
+              examples:
+                response:
+                  value:
+                    data:
+                      - webhookId: webhook_XXXXXXXXXXXXXXX
+                        createdAt: '2021-01-08T14:12:18.000+00:00'
+                        events:
+                          - video.encoding.quality.completed
+                        url: >-
+                          http://clientnotificationserver.com/notif?myquery=query
+                      - webhookId: webhook_XXXXXXXXXYYYYYY
+                        createdAt: '2021-01-12T12:12:12.000+00:00'
+                        events:
+                          - video.encoding.quality.completed
+                        url: >-
+                          http://clientnotificationserver.com/notif?myquery=query2
+                    pagination:
+                      currentPage: 1
+                      pageSize: 25
+                      pagesTotal: 1
+                      itemsTotal: 11
+                      currentPageItems: 11
+                      links:
+                        - rel: self
+                          uri: 'https://ws.api.video/webhooks?currentPage=1'
+                        - rel: first
+                          uri: 'https://ws.api.video/webhooks?currentPage=1'
+                        - rel: last
+                          uri: 'https://ws.api.video/webhooks?currentPage=1'
+      security:
+        - bearerAuth: []
+    post:
+      tags:
+        - Webhooks
+      summary: Create Webhook
+      x-client-action: create
+      description: >-
+        Webhooks can push notifications to your server, rather than polling
+        api.video for changes
+      operationId: POST-webhooks
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/webhooks-create-payload'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/webhook'
+              examples:
+                response:
+                  value:
+                    webhookId: webhook_XXXXXXXXXXXXXXX
+                    createdAt: '2021-01-08T14:12:18.000+00:00'
+                    events:
+                      - video.encoding.quality.completed
+                    url: 'http://clientnotificationserver.com/notif?myquery=query'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/bad-request'
+              examples:
+                response:
+                  value:
+                    type: 'https://docs.api.video/docs/attributerequired'
+                    events: This attribute is required.
+                    name: events
+                    status: 400
+                    problems:
+                      - type: 'https://docs.api.video/docs/attributerequired'
+                        title: This attribute is required.
+                        name: events
+                      - type: 'https://docs.api.video/docs/attributerequired'
+                        title: This attribute is required.
+                        name: url
+                      - type: 'https://docs.api.video/docs/attributeinvalid'
+                        title: This attribute must be an array.
+                        name: events
+      security:
+        - bearerAuth: []
+  '/webhooks/{webhookId}':
+    get:
+      tags:
+        - Webhooks
+      summary: Show Webhook details
+      description: >-
+        This call provides the same JSON information provided on Webjhook
+        creation.
+      operationId: GET-Webhook
+      x-client-action: get
+      parameters:
+        - name: webhookId
+          in: path
+          description: The unique webhook you wish to retreive details on.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/webhook'
+              examples:
+                response:
+                  value:
+                    webhookId: webhook_XXXXXXXXXXXXXXX
+                    createdAt: '2021-01-08T14:12:18.000+00:00'
+                    events:
+                      - video.encoding.quality.completed
+                    url: 'http://clientnotificationserver.com/notif?myquery=query'
+      security:
+        - bearerAuth: []
+    delete:
+      tags:
+        - Webhooks
+      summary: Delete a Webhook
+      description: This endpoint will delete the indicated webhook.
+      operationId: DELETE-webhook
+      x-client-action: delete
+      parameters:
+        - name: webhookId
+          in: path
+          description: The webhook you wish to delete.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+      responses:
+        '204':
+          description: No Content
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/not-found'
+              examples:
+                response:
+                  value:
+                    type: 'https://docs.api.video/docs/resourcenot_found'
+                    title: The requested resource was not found.
+                    name: webhookId
+                    status: 404
+      security:
+        - bearerAuth: []
+  /account:
+    get:
+      tags:
+        - Account
+      summary: Show account
+      description: >-
+        Deprecated. Authenticate and get a token, then you can use the bearer
+        token here to retrieve details about your account.
+      operationId: GET_account
+      deprecated: true
+      x-client-action: get
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/account'
+              examples:
+                response:
+                  value:
+                    quota:
+                      quotaUsed: 6
+                      quotaRemaining: 54
+                      quotaTotal: 60
+                    environment: production
+                    features:
+                      - app.dynamic_metadata
+                      - app.event_log
+                      - player.white_label
+                      - stats.player_events
+                      - transcode.mp4_support
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/not-found'
+              examples:
+                response:
+                  value:
+                    type: 'https://docs.api.video/docs/resourcenot_found'
+                    title: The requested resource was not found.
+                    name: ''
+                    status: 404
+      security:
+        - bearerAuth: []
+x-client-base-paths:
+  production: 'https://ws.api.video'
+  sandbox: 'https://sandbox.api.video'
+components:
+  parameters:
+    currentPage:
+      name: currentPage
+      in: query
+      description: 'Choose the number of search results to return per page. Minimum value: 1'
+      required: false
+      style: form
+      explode: true
+      schema:
+        type: integer
+        default: 1
+      example: 2
+    pageSize:
+      name: pageSize
+      in: query
+      description: 'Results per page. Allowed values 1-100, default is 25.'
+      required: false
+      style: form
+      explode: true
+      schema:
+        type: integer
+        default: 25
+      example: 30
+  schemas:
+    link:
+      type: object
+      properties:
+        rel:
+          type: string
+        uri:
+          type: string
+    access-token:
+      title: AccessToken
+      type: object
+      properties:
+        access_token:
+          type: string
+          description: >-
+            The access token containing security credentials allowing you to
+            acccess the API. The token lasts for one hour.
+          example: >-
+            eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImp0aSI6IjUyZWM4NWUyMjFkODZjOWI0NDQ5NzBhMjQwMzUyOWQ4MDQyNGQ3ZmJjYjFlYWM2MjVlM2VkMjI2YWRlNTcxMDY2NDUyZDc0NjdhN2E4NjI0In0.eyJhdWQiOiJsaWJjYXN0IiwianRpIjoiNTJlYzg1ZTIyMWQ4NmM5YjQ0NDk3MGEyNDAzNTI5ZDgwNDI0ZDdmYmNiMWVhYzYyNWUzZWQyMjZhZGU1NzEwNjY0NTJkNzQ2N2E3YTg2MjQiLCJpYXQiOjE1MjUyNzYxNDcsIm5iZiI6MTUyNTI3NjE0NywiZXhwIjoxNTI1Mjc5NzQ3LCJzdWIiOiJ1c01vbml0b3IiLCJzY29wZXMiOlsibW9uaXRvci5saWJjYXN0LmNvbSJdLCJjb250ZXh0Ijp7InVzZXIiOiJ1c01vbml0b3IiLCJwcm9qZWN0IjoicHJNb25pdG9yIiwibWVtYmVyIjoibWVNb25pdG9yIn19.rUvishDNyJLNlI4W5VmguNecm5KD2uZgPkKJQbaqw-cJbSrVxkSbiKYtk_E3cz3WT7-IS2yFTsYN3uIo5Rbit8_HftweyEp2bdBRI8yjR6oZZ1sNJJXswISN1i2kk4r-aaxu7Xxf_LtsjOMUj_YZsvcc2nqBXPKjHbJCJryx3DDJaIcymOqao7nhQaCCQyrQooAXNTYs4E9fWN1dC_x2O-zok5TuG-xhEW-umwxfSUMWNgSTkz38ACceQ0PCJSgB3jqjDH4MwC7B3ppEPZuK5E6JhKeyRlalswRyYq3UQPnVeMTam7YQHsuTgbehF6WySW8i44o7V_MCe9hjPdp-WA
+        token_type:
+          type: string
+          description: The type of token you have.
+          default: bearer
+        refresh_token:
+          type: string
+          description: >-
+            A token you can use to get the next access token when your current
+            access token expires.
+          example: >-
+            def50200a28d88fb9aaa921be78eeb5604b071101a334899a7d5fc7492cf8ea752962ddc8961fe5c126101d4ecacd980396eb2fd494995b812dffcb98256c4277f790d1f658fc2d2e34f350740544e5232d69d68d34c648271d706c5e7049adac0b1832d0fdf71809715cc7e97fa63f65966deadb501a55ff469b0fd23a637cb6acbe9d9b8594a17f09efc2efeed82984764a0065d5e29c950c7b081a61ba2aaa192be3085c400ee37eac50fa9320ce2cfe8916c8165418d23e9f91b6a5c8515e1d74ee193a5a1ca01954fbff27361c20184240be2359e0afbed0bf1c762cf872450b5e8b5d4704f4fd9583e4470adc98409dd42965709712806bd9019378a72eea0b4912ce684ffd833db5806ab84174f905db2a75380071d004615c944bb8f8c4045cce7234c2be9a2330522cf7f067b8e58f57cffb6edb4b7ef91313e12bcde47e5e76ceee7fa52990132288f345d33ed917ae4fd54b7284f8964d898e97e1ee3bc4157f75d7fee63976e4be66ac1ec32ef74afa533f0eb593523f226cbec57d196ac8962
+        expires_in:
+          type: integer
+          description: >-
+            Lists the time in seconds when your access token expires. It lasts
+            for one hour.
+      example:
+        access_token: est
+        token_type: qui nulla l
+        refresh_token: cillum
+        expires_in: 3600
+    pagination:
+      title: Pagination
+      required:
+        - links
+      type: object
+      properties:
+        itemsTotal:
+          type: integer
+          description: Total number of items that exist.
+          readOnly: true
+        pagesTotal:
+          type: integer
+          description: Number of items listed in the current page.
+          readOnly: true
+        pageSize:
+          type: integer
+          description: Maximum number of item per page.
+          readOnly: true
+        currentPage:
+          type: integer
+          description: The current page index.
+          readOnly: true
+        currentPageItems:
+          type: integer
+          description: The number of items on the current page.
+          readOnly: true
+        links:
+          type: array
+          items:
+            $ref: '#/components/schemas/pagination_link'
+      example:
+        itemsTotal: 123
+        pagesTotal: 7
+        pageSize: 20
+        currentPage: 3
+        currentPageItems: 20
+        links:
+          first:
+            rel: first
+            uri: /videos/search?currentPage=1&pageSize=20
+          previous:
+            rel: previous
+            uri: /videos/search?currentPage=2&pageSize=20
+          next:
+            rel: next
+            uri: /videos/search?currentPage=4&pageSize=20
+          last:
+            rel: last
+            uri: /videos/search?currentPage=6&pageSize=20
+    bad-request:
+      title: BadRequest
+      type: object
+      properties:
+        type:
+          type: string
+        title:
+          type: string
+        name:
+          type: string
+        status:
+          type: integer
+        problems:
+          uniqueItems: true
+          type: array
+          items:
+            $ref: '#/components/schemas/bad-request'
+    not-found:
+      title: NotFound
+      type: object
+      properties:
+        type:
+          type: string
+        title:
+          type: string
+        name:
+          type: string
+        status:
+          type: integer
+    video:
+      title: video
+      type: object
+      properties:
+        videoId:
+          type: string
+          description: The unique identifier of the video object.
+          example: vi4k0jvEUuaTdRAEjQ4Prklg
+        title:
+          type: string
+          description: |
+            The title of the video content.
+          example: Maths video
+        description:
+          type: string
+          description: |
+            A description for the video content.
+          example: An amazing video explaining string theory.
+        publishedAt:
+          type: string
+          description: >-
+            The date and time the API created the video. Date and time are
+            provided using ISO-8601 UTC format.
+          example: '2019-12-16T08:25:51+00:00'
+        updatedAt:
+          type: string
+          description: >-
+            The date and time the video was updated. Date and time are provided
+            using ISO-8601 UTC format.
+          format: date-time
+          example: '2019-12-16T08:25:51+00:10'
+        tags:
+          type: array
+          description: >
+            One array of tags (each tag is a string) in order to categorize a
+            video. Tags may include spaces. 
+          example: '"tags": ["maths", "string theory", "video"]'
+          items: {}
+        metadata:
+          type: array
+          description: >
+            Metadata you can use to categorise and filter videos. Metadata is a
+            list of dictionaries, where each dictionary represents a key value
+            pair for categorising a video. 
+          example: >-
+            [{"key":"Author", "value":"John Doe"}, {"key":"Format",
+            "value":"Tutorial"}]
+          items:
+            $ref: '#/components/schemas/metadata'
+        source:
+          $ref: '#/components/schemas/videoSource'
+        assets:
+          $ref: '#/components/schemas/videoAssets'
+        playerId:
+          type: string
+          description: |
+            The id of the player that will be applied on the video.
+          example: pl45KFKdlddgk654dspkze
+        public:
+          type: boolean
+          description: >
+            Defines if the content is publicly reachable or if a unique token is
+            needed for each play session.
+          example: false
+        panoramic:
+          type: boolean
+          description: |
+            Defines if video is panoramic.
+          example: false
+        mp4Support:
+          type: boolean
+          description: >
+            This lets you know whether mp4 is supported. If enabled, an mp4 URL
+            will be provided in the response for the video.
+          example: true
+      example:
+        videoId: vi4k0jvEUuaTdRAEjQ4Jfrgz
+        title: Maths video
+        description: An amazing video explaining the string theory
+        tags:
+          - maths
+          - string theory
+          - video
+        metadata:
+          - key: Author
+            value: John Doe
+          - key: Format
+            value: Tutorial
+        scheduledAt: '4251-03-03T12:52:03.085Z'
+        publishedAt: '4665-07-14T23:36:18.598Z'
+        actions:
+          - video_delete
+          - video_download
+          - video_update
+    player:
+      allOf:
+        - $ref: '#/components/schemas/playerinput'
+        - type: object
+          properties:
+            playerId:
+              type: string
+              example: pl45KFKdlddgk654dspkze
+            createdAt:
+              type: string
+              description: 'When the player was created, presented in ISO-8601 format.'
+              format: date-time
+              example: '2020-01-31T10:17:47+00:00'
+            updatedAt:
+              type: string
+              description: 'When the player was last updated, presented in ISO-8601 format.'
+              format: date-time
+              example: '2020-01-31T10:18:47+00:00'
+            shapeMargin:
+              type: integer
+              description: Deprecated
+            shapeRadius:
+              type: integer
+              description: Deprecated
+            shapeAspect:
+              type: string
+              description: Deprecated
+            shapeBackgroundTop:
+              type: string
+              description: Deprecated
+            shapeBackgroundBottom:
+              type: string
+              description: Deprecated
+            linkActive:
+              type: string
+              description: Deprecated
+            assets:
+              type: object
+              properties:
+                logo:
+                  type: string
+                  description: The name of the file containing the logo you want to use.
+                  example: mylogo.jpg
+                link:
+                  type: string
+                  description: The path to the file containing your logo.
+                  example: path/to/my/logo/mylogo.jpg
+      title: Player
+    playerCreationPayload:
+      allOf:
+        - $ref: '#/components/schemas/playerinput'
+    playerUpdatePayload:
+      allOf:
+        - $ref: '#/components/schemas/playerinput'
+    playerinput:
+      title: PlayerInput
+      type: object
+      properties:
+        text:
+          type: string
+          description: 'RGBA color for timer text. Default: rgba(255, 255, 255, 1)'
+        link:
+          type: string
+          description: 'RGBA color for all controls. Default: rgba(255, 255, 255, 1)'
+        linkHover:
+          type: string
+          description: >-
+            RGBA color for all controls when hovered. Default: rgba(255, 255,
+            255, 1)
+        trackPlayed:
+          type: string
+          description: >-
+            RGBA color playback bar: played content. Default: rgba(88, 131, 255,
+            .95)
+        trackUnplayed:
+          type: string
+          description: >-
+            RGBA color playback bar: downloaded but unplayed (buffered) content.
+            Default: rgba(255, 255, 255, .35)
+        trackBackground:
+          type: string
+          description: >-
+            RGBA color playback bar: background. Default: rgba(255, 255, 255,
+            .2)
+        backgroundTop:
+          type: string
+          description: 'RGBA color: top 50% of background. Default: rgba(0, 0, 0, .7)'
+        backgroundBottom:
+          type: string
+          description: 'RGBA color: bottom 50% of background. Default: rgba(0, 0, 0, .7)'
+        backgroundText:
+          type: string
+          description: 'RGBA color for title text. Default: rgba(255, 255, 255, 1)'
+        enableApi:
+          type: boolean
+          description: 'enable/disable player SDK access. Default: true'
+          default: true
+        enableControls:
+          type: boolean
+          description: 'enable/disable player controls. Default: true'
+          default: true
+        forceAutoplay:
+          type: boolean
+          description: 'enable/disable player autoplay. Default: false'
+          default: false
+        hideTitle:
+          type: boolean
+          description: 'enable/disable title. Default: false'
+          default: false
+        forceLoop:
+          type: boolean
+          description: 'enable/disable looping. Default: false'
+          default: false
+      example:
+        assets:
+          logo: 'https://cdn.api.video/player/pl14Db6oMJRH6SRVoOwORacK/logo.png'
+          link: 'https://api.video'
+        shapeMargin: 10
+        shapeRadius: 3
+        shapeAspect: flat
+        shapeBackgroundTop: 'rgba(50, 50, 50, .7)'
+        shapeBackgroundBottom: 'rgba(50, 50, 50, .8)'
+        text: 'rgba(255, 255, 255, .95)'
+        link: 'rgba(255, 0, 0, .95)'
+        linkHover: 'rgba(255, 255, 255, .75)'
+        linkActive: 'rgba(255, 0, 0, .75)'
+        trackPlayed: 'rgba(255, 255, 255, .95)'
+        trackUnplayed: 'rgba(255, 255, 255, .1)'
+        trackBackground: 'rgba(0, 0, 0, 0)'
+        backgroundTop: 'rgba(72, 4, 45, 1)'
+        backgroundBottom: 'rgba(94, 95, 89, 1)'
+        backgroundText: 'rgba(255, 255, 255, .95)'
+        language: en
+        enableApi: true
+        enableControls: true
+        forceAutoplay: false
+        hideTitle: false
+        forceLoop: false
+    subtitle:
+      title: Subtitle
+      type: object
+      properties:
+        uri:
+          type: string
+        src:
+          type: string
+        srclang:
+          type: string
+        default:
+          type: boolean
+          description: >-
+            Whether you will have subtitles or not. True for yes you will have
+            subtitles, false for no you will not have subtitles.
+          example: false
+          default: false
+    video-session:
+      title: Video Session
+      type: object
+      properties:
+        session:
+          $ref: '#/components/schemas/video_session_session'
+        location:
+          $ref: '#/components/schemas/video_session_location'
+        referrer:
+          $ref: '#/components/schemas/video_session_referrer'
+        device:
+          $ref: '#/components/schemas/video_session_device'
+        os:
+          $ref: '#/components/schemas/video_session_os'
+        client:
+          $ref: '#/components/schemas/video_session_client'
+      example:
+        session:
+          sessionId: psEmFwGQUAXR2lFHj5nDOpy
+          loadedAt: '2019-06-24T11:45:01.109+00'
+          endedAt: '2019-06-24T11:49:19.243+00'
+        location:
+          country: France
+          city: Paris
+        referrer:
+          url: 'https://api.video'
+          medium: organic
+          source: 'https://google.com'
+          searchTerm: video encoding hosting and delivery
+        device:
+          type: desktop
+          vendor: Dell
+          model: unknown
+        os:
+          name: Microsoft Windows
+          shortname: W10
+          version: Windows10
+        client:
+          type: browser
+          name: Firefox
+          version: '67.0'
+    live-stream:
+      title: LiveStream
+      type: object
+      properties:
+        liveStreamId:
+          type: string
+          description: >-
+            The unique identifier for the live stream. Live stream IDs begin
+            with "li."
+          example: li400mYKSgQ6xs7taUeSaEKr
+        name:
+          type: string
+          description: The name of your live stream.
+          example: My Live Stream
+        streamKey:
+          type: string
+          description: 'The unique, private stream key that you use to begin streaming.'
+          example: cc1b4df0-d1c5-4064-a8f9-9f0368385135
+        record:
+          type: boolean
+          description: Whether you are recording or not.
+          example: true
+        public:
+          type: boolean
+          description: >-
+            BETA FEATURE Please limit all public = false ("private") livestreams
+            to 3,000 users. Whether your video can be viewed by everyone, or
+            requires authentication to see it. A setting of false will require a
+            unique token for each view.
+          example: true
+        assets:
+          $ref: '#/components/schemas/live_stream_assets'
+        playerId:
+          type: string
+          description: The unique identifier for the player.
+          example: pl45d5vFFGrfdsdsd156dGhh
+        broadcasting:
+          type: boolean
+          description: >-
+            Whether or not you are broadcasting the live video you recorded for
+            others to see. True means you are broadcasting to viewers, false
+            means you are not.
+          example: true
+    live-stream-session:
+      title: Live Stream Session
+      type: object
+      properties:
+        session:
+          $ref: '#/components/schemas/live_stream_session_session'
+        location:
+          $ref: '#/components/schemas/live_stream_session_location'
+        referrer:
+          $ref: '#/components/schemas/live_stream_session_referrer'
+        device:
+          $ref: '#/components/schemas/live_stream_session_device'
+        os:
+          $ref: '#/components/schemas/video_session_os'
+        client:
+          $ref: '#/components/schemas/live_stream_session_client'
+    player-session-event:
+      title: Player Session Event
+      type: object
+      properties:
+        type:
+          type: string
+          description: >-
+            Possible values are: ready, play, pause, resume, seek.backward,
+            seek.forward, end
+          example: play
+        emittedAt:
+          type: string
+          description: 'When an event occurred, presented in ISO-8601 format.'
+          format: date-time
+          example: '2019-06-24T11:45:01.109+00'
+        at:
+          type: integer
+        from:
+          type: integer
+        to:
+          type: integer
+    webhook:
+      title: Webhook
+      type: object
+      properties:
+        webhookId:
+          type: string
+          description: Unique identifier of the webhook
+          example: webhook_XXXXXXXXXXXXXXX
+        createdAt:
+          type: string
+          format: date-time
+          description: 'When an webhook was created, presented in ISO-8601 format.'
+          example: '2019-06-24T11:45:01.109+00'
+        events:
+          type: array
+          description: A list of events that will trigger the webhook.
+          example: '["video.encoding.quality.completed"]'
+          items:
+            type: string
+        url:
+          type: string
+          description: URL of the webhook
+          example: 'http://clientnotificationserver.com/notif?myquery=query'
+    videostatus:
+      title: VideoStatus
+      type: object
+      properties:
+        ingest:
+          $ref: '#/components/schemas/videostatus_ingest'
+        encoding:
+          $ref: '#/components/schemas/videostatus_encoding'
+      example:
+        ingest:
+          status: uploaded
+          filesize: 273579401
+          receivedBytes:
+            - to: 134217727
+              from: 0
+              total: 273579401
+            - to: 268435455
+              from: 134217728
+              total: 273579401
+            - to: 273579400
+              from: 268435456
+              total: 273579401
+        encoding:
+          playable: true
+          qualities:
+            - quality: 240p
+              status: encoded
+            - quality: 360p
+              status: encoded
+            - quality: 480p
+              status: encoded
+            - quality: 720p
+              status: encoded
+            - quality: 1080p
+              status: encoding
+            - quality: 2160p
+              status: waiting
+          metadata:
+            width: 424
+            height: 240
+            bitrate: 411.218
+            duration: 4176
+            framerate: 24
+            samplerate: 48000
+            videoCodec: h264
+            audioCodec: aac
+            aspectRatio: 16/9
+    quality:
+      title: quality
+      type: object
+      properties:
+        quality:
+          type: string
+          description: >-
+            The quality of the video you have, in pixels. Choices include 360p,
+            480p, 720p, 1080p, and 2160p.
+          example: 720p
+          enum:
+            - 240p
+            - 360p
+            - 480p
+            - 720p
+            - 1080p
+            - 2160p
+        status:
+          type: string
+          description: >-
+            The status of your video. Statuses include waiting - the video is
+            waiting to be encoded. encoding - the video is in the process of
+            being encoded. encoded - the video was successfully encoded. failed
+            - the video failed to be encoded.
+          enum:
+            - waiting
+            - encoding
+            - encoded
+            - failed
+    bytes_range:
+      title: bytes_range
+      type: object
+      properties:
+        from:
+          type: integer
+          description: The starting point for the range of bytes for a chunk of a video.
+          example: 0
+        to:
+          type: integer
+          description: The ending point for the range of bytes for a chunk of a video.
+          example: 9999
+        total:
+          type: integer
+          description: The total number of bytes in the provided range.
+          example: 10000
+    chapter:
+      title: Chapter
+      type: object
+      properties:
+        uri:
+          type: string
+        src:
+          type: string
+          description: >-
+            The link to your VTT file, which contains your chapters information
+            for the video.
+          example: 'https://cdn.api.video/vod/vi3N6cDinStg3oBbN79GklWS/chapters/fr.vtt'
+        language:
+          type: string
+    upload-token:
+      title: UploadToken
+      type: object
+      properties:
+        token:
+          type: string
+          description: >-
+            The unique identifier for the token you will use to authenticate an
+            upload.
+          example: to1tcmSFHeYY5KzyhOqVKMKb
+        ttl:
+          maximum: 2147483647
+          minimum: 0
+          type: integer
+          description: Time-to-live - how long the upload token is valid for.
+        createdAt:
+          type: string
+          description: 'When the token was created, displayed in ISO-8601 format.'
+          format: date-time
+          example: '2019-12-16T08:25:51+00:00'
+        expiresAt:
+          type: string
+          description: 'When the token expires, displayed in ISO-8601 format.'
+          format: date-time
+          example: '2019-12-16T09:25:51+00:00'
+    authenticate-payload:
+      title: apiKey
+      required:
+        - apiKey
+      type: object
+      properties:
+        apiKey:
+          type: string
+          description: >-
+            Your account API key. You can use your sandbox API key, or you can
+            use your production API key.
+      example:
+        apiKey: 9VxMaPgsaFg7EBqmuspSzF7
+    refresh-token-payload:
+      title: refreshToken
+      required:
+        - refreshToken
+      type: object
+      properties:
+        refreshToken:
+          type: string
+          description: >
+            The refresh token is either the first refresh token you received
+            when you authenticated with the auth/api-key endpoint, or it's the
+            refresh token from the last time you used the auth/refresh endpoint.
+            Place this in the body of your request to obtain a new access token
+            (which is valid for an hour) and a new refresh token.
+      example:
+        refreshToken: >-
+          def502005346d9cc2bd79a7793ab5bdabfefcaabfbb8c253f14733f1262077e1a3f38c4751d6d20f590c3784e531a82adc11f05fc1949aa46d5575aaa99cb84b9334ba66ac773576b5d7a418937ae337de62811d086dd42ad1164b12f87d67be6ffea18f2d50be9b95697b21c4d3c4372849bdb2287259cb80541570e913691a08b2fa33c85885930de15cebea627fc09f0255562ab3d39d87d4ff8fc02b00e252afcd480421dec7de9d1411176bcf669c527762e22294b453bc9ea06e9fa8ba5b873feb2ee14ce0a6a6ddd4b78c580631e210e9b9387265dc2bec9478a66a09dcdce1c40d2f856689e9d81742c9628a0b87b359e0b218ea1f07427eef89f999e47af89792f598e05847bd008fddc32ee63f4a601ffb4cd2ad08977f1c854ec358238322c918f05aa5a41f8a171dee497218408abc8283473f6112aeed7310815416a0fa36c63667e0ed014fa40b8992891bf58bae400d901c01450101c88f4978938ad138adc19cfe5698d60fd82cb27c586f6a8f70f4393c7c9e579df8739d46d249fb76d7
+    videos-list-response:
+      title: Videos
+      required:
+        - data
+        - pagination
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/video'
+        pagination:
+          $ref: '#/components/schemas/pagination'
+    metadata:
+      title: metadata
+      type: object
+      x-client-all-args-constructor: true
+      properties:
+        key:
+          type: string
+          description: The constant that defines the data set.
+          example: Color
+        value:
+          type: string
+          description: A variable which belongs to the data set.
+          example: Green
+    video-create-payload:
+      required:
+        - title
+      type: object
+      title: videoCreationPayload
+      properties:
+        title:
+          type: string
+          description: The title of your new video.
+          example: Maths video
+        description:
+          type: string
+          description: A brief description of your video.
+          example: A video about string theory.
+        source:
+          type: string
+          description: >-
+            If you add a video already on the web, this is where you enter the
+            url for the video.
+          example: 'https://www.myvideo.url.com/video.mp4'
+        public:
+          type: boolean
+          description: >-
+            Whether your video can be viewed by everyone, or requires
+            authentication to see it. A setting of false will require a unique
+            token for each view.
+          example: true
+          default: true
+        panoramic:
+          type: boolean
+          description: Indicates if your video is a 360/immersive video.
+          example: false
+          default: false
+        mp4Support:
+          type: boolean
+          description: Enables mp4 version in addition to streamed version.
+          example: true
+          default: true
+        playerId:
+          type: string
+          description: The unique identification number for your video player.
+          example: pl45KFKdlddgk654dspkze
+        tags:
+          type: array
+          description: A list of tags you want to use to describe your video.
+          example: '["maths", "string theory", "video"]'
+          items:
+            type: string
+        metadata:
+          type: array
+          description: >-
+            A list of key value pairs that you use to provide metadata for your
+            video. These pairs can be made dynamic, allowing you to segment your
+            audience. You can also just use the pairs as another way to tag and
+            categorize your videos.
+          example: '[{"key": "Author", "value": "John Doe"}]'
+          items:
+            $ref: '#/components/schemas/metadata'
+        publishedAt:
+          type: string
+          description: >-
+            The API uses ISO-8601 format for time, and includes 3 places for
+            milliseconds.
+          format: date-time
+          example: '2020-07-14T23:36:18.598Z'
+      example:
+        title: Maths video
+        description: An amazing video explaining string theory.
+        public: false
+        panoramic: false
+        mp4Support: true
+        playerId: pl45KFKdlddgk654dspkze
+        tags:
+          - maths
+          - string theory
+          - video
+        metadata:
+          - key: Author
+            value: John Doe
+          - key: Format
+            value: Tutorial
+    video-upload-payload:
+      required:
+        - file
+      type: object
+      properties:
+        file:
+          type: string
+          x-client-chunk-upload: 'true'
+          format: binary
+          description: >-
+            The path to the video you would like to upload. The path must be
+            local. If you want to use a video from an online source, you must
+            use the "/videos" endpoint and add the "source" parameter when you
+            create a new video.
+          example: '@/path/to/video.mp4'
+    video-thumbnail-pick-payload:
+      type: object
+      title: pickThumbnailPayload
+      required:
+        - timecode
+      properties:
+        timecode:
+          pattern: '00:00:00.00'
+          type: string
+          description: |-
+            Frame in video to be used as a placeholder before the video plays. 
+            Example: '"00:01:00.000" for 1 minute into the video.'
+            Valid Patterns: 
+            "hh:mm:ss.ms"
+            "hh:mm:ss:frameNumber"
+            "124" (integer value is reported as seconds) 
+            If selection is out of range, "00:00:00.00" will be chosen.
+      example:
+        timecode: '00:00:00.000'
+    video-thumbnail-upload-payload:
+      required:
+        - file
+      type: object
+      properties:
+        file:
+          type: string
+          description: The image to be added as a thumbnail.
+          format: binary
+    video-update-payload:
+      type: object
+      title: videoUpdatePayload
+      properties:
+        playerId:
+          type: string
+          description: The unique ID for the player you want to associate with your video.
+          example: pl4k0jvEUuaTdRAEjQ4Jfrgz
+        title:
+          type: string
+          description: The title you want to use for your video.
+        description:
+          type: string
+          description: A brief description of the video.
+          example: A film about good books.
+        public:
+          type: boolean
+          description: >-
+            Whether the video is publicly available or not. False means it is
+            set to private.
+          example: true
+        panoramic:
+          type: boolean
+          description: Whether the video is a 360 degree or immersive video.
+          example: false
+        mp4Support:
+          type: boolean
+          description: Whether the player supports the mp4 format.
+          example: true
+        tags:
+          type: array
+          description: >-
+            A list of terms or words you want to tag the video with. Make sure
+            the list includes all the tags you want as whatever you send in this
+            list will overwrite the existing list for the video.
+          example: '["maths", "string theory", "video"]'
+          items:
+            type: string
+        metadata:
+          type: array
+          description: >-
+            A list (array) of dictionaries where each dictionary contains a key
+            value pair that describes the video. As with tags, you must send the
+            complete list of metadata you want as whatever you send here will
+            overwrite the existing metadata for the video.
+          items:
+            $ref: '#/components/schemas/metadata'
+      example:
+        playerId: pl45KFKdlddgk654dspkze
+        title: String theory
+        description: An amazing video explaining the string theory
+        public: false
+        panoramic: false
+        mp4Support: true
+        tags:
+          - maths
+          - string theory
+          - video
+        metadata:
+          - key: Author
+            value: John Doe
+          - key: Format
+            value: Tutorial
+    token-list-response:
+      title: uploadTokens
+      required:
+        - data
+        - pagination
+      type: object
+      properties:
+        data:
+          title: uploadToken
+          type: array
+          items:
+            $ref: '#/components/schemas/upload-token'
+        pagination:
+          $ref: '#/components/schemas/pagination'
+    token-create-payload:
+      title: tokenCreationPayload
+      type: object
+      properties:
+        ttl:
+          maximum: 2147483647
+          minimum: 0
+          type: integer
+          description: >-
+            Time in seconds that the token will be active. A value of 0 means
+            that the token has no exipration date. The default is to have no
+            expiration.
+          default: 0
+      example:
+        ttl: 3600
+    token-upload-payload:
+      required:
+        - file
+      type: object
+      properties:
+        file:
+          x-client-chunk-upload: 'true'
+          format: binary
+          type: string
+          description: The path to the video you want to upload.
+          example: path/to/video/video.mp4
+        videoId:
+          x-client-ignore: true
+          x-client-copy-from-response: true
+          type: string
+          description: >-
+            The video id returned by the first call to this endpoint in a large
+            video upload scenario.
+    live-stream-list-response:
+      title: LiveStreams
+      required:
+        - data
+        - pagination
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/live-stream'
+        pagination:
+          $ref: '#/components/schemas/pagination'
+    live-stream-create-payload:
+      title: liveStreamCreationPayload
+      required:
+        - name
+      type: object
+      properties:
+        name:
+          type: string
+          description: Add a name for your live stream here.
+          example: My Live Stream Video
+        record:
+          type: boolean
+          description: >-
+            Whether you are recording or not. True for record, false for not
+            record.
+          example: true
+          default: false
+        public:
+          type: boolean
+          description: >-
+            BETA FEATURE Please limit all public = false ("private") livestreams
+            to 3,000 users. Whether your video can be viewed by everyone, or
+            requires authentication to see it. A setting of false will require a
+            unique token for each view.
+        playerId:
+          type: string
+          description: The unique identifier for the player.
+          example: pl4f4ferf5erfr5zed4fsdd
+      example:
+        name: Test live
+        record: true
+        playerId: pl4f4ferf5erfr5zed4fsdd
+    live-stream-update-payload:
+      title: LiveStreamUpdatePayload
+      type: object
+      properties:
+        name:
+          type: string
+          description: The name you want to use for your live stream.
+          example: My Live Stream Video
+        public:
+          type: boolean
+          description: >-
+            BETA FEATURE Please limit all public = false ("private") livestreams
+            to 3,000 users.
+
+            Whether your video can be viewed by everyone, or requires
+            authentication to see it. A setting of false will require a unique
+            token for each view.
+        record:
+          type: boolean
+          description: >-
+            Use this to indicate whether you want the recording on or off. On is
+            true, off is false.
+          example: true
+        playerId:
+          type: string
+          description: >-
+            The unique ID for the player associated with a live stream that you
+            want to update.
+          example: pl45KFKdlddgk654dspkze
+    captions-upload-payload:
+      required:
+        - file
+      type: object
+      properties:
+        file:
+          type: string
+          description: The video text track (VTT) you want to upload.
+          format: binary
+          example: 'https://cdn.api.video/vod/vi3N6cDinStg3oBbN79GklWS/captions/en.vtt'
+    live-stream-thumbnail-upload-payload:
+      required:
+        - file
+      type: object
+      properties:
+        file:
+          type: string
+          description: The image to be added as a thumbnail.
+          format: binary
+    captions-update-payload:
+      title: UpdateCaptionPayload
+      type: object
+      properties:
+        default:
+          type: boolean
+    captions-list-response:
+      title: VideoCaptions
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/subtitle'
+        pagination:
+          $ref: '#/components/schemas/pagination'
+    chapters-update-payload:
+      title: UpdateChapterPayload
+      required:
+        - file
+      type: object
+      properties:
+        file:
+          type: string
+          description: The VTT file describing the chapters you want to upload.
+          format: binary
+    chapters-list-response:
+      title: VideoChapters
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/chapter'
+        pagination:
+          $ref: '#/components/schemas/pagination'
+    players-list-response:
+      title: Players
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/player'
+        pagination:
+          $ref: '#/components/schemas/pagination'
+    players-upload-logo-payload:
+      required:
+        - file
+        - link
+      type: object
+      properties:
+        file:
+          type: string
+          format: binary
+          description: The name of the file you want to use for your logo.
+          example: mylogo.jpg
+        link:
+          type: string
+          format: string
+          description: The path to the file you want to upload and use as a logo.
+          example: path/to/my/logo/mylogo.jpg
+    raw-statistics-list-sessions-response:
+      title: VideoSessions
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/video-session'
+        pagination:
+          $ref: '#/components/schemas/pagination'
+    raw-statistics-list-live-stream-analytics-response:
+      title: LiveStreamSessions
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/live-stream-session'
+        pagination:
+          $ref: '#/components/schemas/pagination'
+    raw-statistics-list-player-session-events-response:
+      title: PlayerSessionEvents
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/player-session-event'
+        pagination:
+          $ref: '#/components/schemas/pagination'
+    webhooks-list-response:
+      title: Webhooks
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/webhook'
+        pagination:
+          $ref: '#/components/schemas/pagination'
+    webhooks-create-payload:
+      required:
+        - events
+        - url
+      type: object
+      properties:
+        events:
+          type: array
+          description: >-
+            A list of the webhooks that you are subscribing to. Currently
+            "video.encoding.quality.completed" is the only option.
+            video.encoding.quality.completed - a video encoding quality is ready
+            for the video (for example the 720p quality hls encoding video is
+            ready.)
+          example: video.encoding.quality.completed
+          items:
+            type: string
+        url:
+          type: string
+          description: >-
+            The the url to which HTTP notifications are sent. It could be any
+            http or https URL.
+          example: 'https://example.com/webhooks'
+      example:
+        events:
+          - video.encoding.quality.completed
+        url: 'http://clientnotificationserver.com/notif?myquery=query'
+    pagination_link:
+      type: object
+      title: PaginationLink
+      properties:
+        rel:
+          type: string
+          pattern: ^self$
+        uri:
+          type: string
+          format: uri
+    video_source_live_stream_link:
+      type: object
+      properties:
+        rel:
+          type: string
+        uri:
+          type: string
+    video_source_live_stream:
+      type: object
+      properties:
+        liveStreamId:
+          type: string
+          description: The unique identifier for the live stream.
+          example: li400mYKSgQ6xs7taUeSaEKr
+        links:
+          type: array
+          items:
+            $ref: '#/components/schemas/video_source_live_stream_link'
+      description: This appears if the video is from a Live Record.
+    videoSource:
+      type: object
+      properties:
+        uri:
+          type: string
+          description: The URL where the video is stored.
+          example: /videos/vi4k0jvEUuaTdRAEjQ4Prklg/source
+        type:
+          type: string
+        liveStream:
+          $ref: '#/components/schemas/video_source_live_stream'
+      description: Source information about the video.
+    videoAssets:
+      type: object
+      properties:
+        hls:
+          type: string
+          description: >-
+            This is the manifest URL. For HTTP Live Streaming (HLS), when a HLS
+            video stream is initiated, the first file to download is the
+            manifest. This file has the extension M3U8, and provides the video
+            player with information about the various bitrates available for
+            streaming.
+          format: uri
+        iframe:
+          type: string
+          description: Code to use video from a third party website
+          example: >-
+            <iframe
+            src="//embed.api.video/c188ed58-3403-46a2-b91b-44603d10b2c9?token=831a9bd9-9f50-464c-a369-8e9d914371ae"
+            width="100%" height="100%" frameborder="0" scrolling="no"
+            allowfullscreen=""></iframe>
+        player:
+          type: string
+          description: Raw url of the player.
+          format: uri
+          example: >-
+            https://embed.api.video/1b9d6ae8-8f57-4b6d-8552-d636926b4f5f?token=831a9bd9-9f50-464c-a369-8e9d914371ae
+        thumbnail:
+          type: string
+          description: Poster of the video.
+          format: uri
+          example: >-
+            https://cdn.api.video/stream/831a9bd9-9f50-464c-a369-8e9d914371ae/thumbnail.jpg
+        mp4:
+          type: string
+          description: Available only if mp4Support is enabled. Raw mp4 url.
+          format: uri
+          example: >-
+            https://cdn.api.video/vod/vi4k0jvEUuaTdRAEjQ4Jfrgz/token/8fd70443-d9f0-45d2-b01c-12c8cfc707c9/mp4/720/source.mp4
+      description: >-
+        Collection of details about the video object that you can use to work
+        with the video object.
+    video_session_session:
+      type: object
+      properties:
+        sessionId:
+          type: string
+          description: >-
+            The unique identifier for the session that you can use to track what
+            happens during it.
+          example: psEmFwGQUAXR2lFHj5nDOpy
+        loadedAt:
+          type: string
+          description: 'When the video session started, presented in ISO-8601 format.'
+          format: date-time
+          example: '2019-06-24T11:45:01.109+00'
+        endedAt:
+          type: string
+          description: 'When the video session ended, presented in ISO-8601 format.'
+          format: date-time
+          example: '2019-06-24T12:45:01.109+00'
+    video_session_location:
+      type: object
+      properties:
+        country:
+          type: string
+          description: The country of the viewer.
+          example: France
+        city:
+          type: string
+          description: The city of the viewer.
+          example: Paris
+      description: The location of the viewer.
+    video_session_referrer:
+      type: object
+      properties:
+        url:
+          type: string
+          description: The link the viewer used to reach the video session.
+          example: 'https://api.video'
+        medium:
+          type: string
+          description: >-
+            How they arrived at the site, for example organic or paid. Organic
+            meaning they found it themselves and paid meaning they followed a
+            link from an advertisement.
+          example: organic
+        source:
+          type: string
+          description: >-
+            The source the referrer came from to the video session. For example
+            if they searched through google to find the stream.
+          example: 'https://google.com'
+        searchTerm:
+          type: string
+          description: The search term they typed to arrive at the video session.
+    video_session_device:
+      type: object
+      properties:
+        type:
+          type: string
+          description: 'What the type is like desktop, laptop, mobile.'
+          example: desktop
+        vendor:
+          type: string
+          description: 'If known, what the brand of the device is, like Apple, Dell, etc.'
+          example: Dell
+        model:
+          type: string
+          description: 'The specific model of the device, if known.'
+          example: unknown
+      description: What type of device the user is on when in the video session.
+    video_session_os:
+      type: object
+      properties:
+        name:
+          type: string
+          description: The name of the operating system.
+          example: Microsoft Windows
+        shortname:
+          type: string
+          description: >-
+            The nickname for the operating system, often representing the
+            version.
+          example: W10
+        version:
+          type: string
+          description: The version of the operating system.
+          example: Windows 10
+      description: The operating system the viewer is on.
+    video_session_client:
+      type: object
+      properties:
+        name:
+          type: string
+          description: The name of the browser used to view the video session.
+          example: Firefox
+        version:
+          type: string
+          description: The version of the browser used to view the video session.
+          example: '67.0'
+        type:
+          type: string
+          description: The type of client used to view the video session.
+          example: browser
+      description: What kind of browser the viewer is using for the video session.
+    live_stream_assets:
+      type: object
+      properties:
+        hls:
+          type: string
+          description: The http live streaming (HLS) link for your live video stream.
+          format: uri
+          example: 'https://live.api.video/li4pqNqGUkhKfWcBGpZVLRY5.m3u8'
+        iframe:
+          type: string
+          description: The embed code for the iframe containing your live video stream.
+          example: >-
+            <iframe
+            src=\"https://embed.api.video/live/li4pqNqGUkhKfWcBGpZVLRY5\"
+            width=\"100%\" height=\"100%\" frameborder=\"0\" scrolling=\"no\"
+            allowfullscreen=\"\"></iframe>
+        player:
+          type: string
+          description: A link to the video player that is playing your live stream.
+          format: uri
+          example: 'https://embed.api.video/live/li400mYKSgQ6xs7taUeSaEKr'
+        thumbnail:
+          type: string
+          description: A link to the thumbnail for your video.
+          format: uri
+          example: 'https://cdn.api.video/live/li400mYKSgQ6xs7taUeSaEKr/thumbnail.jpg'
+    live_stream_session_session:
+      type: object
+      properties:
+        sessionId:
+          type: string
+          description: >-
+            A unique identifier for your session. You can use this to track what
+            happens during a specific session.
+        loadedAt:
+          type: string
+          description: >-
+            When the session started, with the date and time presented in
+            ISO-8601 format.
+          format: date-time
+          example: '2019-06-24T11:45:01.109+00'
+        endedAt:
+          type: string
+          description: >-
+            When the session ended, with the date and time presented in ISO-8601
+            format.
+          format: date-time
+          example: '2019-06-24T12:45:01.109+00'
+    live_stream_session_location:
+      type: object
+      properties:
+        country:
+          type: string
+          description: The country of the viewer of the live stream.
+          example: France
+        city:
+          type: string
+          description: The city of the viewer of the live stream.
+          example: Paris
+      description: The location of the viewer of the live stream.
+    live_stream_session_referrer:
+      type: object
+      properties:
+        url:
+          type: string
+          description: >-
+            The website the viewer of the live stream was referred to in order
+            to view the live stream.
+          example: 'https://api.video'
+        medium:
+          type: string
+          description: >-
+            The type of search that brought the viewer to the live stream.
+            Organic would be they found it on their own, paid would be they
+            found it via an advertisement.
+          example: organic
+        source:
+          type: string
+          description: >-
+            Where the viewer came from to see the live stream (usually where
+            they searched from).
+          example: 'https://google.com'
+        searchTerm:
+          type: string
+          description: What term they searched for that led them to the live stream.
+          example: video stream
+    live_stream_session_device:
+      type: object
+      properties:
+        type:
+          type: string
+          description: 'What the type is like desktop, laptop, mobile.'
+          example: desktop
+        vendor:
+          type: string
+          description: 'If known, what the brand of the device is, like Apple, Dell, etc.'
+          example: Dell
+        model:
+          type: string
+          description: 'The specific model of the device, if known.'
+          example: unknown
+      description: What type of device the user is on when in the live stream session.
+    live_stream_session_client:
+      type: object
+      properties:
+        name:
+          type: string
+          description: The name of the browser used to view the live stream session.
+          example: Firefox
+        version:
+          type: string
+          description: The version of the browser used to view the live stream session.
+          example: '67.0'
+        type:
+          type: string
+          description: The type of client used to view the live stream session.
+          example: browser
+      description: What kind of browser the viewer is using for the live stream session.
+    videostatus_ingest:
+      type: object
+      properties:
+        status:
+          type: string
+          description: >-
+            There are three possible ingest statuses. missing - you are missing
+            information required to ingest the video. uploading - the video is
+            in the process of being uploaded. uploaded - the video is ready for
+            use.
+          example: uploaded
+          enum:
+            - missing
+            - uploading
+            - uploaded
+        filesize:
+          type: integer
+          description: The size of your file in bytes.
+          example: 200000
+        receivedBytes:
+          type: array
+          description: >-
+            The total number of bytes received, listed for each chunk of the
+            upload.
+          items:
+            $ref: '#/components/schemas/bytes_range'
+      description: >-
+        Details about the capturing, transferring, and storing of your video for
+        use immediately or in the future.
+    videostatus_encoding_metadata:
+      type: object
+      properties:
+        width:
+          type: integer
+          description: The width of the video in pixels.
+        height:
+          type: integer
+          description: The height of the video in pixels.
+        bitrate:
+          type: number
+          description: The number of bits processed per second.
+        duration:
+          type: integer
+          description: The length of the video.
+        framerate:
+          type: integer
+          description: >-
+            The frequency with which consecutive images or frames appear on a
+            display. Shown in this API as frames per second (fps).
+          example: 60
+        samplerate:
+          type: integer
+          description: >-
+            How many samples per second a digital audio system uses to record an
+            audio signal. The higher the rate, the higher the frequencies that
+            can be recorded. They are presented in this API using hertz.
+          example: 48000
+        videoCodec:
+          type: string
+          description: >-
+            The method used to compress and decompress digital video. API Video
+            supports all codecs in the libavcodec library. 
+        audioCodec:
+          type: string
+          description: >-
+            The method used to compress and decompress digital audio for your
+            video.
+        aspectRatio:
+          type: string
+    videostatus_encoding:
+      type: object
+      properties:
+        playable:
+          type: boolean
+          description: Whether the video is playable or not.
+          example: true
+        qualities:
+          type: array
+          description: Available qualities the video can be viewed in.
+          items:
+            $ref: '#/components/schemas/quality'
+        metadata:
+          $ref: '#/components/schemas/videostatus_encoding_metadata'
+    account:
+      type: object
+      title: Account
+      deprecated: true
+      properties:
+        quota:
+          type: object
+          description: Deprecated
+          properties:
+            quotaUsed:
+              type: number
+              description: Deprecated
+            quotaRemaining:
+              type: number
+              description: Deprecated
+            quotaTotal:
+              type: number
+              description: Deprecated
+        features:
+          type: array
+          description: >-
+            Deprecated. What features are enabled for your account. Choices
+            include: app.dynamic_metadata - the ability to dynamically tag
+            videos to better segment and understand your audiences,
+            app.event_log - the ability to create and retrieve a log detailing
+            how your videos were interacted with, player.white_label - the
+            ability to customise your player, stats.player_events - the ability
+            to see statistics about how your player is being used,
+            transcode.mp4_support - the ability to reformat content into mp4
+            using the H264 codec.
+          example: '["app.dynamic_metadata, app.event_log"]'
+          items:
+            type: string
+        environment:
+          type: string
+          description: >-
+            Deprecated. Whether you are using your production or sandbox API key
+            will impact what environment is displayed here, as well as stats and
+            features information. If you use your sandbox key, the environment
+            is "sandbox." If you use your production key, the environment is
+            "production."
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+x-explorer-enabled: true
+x-proxy-enabled: true
+x-samples-enabled: true
+x-samples-languages:
+  - curl
+  - node
+  - ruby
+  - javascript
+  - python


### PR DESCRIPTION
- Main changes made in the JSON description:
   - add the x-* attributes (used by the clients generator, ignored elsewhere)
   - renames que “inline-xxx” schemas with more explicit labels
   - replaced “application/vnd.api.video+json” mimetype by standard json one
   - remove the “requestBodies” components (not well handled by generator)

- Added the YALM file that should be used now