### PR TITLE
Changes for API clients

### DIFF
--- a/oas_apivideo.yaml
+++ b/oas_apivideo.yaml
@@ -5,21 +5,22 @@ info:
   description: api.video is an API that encodes on the go to facilitate immediate playback, enhancing viewer streaming experiences across multiple devices and platforms. You can stream live or on-demand online videos within minutes.
   version: "1"
 servers:
-- url: https://ws.api.video
-  description: Production server
-- url: https://sandbox.api.video
-  description: Test server `all videos are watermarked, and deleted after 24 hours.
+  - url: https://ws.api.video
+    description: Production server
+  - url: https://sandbox.api.video
+    description: Test server `all videos are watermarked, and deleted after 24 hours.
 paths:
   /auth/api-key:
     post:
       tags:
-      - Authentication
+        - Authentication
       summary: Authenticate
       description: |-
         To get started, submit your API key in the body of your request. api.video returns an access token that is valid for one hour (3600 seconds). A refresh token is also returned. View a [tutorial](https://api.video/blog/tutorials/authentication-tutorial) on authentication.
         All tutorials using the [authentication endpoint](https://api.video/blog/endpoints/authenticate)
       operationId: POST_auth-api-key
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -55,38 +56,39 @@ paths:
       x-client-hidden: true
       x-readme:
         code-samples:
-        - language: go
-          code: |
-            //With the api.video API clients, authentication is taken care of with each client created.
-            // You get to skip this step!
-        - language: node
-          code: |
-            //With the api.video API clients, authentication is taken care of with each client created.
-            // You get to skip this step!
-        - language: php
-          code: |
-            //With the api.video API clients, authentication is taken care of with each client created.
-            // You get to skip this step!
-        - language: python
-          code: |
-            #With the api.video API clients, authentication is taken care of with each client created.
-            # You get to skip this step!
-        - language: java
-          code: |
-            //With the api.video API clients, authentication is taken care of with each client created.
-            // You get to skip this step!
-        - language: csharp
-          code: |
-            //With the api.video API clients, authentication is taken care of with each client created.
-            // You get to skip this step!
+          - language: go
+            code: |
+              //With the api.video API clients, authentication is taken care of with each client created.
+              // You get to skip this step!
+          - language: node
+            code: |
+              //With the api.video API clients, authentication is taken care of with each client created.
+              // You get to skip this step!
+          - language: php
+            code: |
+              //With the api.video API clients, authentication is taken care of with each client created.
+              // You get to skip this step!
+          - language: python
+            code: |
+              #With the api.video API clients, authentication is taken care of with each client created.
+              # You get to skip this step!
+          - language: java
+            code: |
+              //With the api.video API clients, authentication is taken care of with each client created.
+              // You get to skip this step!
+          - language: csharp
+            code: |
+              //With the api.video API clients, authentication is taken care of with each client created.
+              // You get to skip this step!
   /auth/refresh:
     post:
       tags:
-      - Authentication
+        - Authentication
       summary: Refresh token
       description: "Use the refresh endpoint with the refresh token you received when you first authenticated using the api-key endpoint. Send the refresh token in the body of your request. The api.video API returns a new access token that is valid for one hour (3600 seconds) and a new refresh token. \n"
       operationId: POST_auth-refresh
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -122,125 +124,108 @@ paths:
       x-client-hidden: true
       x-readme:
         code-samples:
-        - language: go
-          code: |
-            //With the api.video API clients, authentication is taken care of with each client created.
-            // You get to skip this step!
-        - language: node
-          code: |
-            //With the api.video API clients, authentication is taken care of with each client created.
-            // You get to skip this step!
-        - language: php
-          code: |
-            //With the api.video API clients, authentication is taken care of with each client created.
-            // You get to skip this step!
-        - language: python
-          code: |
-            #With the api.video API clients, authentication is taken care of with each client created.
-            # You get to skip this step!
-        - language: java
-          code: |
-            //With the api.video API clients, authentication is taken care of with each client created.
-            // You get to skip this step!
-        - language: csharp
-          code: |
-            //With the api.video API clients, authentication is taken care of with each client created.
-            // You get to skip this step!
+          - language: go
+            code: |
+              //With the api.video API clients, authentication is taken care of with each client created.
+              // You get to skip this step!
+          - language: node
+            code: |
+              //With the api.video API clients, authentication is taken care of with each client created.
+              // You get to skip this step!
+          - language: php
+            code: |
+              //With the api.video API clients, authentication is taken care of with each client created.
+              // You get to skip this step!
+          - language: python
+            code: |
+              #With the api.video API clients, authentication is taken care of with each client created.
+              # You get to skip this step!
+          - language: java
+            code: |
+              //With the api.video API clients, authentication is taken care of with each client created.
+              // You get to skip this step!
+          - language: csharp
+            code: |
+              //With the api.video API clients, authentication is taken care of with each client created.
+              // You get to skip this step!
   /videos:
     get:
       tags:
-      - Videos
+        - Videos
       summary: List all videos
       description: Requests to this endpoint return a list of your videos (with all their details). With no parameters added to this query, the API returns all videos. You can filter what videos the API returns using the parameters described below.  We have [several tutorials](https://api.video/blog/endpoints/video-list) that demonstrate this endpoint.
       operationId: LIST-videos
       parameters:
-      - name: title
-        in: query
-        description: The title of a specific video you want to find. The search will match exactly to what term you provide and return any videos that contain the same term as part of their titles.
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-        example: My Video.mp4
-      - name: tags
-        in: query
-        description: A tag is a category you create and apply to videos. You can search for videos with particular tags by listing one or more here. Only videos that have all the tags you list will be returned.
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: array
-          items:
+        - name: title
+          in: query
+          description: The title of a specific video you want to find. The search will match exactly to what term you provide and return any videos that contain the same term as part of their titles.
+          required: false
+          style: form
+          explode: true
+          schema:
             type: string
-        example: '"tags": ["captions", "dialogue"]'
-      - name: metadata
-        in: query
-        description: Videos can be tagged with metadata tags in key:value pairs. You can search for videos with specific key value pairs using this parameter. [Dynamic Metadata](https://api.video/blog/endpoints/dynamic-metadata) allows you to define a key that allows any value pair.
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: array
-          items:
+          example: My Video.mp4
+        - name: tags
+          in: query
+          description: A tag is a category you create and apply to videos. You can search for videos with particular tags by listing one or more here. Only videos that have all the tags you list will be returned.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+          example: '["captions", "dialogue"]'
+        - name: metadata
+          in: query
+          description: Videos can be tagged with metadata tags in key:value pairs. You can search for videos with specific key value pairs using this parameter. [Dynamic Metadata](https://api.video/blog/endpoints/dynamic-metadata) allows you to define a key that allows any value pair.
+          required: false
+          style: deepObject
+          x-is-deep-object: true
+          explode: true
+          schema:
+            type: object
+            additionalProperties:
+              type: string
+          example: metadata[Author]=John Doe&metadata[Format]=Tutorial
+        - name: description
+          in: query
+          description: If you described a video with a term or sentence, you can add it here to return videos containing this string.
+          required: false
+          style: form
+          explode: true
+          schema:
             type: string
-        example: '[{"key":"Author", "value":"John Doe"}, {"key":"Format", "value":"Tutorial"}]'
-      - name: description
-        in: query
-        description: If you described a video with a term or sentence, you can add it here to return videos containing this string.
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-        example: New Zealand
-      - name: liveStreamId
-        in: query
-        description: If you know the ID for a live stream, you can retrieve the stream by adding the ID for it here.
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-        example: li400mYKSgQ6xs7taUeSaEKr
-      - name: sortBy
-        in: query
-        description: 'Allowed: publishedAt, title. You can search by the time videos were published at, or by title.'
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-        example: publishedAt
-      - name: sortOrder
-        in: query
-        description: 'Allowed: asc, desc. asc is ascending and sorts from A to Z. desc is descending and sorts from Z to A.'
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-        example: asc
-      - name: currentPage
-        in: query
-        description: 'Choose the number of search results to return per page. Minimum value: 1'
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          default: 1
-        example: 2
-      - name: pageSize
-        in: query
-        description: Results per page. Allowed values 1-100, default is 25.
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          default: 25
-        example: 30
+          example: New Zealand
+        - name: liveStreamId
+          in: query
+          description: If you know the ID for a live stream, you can retrieve the stream by adding the ID for it here.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+          example: li400mYKSgQ6xs7taUeSaEKr
+        - name: sortBy
+          in: query
+          description: 'Allowed: publishedAt, title. You can search by the time videos were published at, or by title.'
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+          example: publishedAt
+        - name: sortOrder
+          in: query
+          description: 'Allowed: asc, desc. asc is ascending and sorts from A to Z. desc is descending and sorts from Z to A.'
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+          example: asc
+        - $ref: '#/components/parameters/current-page'
+        - $ref: '#/components/parameters/page-size'
       responses:
         "200":
           description: Success
@@ -252,81 +237,81 @@ paths:
                 response:
                   value:
                     data:
-                    - videoId: vi4blUQJFrYWbaG44NChkH27
-                      playerId: pl45KFKdlddgk654dspkze
-                      title: Maths video
-                      description: An amazing video explaining the string theory
-                      public: false
-                      panoramic: false
-                      mp4Support: true
-                      tags:
-                      - maths
-                      - string theory
-                      - video
-                      metadata:
-                      - key: Author
-                        value: John Doe
-                      - key: Format
-                        value: Tutorial
-                      publishedAt: 2019-12-16T08:25:51+00:00
-                      updateddAt: 2019-12-16T08:48:49+00:00
-                      source:
-                        uri: /videos/c188ed58-3403-46a2-b91b-44603d10b2c9/source
-                      assets:
-                        iframe: <iframe src="https://embed.api.video/vod/vi4blUQJFrYWbaG44NChkH27" width="100%" height="100%" frameborder="0" scrolling="no" allowfullscreen=""></iframe>
-                        player: https://embed.api.video/vod/vi4blUQJFrYWbaG44NChkH27
-                        hls: https://cdn.api.video/vod/vi4blUQJFrYWbaG44NChkH27/hls/manifest.m3u8
-                        thumbnail: https://cdn.api.video/vod/vi4blUQJFrYWbaG44NChkH27/thumbnail.jpg
-                        mp4: https://cdn.api.video/vod/vi4blUQJFrYWbaG44NChkH27/mp4/1080/source.mp4
-                    - videoId: vi4blUQJFrYWbaG44NChkH27
-                      title: Video Title
-                      description: A description for your video.
-                      public: false
-                      panoramic: false
-                      mp4Support: true
-                      tags:
-                      - books
-                      - short stories
-                      metadata:
-                      - key: Author
-                        value: John Doe
-                      - key: Science Fiction
-                        value: Cyberpunk
-                      - key: Technology
-                        value: Computers
-                      publishedAt: 2019-12-16T08:25:51+00:00
-                      updateddAt: 2019-12-16T08:48:49+00:00
-                      source:
-                        uri: /videos/vi4blUQJFrYWbaG44NChkH27/source
-                      assets:
-                        iframe: <iframe src="https://embed.api.video/vod/vi4blUQJFrYWbaG44NChkH27" width="100%" height="100%" frameborder="0" scrolling="no" allowfullscreen=""></iframe>
-                        player: https://embed.api.video/vod/vi4blUQJFrYWbaG44NChkH27
-                        hls: https://cdn.api.video/vod/vi4blUQJFrYWbaG44NChkH27/hls/manifest.m3u8
-                        thumbnail: https://cdn.api.video/vod/vi4blUQJFrYWbaG44NChkH27/thumbnail.jpg
-                        mp4: https://cdn.api.video/vod/vi4blUQJFrYWbaG44NChkH27/mp4/1080/source.mp4
-                    - videoId: vi4blUQJFrYWbaG44NChkH27
-                      playerId: pl45KFKdlddgk654dspkze
-                      title: My Video Title
-                      description: A brief description of the video.
-                      public: false
-                      panoramic: false
-                      mp4Support: true
-                      tags:
-                      - General
-                      - Videos
-                      metadata:
-                      - key: Length
-                        value: Short
-                      publishedAt: 2019-12-16T08:25:51+00:00
-                      updateddAt: 2019-12-16T08:48:49+00:00
-                      source:
-                        uri: /videos/vi4blUQJFrYWbaG44NChkH27/source
-                      assets:
-                        iframe: <iframe src="https://embed.api.video/vod/vi4blUQJFrYWbaG44NChkH27" width="100%" height="100%" frameborder="0" scrolling="no" allowfullscreen=""></iframe>
-                        player: https://embed.api.video/vod/vi4blUQJFrYWbaG44NChkH27
-                        hls: https://cdn.api.video/vod/vi4blUQJFrYWbaG44NChkH27/hls/manifest.m3u8
-                        thumbnail: https://cdn.api.video/vod/vi4blUQJFrYWbaG44NChkH27/thumbnail.jpg
-                        mp4: https://cdn.api.video/vod/vi4blUQJFrYWbaG44NChkH27/mp4/1080/source.mp4
+                      - videoId: vi4blUQJFrYWbaG44NChkH27
+                        playerId: pl45KFKdlddgk654dspkze
+                        title: Maths video
+                        description: An amazing video explaining the string theory
+                        public: false
+                        panoramic: false
+                        mp4Support: true
+                        tags:
+                          - maths
+                          - string theory
+                          - video
+                        metadata:
+                          - key: Author
+                            value: John Doe
+                          - key: Format
+                            value: Tutorial
+                        publishedAt: 2019-12-16T08:25:51+00:00
+                        updatedAt: 2019-12-16T08:48:49+00:00
+                        source:
+                          uri: /videos/c188ed58-3403-46a2-b91b-44603d10b2c9/source
+                        assets:
+                          iframe: <iframe src="https://embed.api.video/vod/vi4blUQJFrYWbaG44NChkH27" width="100%" height="100%" frameborder="0" scrolling="no" allowfullscreen=""></iframe>
+                          player: https://embed.api.video/vod/vi4blUQJFrYWbaG44NChkH27
+                          hls: https://cdn.api.video/vod/vi4blUQJFrYWbaG44NChkH27/hls/manifest.m3u8
+                          thumbnail: https://cdn.api.video/vod/vi4blUQJFrYWbaG44NChkH27/thumbnail.jpg
+                          mp4: https://cdn.api.video/vod/vi4blUQJFrYWbaG44NChkH27/mp4/1080/source.mp4
+                      - videoId: vi4blUQJFrYWbaG44NChkH27
+                        title: Video Title
+                        description: A description for your video.
+                        public: false
+                        panoramic: false
+                        mp4Support: true
+                        tags:
+                          - books
+                          - short stories
+                        metadata:
+                          - key: Author
+                            value: John Doe
+                          - key: Science Fiction
+                            value: Cyberpunk
+                          - key: Technology
+                            value: Computers
+                        publishedAt: 2019-12-16T08:25:51+00:00
+                        updatedAt: 2019-12-16T08:48:49+00:00
+                        source:
+                          uri: /videos/vi4blUQJFrYWbaG44NChkH27/source
+                        assets:
+                          iframe: <iframe src="https://embed.api.video/vod/vi4blUQJFrYWbaG44NChkH27" width="100%" height="100%" frameborder="0" scrolling="no" allowfullscreen=""></iframe>
+                          player: https://embed.api.video/vod/vi4blUQJFrYWbaG44NChkH27
+                          hls: https://cdn.api.video/vod/vi4blUQJFrYWbaG44NChkH27/hls/manifest.m3u8
+                          thumbnail: https://cdn.api.video/vod/vi4blUQJFrYWbaG44NChkH27/thumbnail.jpg
+                          mp4: https://cdn.api.video/vod/vi4blUQJFrYWbaG44NChkH27/mp4/1080/source.mp4
+                      - videoId: vi4blUQJFrYWbaG44NChkH27
+                        playerId: pl45KFKdlddgk654dspkze
+                        title: My Video Title
+                        description: A brief description of the video.
+                        public: false
+                        panoramic: false
+                        mp4Support: true
+                        tags:
+                          - General
+                          - Videos
+                        metadata:
+                          - key: Length
+                            value: Short
+                        publishedAt: 2019-12-16T08:25:51+00:00
+                        updatedAt: 2019-12-16T08:48:49+00:00
+                        source:
+                          uri: /videos/vi4blUQJFrYWbaG44NChkH27/source
+                        assets:
+                          iframe: <iframe src="https://embed.api.video/vod/vi4blUQJFrYWbaG44NChkH27" width="100%" height="100%" frameborder="0" scrolling="no" allowfullscreen=""></iframe>
+                          player: https://embed.api.video/vod/vi4blUQJFrYWbaG44NChkH27
+                          hls: https://cdn.api.video/vod/vi4blUQJFrYWbaG44NChkH27/hls/manifest.m3u8
+                          thumbnail: https://cdn.api.video/vod/vi4blUQJFrYWbaG44NChkH27/thumbnail.jpg
+                          mp4: https://cdn.api.video/vod/vi4blUQJFrYWbaG44NChkH27/mp4/1080/source.mp4
                     pagination:
                       currentPage: 1
                       pageSize: 25
@@ -334,12 +319,12 @@ paths:
                       itemsTotal: 11
                       currentPageItems: 11
                       links:
-                      - rel: self
-                        uri: https://ws.api.video/videos?currentPage=1
-                      - rel: first
-                        uri: https://ws.api.video/videos?currentPage=1
-                      - rel: last
-                        uri: https://ws.api.video/videos?currentPage=1
+                        - rel: self
+                          uri: https://ws.api.video/videos?currentPage=1
+                        - rel: first
+                          uri: https://ws.api.video/videos?currentPage=1
+                        - rel: last
+                          uri: https://ws.api.video/videos?currentPage=1
         "400":
           description: Bad Request
           content:
@@ -355,23 +340,51 @@ paths:
                     range:
                       min: 1
                     problems:
-                    - title: This parameter is out of the allowed range of values.
-                      name: page
-                      range:
-                        min: 1
-                    - title: This parameter is out of the allowed range of values.
-                      name: pageSize
-                      range:
-                        min: 10
-                        max: 100
+                      - title: This parameter is out of the allowed range of values.
+                        name: page
+                        range:
+                          min: 1
+                      - title: This parameter is out of the allowed range of values.
+                        name: pageSize
+                        range:
+                          min: 10
+                          max: 100
       security:
-      - bearerAuth: []
+        - bearerAuth: []
+      x-readme:
+        code-samples:
+          - language: php
+            code: |
+              <?php
+
+              require __DIR__ . '/vendor/autoload.php';
+
+              $httpClient = new \Symfony\Component\HttpClient\Psr18Client();
+              $client = new \ApiVideo\Client(
+                                  'https://sandbox.api.video',
+                                  'YOUR_API_TOKEN',
+                                  $httpClient
+                              );
+
+              // list all videos (all pages)
+              $allVideos = [];
+              do {
+                  $currentPage = $client->videos()->list([]);
+                  $allVideos = array_merge($allVideos, $currentPage->getData());
+              } while($currentPage->getPagination()->getCurrentPage() < $currentPage->getPagination()->getPagesTotal());
+
+              // list videos that have all the given tags (only first results page)
+              $videosWithTag = $client->videos()->list(['tags' => ['TAG2','TAG1']]);
+
+              // list videos that have all the given metadata values (only first results page)
+              $videosWithMetadata = $client->videos()->list(['metadata' => ['key1' => 'key1value1', 'key2' => 'key2value1']]);
       x-client-action: list
       x-group-parameters: true
       x-client-paginated: true
+      x-optional-object: true
     post:
       tags:
-      - Videos
+        - Videos
       summary: Create a video
       description: |2
 
@@ -388,10 +401,11 @@ paths:
       operationId: POST-video
       requestBody:
         description: video to create
+        required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/video-create-payload'
+              $ref: '#/components/schemas/video-creation-payload'
       responses:
         "201":
           description: Created
@@ -410,14 +424,14 @@ paths:
                     mp4Support: true
                     playerId: pl4k0jvEUuaTdRAEjQ4Jfrgz
                     tags:
-                    - maths
-                    - string theory
-                    - video
+                      - maths
+                      - string theory
+                      - video
                     metadata:
-                    - key: Author
-                      value: John Doe
-                    - key: Format
-                      value: Tutorial
+                      - key: Author
+                        value: John Doe
+                      - key: Format
+                        value: Tutorial
                     publishedAt: 4665-07-14T23:36:18.598Z
                     source:
                       uri: /videos/vi4blUQJFrYWbaG44NChkH27/source
@@ -447,122 +461,130 @@ paths:
                     name: title
                     status: 400
                     problems:
-                    - type: https://docs.api.video/docs/attributerequired
-                      title: This attribute is required.
-                      name: title
-                    - type: https://docs.api.video/docs/attributeinvalid
-                      title: This attribute must be a ISO8601 date.
-                      name: scheduledAt
-                    - type: https://docs.api.video/docs/attributeinvalid
-                      title: This attribute must be an array.
-                      name: tags
-                    - type: https://docs.api.video/docs/attributeinvalid
-                      title: This attribute must be an array.
-                      name: metadata
+                      - type: https://docs.api.video/docs/attributerequired
+                        title: This attribute is required.
+                        name: title
+                      - type: https://docs.api.video/docs/attributeinvalid
+                        title: This attribute must be a ISO8601 date.
+                        name: scheduledAt
+                      - type: https://docs.api.video/docs/attributeinvalid
+                        title: This attribute must be an array.
+                        name: tags
+                      - type: https://docs.api.video/docs/attributeinvalid
+                        title: This attribute must be an array.
+                        name: metadata
       security:
-      - bearerAuth: []
+        - bearerAuth: []
       x-client-action: create
       x-readme:
         code-samples:
-        - language: go
-          code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\n\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    videoCreationPayload := *apivideosdk.NewVideoCreationPayload(\"Maths video\") // VideoCreationPayload | video to create\n\n    \n    res, err := client.Videos.Create(videoCreationPayload)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `Videos.Create``: %v\\n\", err)\n    }\n    // response from `Create`: Video\n    fmt.Fprintf(os.Stdout, \"Response from `Videos.Create`: %v\\n\", res)\n}\n"
-        - language: node
-          code: "//install the module with npm or yarn\n//npm install @api.video/nodejs-client --save\n//yarn add @api.video/nodejs-client\nconst client = new ApiVideoClient({ apiKey: \"YOUR_API_TOKEN\" });\nconst videoCreationPayload = {\n  title: \"Maths video\", // The title of your new video.\n  description: \"A video about string theory.\", // A brief description of your video.\n  source: \"https://www.myvideo.url.com/video.mp4\", // If you add a video already on the web, this is where you enter the url for the video.\n  _public: true, // Whether your video can be viewed by everyone, or requires authentication to see it. A setting of false will require a unique token for each view.\n  panoramic: false, // Indicates if your video is a 360/immersive video.\n  mp4Support: true, // Enables mp4 version in addition to streamed version.\n  playerId: \"pl45KFKdlddgk654dspkze\", // The unique identification number for your video player.\n  tags: [\"maths\", \"string theory\", \"video\"], // A list of tags you want to use to describe your video.\n  metadata: [{\"key\": \"Author\", \"value\": \"John Doe\"}], // A list of key value pairs that you use to provide metadata for your video. These pairs can be made dynamic, allowing you to segment your audience. You can also just use the pairs as another way to tag and categorize your videos.\n}; \n\n// Video\nconst result = await client.videos.create(videoCreationPayload);\n"
-        - language: php
-          code: |
-            //install the PHP client
-            //composer require api-video/php-api-client
-            $httpClient = new \Symfony\Component\HttpClient\Psr18Client();
-            $client = new \ApiVideo\Client(
-                'https://sandbox.api.video',
-                'YOUR_API_TOKEN',
-                $httpClient
-            );
-            $payload = (new VideoCreationPayload())
-                ->setTitle('Test video creation');
+          - language: go
+            code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\n\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    videoCreationPayload := *apivideosdk.NewVideoCreationPayload(\"Maths video\") // VideoCreationPayload | video to create\n\n    \n    res, err := client.Videos.Create(videoCreationPayload)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `Videos.Create``: %v\\n\", err)\n    }\n    // response from `Create`: Video\n    fmt.Fprintf(os.Stdout, \"Response from `Videos.Create`: %v\\n\", res)\n}\n"
+          - language: node
+            code: "//install the module with npm or yarn\n//npm install @api.video/nodejs-client --save\n//yarn add @api.video/nodejs-client\nconst client = new ApiVideoClient({ apiKey: \"YOUR_API_TOKEN\" });\nconst videoCreationPayload = {\n  title: \"Maths video\", // The title of your new video.\n  description: \"A video about string theory.\", // A brief description of your video.\n  source: \"https://www.myvideo.url.com/video.mp4\", // If you add a video already on the web, this is where you enter the url for the video.\n  _public: true, // Whether your video can be viewed by everyone, or requires authentication to see it. A setting of false will require a unique token for each view.\n  panoramic: false, // Indicates if your video is a 360/immersive video.\n  mp4Support: true, // Enables mp4 version in addition to streamed version.\n  playerId: \"pl45KFKdlddgk654dspkze\", // The unique identification number for your video player.\n  tags: [\"maths\", \"string theory\", \"video\"], // A list of tags you want to use to describe your video.\n  metadata: [{\"key\": \"Author\", \"value\": \"John Doe\"}], // A list of key value pairs that you use to provide metadata for your video. These pairs can be made dynamic, allowing you to segment your audience. You can also just use the pairs as another way to tag and categorize your videos.\n}; \n\n// Video\nconst result = await client.videos.create(videoCreationPayload);\n"
+          - language: php
+            code: |
+              <?php
 
-            $video = $client->videos()->create($payload);
-        - language: python
-          code: |
-            #install the api.video API client library
-            #pip install api.video
-            import apivideo
-            from apivideo.api import videos_api
-            from apivideo.model.video_creation_payload import VideoCreationPayload
-            from apivideo.model.bad_request import BadRequest
-            from apivideo.model.video import Video
-            from pprint import pprint
+              use ApiVideo\Client\Model\Metadata;
+              use ApiVideo\Client\Model\VideoCreationPayload;
 
-            # Enter a context with an instance of the API client
-            with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
-                # Create an instance of the API class
-                api_instance = videos_api.VideosApi(api_client)
-                video_creation_payload = VideoCreationPayload(
-                    title="Maths video",
-                    description="A video about string theory.",
-                    source="https://www.myvideo.url.com/video.mp4",
-                    public=True,
-                    panoramic=False,
-                    mp4_support=True,
-                    player_id="pl45KFKdlddgk654dspkze",
-                    tags=["maths", "string theory", "video"],
-                    metadata=[
-                        Metadata(
-                            key="Color",
-                            value="Green",
-                        ),
-                    ],
-                ) # VideoCreationPayload | video to create
+              require __DIR__ . '/vendor/autoload.php';
 
-                # example passing only required values which don't have defaults set
-                try:
-                    # Create a video
-                    api_response = api_instance.create(video_creation_payload)
-                    pprint(api_response)
-                except apivideo.ApiException as e:
-                    print("Exception when calling VideosApi->create: %s\n" % e)
-        - language: java
-          code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.VideosApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    VideosApi apiInstance = client.videos();\n    \n    VideoCreationPayload videoCreationPayload = new VideoCreationPayload(); // video to create\n    videoCreationPayload.setTitle(\"Maths video\"); // The title of your new video.\n    videoCreationPayload.setDescription(\"A video about string theory.\"); // A brief description of your video.\n    videoCreationPayload.setSource(\"https://www.myvideo.url.com/video.mp4\"); // If you add a video already on the web, this is where you enter the url for the video.\n    videoCreationPayload.setPublic(true); // Whether your video can be viewed by everyone, or requires authentication to see it. A setting of false will require a unique token for each view.\n    videoCreationPayload.setPanoramic(false); // Indicates if your video is a 360/immersive video.\n    videoCreationPayload.setMp4Support(true); // Enables mp4 version in addition to streamed version.\n    videoCreationPayload.setPlayerId(\"pl45KFKdlddgk654dspkze\"); // The unique identification number for your video player.\n    videoCreationPayload.setTags(Arrays.asList(\"maths\", \"string theory\", \"video\")); // A list of tags you want to use to describe your video.\n    videoCreationPayload.setMetadata(Collections.<Metadata>emptyList()); // A list of key value pairs that you use to provide metadata for your video. These pairs can be made dynamic, allowing you to segment your audience. You can also just use the pairs as another way to tag and categorize your videos.\n\n\n    try {\n      Video result = apiInstance.create(videoCreationPayload);\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling VideosApi#create\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
-        - language: csharp
-          code: |
-            //install via Nuget
-            //Install-Package ApiVideo
+              $httpClient = new \Symfony\Component\HttpClient\Psr18Client();
+              $client = new \ApiVideo\Client(
+                                  'https://sandbox.api.video',
+                                  'YOUR_API_TOKEN',
+                                  $httpClient
+                              );
 
-            using System.Diagnostics;
-            using ApiVideo.Client;
+              $myVideo = $client->videos()->create((new VideoCreationPayload())
+                  ->setTitle('Video B')
+                  ->setTags(array("TAG1", "TAG2"))
+                  ->setMetadata(array(
+                      new Metadata(['key' => 'key1', 'value' => 'key1value1']),
+                      new Metadata(['key' => 'key2', 'value' => 'key2value1']))));
+          - language: python
+            code: |
+              #install the api.video API client library
+              #pip install api.video
+              import apivideo
+              from apivideo.api import videos_api
+              from apivideo.model.video_creation_payload import VideoCreationPayload
+              from apivideo.model.bad_request import BadRequest
+              from apivideo.model.video import Video
+              from pprint import pprint
 
-            namespace Example
-            {
-                public class createExample
-                {
-                    public static void Main()
-                    {
-                        var basePath = ApiVideoClient.Client.Environment.SANDBOX;
-                        var apiKey = "YOUR_API_KEY";
+              # Enter a context with an instance of the API client
+              with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
+                  # Create an instance of the API class
+                  api_instance = videos_api.VideosApi(api_client)
+                  video_creation_payload = VideoCreationPayload(
+                      title="Maths video",
+                      description="A video about string theory.",
+                      source="https://www.myvideo.url.com/video.mp4",
+                      public=True,
+                      panoramic=False,
+                      mp4_support=True,
+                      player_id="pl45KFKdlddgk654dspkze",
+                      tags=["maths", "string theory", "video"],
+                      metadata=[
+                          Metadata(
+                              key="Color",
+                              value="Green",
+                          ),
+                      ],
+                  ) # VideoCreationPayload | video to create
 
-                        var apiInstance = new ApiVideoClient(apiKey,basePath);
+                  # example passing only required values which don't have defaults set
+                  try:
+                      # Create a video
+                      api_response = api_instance.create(video_creation_payload)
+                      pprint(api_response)
+                  except apivideo.ApiException as e:
+                      print("Exception when calling VideosApi->create: %s\n" % e)
+          - language: java
+            code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.VideosApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    VideosApi apiInstance = client.videos();\n    \n    VideoCreationPayload videoCreationPayload = new VideoCreationPayload(); // video to create\n    videoCreationPayload.setTitle(\"Maths video\"); // The title of your new video.\n    videoCreationPayload.setDescription(\"A video about string theory.\"); // A brief description of your video.\n    videoCreationPayload.setSource(\"https://www.myvideo.url.com/video.mp4\"); // If you add a video already on the web, this is where you enter the url for the video.\n    videoCreationPayload.setPublic(true); // Whether your video can be viewed by everyone, or requires authentication to see it. A setting of false will require a unique token for each view.\n    videoCreationPayload.setPanoramic(false); // Indicates if your video is a 360/immersive video.\n    videoCreationPayload.setMp4Support(true); // Enables mp4 version in addition to streamed version.\n    videoCreationPayload.setPlayerId(\"pl45KFKdlddgk654dspkze\"); // The unique identification number for your video player.\n    videoCreationPayload.setTags(Arrays.asList(\"maths\", \"string theory\", \"video\")); // A list of tags you want to use to describe your video.\n    videoCreationPayload.setMetadata(Collections.<Metadata>emptyList()); // A list of key value pairs that you use to provide metadata for your video. These pairs can be made dynamic, allowing you to segment your audience. You can also just use the pairs as another way to tag and categorize your videos.\n\n\n    try {\n      Video result = apiInstance.create(videoCreationPayload);\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling VideosApi#create\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
+          - language: csharp
+            code: |
+              //install via Nuget
+              //Install-Package ApiVideo
 
-                        var videoCreationPayload = new VideoCreationPayload(); // VideoCreationPayload | video to create
-                        var apiVideosInstance = apiInstance.Videos();
-                        try
-                        {
-                            // Create a video
-                            Video result = apiVideosInstance.create(videoCreationPayload);
-                            Debug.WriteLine(result);
-                        }
-                        catch (ApiException  e)
-                        {
-                            Debug.Print("Exception when calling VideosApi.create: " + e.Message );
-                            Debug.Print("Status Code: "+ e.ErrorCode);
-                            Debug.Print(e.StackTrace);
-                        }
-                    }
-                }
-            }
+              using System.Diagnostics;
+              using ApiVideo.Client;
+
+              namespace Example
+              {
+                  public class createExample
+                  {
+                      public static void Main()
+                      {
+                          var basePath = ApiVideoClient.Client.Environment.SANDBOX;
+                          var apiKey = "YOUR_API_KEY";
+
+                          var apiInstance = new ApiVideoClient(apiKey,basePath);
+
+                          var videoCreationPayload = new VideoCreationPayload(); // VideoCreationPayload | video to create
+                          var apiVideosInstance = apiInstance.Videos();
+                          try
+                          {
+                              // Create a video
+                              Video result = apiVideosInstance.create(videoCreationPayload);
+                              Debug.WriteLine(result);
+                          }
+                          catch (ApiException  e)
+                          {
+                              Debug.Print("Exception when calling VideosApi.create: " + e.Message );
+                              Debug.Print("Status Code: "+ e.ErrorCode);
+                              Debug.Print(e.StackTrace);
+                          }
+                      }
+                  }
+              }
   /videos/{videoId}/source:
     post:
       tags:
-      - Videos
+        - Videos
       summary: Upload a video
       description: |-
         To upload a video to the videoId you created. Replace {videoId} with the id you'd like to use, {access_token} with your token, and /path/to/video.mp4 with the path to the video you'd like to upload. You can only upload your video to the videoId once.
@@ -575,27 +597,28 @@ paths:
         Tutorials using [video upload](https://api.video/blog/endpoints/video-upload).
       operationId: POST_videos-videoId-source
       parameters:
-      - name: videoId
-        in: path
-        description: Enter the videoId you want to use to upload your video.
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-        example: vi4k0jvEUuaTdRAEjQ4Jfrgz
-      - name: Content-Range
-        in: header
-        description: Content-Range represents the range of bytes that will be returned as a result of the request. Byte ranges are inclusive, meaning that bytes 0-999 represents the first 1000 bytes in a file or object.
-        required: false
-        style: simple
-        explode: false
-        schema:
-          pattern: ^bytes [0-9]*-[0-9]*\/[0-9]*$
-          type: string
-        example: 'Content-Range: bytes 200-100/5000'
-        x-client-ignore: true
+        - name: videoId
+          in: path
+          description: Enter the videoId you want to use to upload your video.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: vi4k0jvEUuaTdRAEjQ4Jfrgz
+        - name: Content-Range
+          in: header
+          description: Content-Range represents the range of bytes that will be returned as a result of the request. Byte ranges are inclusive, meaning that bytes 0-999 represents the first 1000 bytes in a file or object.
+          required: false
+          style: simple
+          explode: false
+          schema:
+            pattern: ^bytes [0-9]*-[0-9]*\/[0-9]*$
+            type: string
+          example: 'Content-Range: bytes 200-100/5000'
+          x-client-ignore: true
       requestBody:
+        required: true
         content:
           multipart/form-data:
             schema:
@@ -606,6 +629,7 @@ paths:
           content:
             application/json:
               schema:
+                type: object
                 $ref: '#/components/schemas/video'
               examples:
                 response:
@@ -618,15 +642,15 @@ paths:
                     mp4Support: true
                     playerId: pl45KFKdlddgk654dspkze
                     tags:
-                    - maths
-                    - string theory
-                    - video
+                      - maths
+                      - string theory
+                      - video
                     metadata:
-                    - key: Author
-                      value: John Doe
-                    - key: Format
-                      value: Tutorial
-                    publishedAt: 4665-07-14T23:36:18.598Z
+                      - key: Author
+                        value: John Doe
+                      - key: Format
+                        value: Tutorial
+                    publishedAt: 4665-07-14T23:36:18.598+00:00
                     source:
                       uri: /videos/vi4blUQJFrYWbaG44NChkH27/source
                     assets:
@@ -649,18 +673,18 @@ paths:
                     name: file
                     status: 400
                     problems:
-                    - type: https://docs.api.video/docs/filealreadyuploaded
-                      title: The source of the video is already uploaded.
-                      name: file
-                    - type: https://docs.api.video/docs/filealreadyuploaded
-                      title: The video xxxx has already been uploaded.
-                      name: video
-                    - type: https://docs.api.video/docs/filemissing
-                      title: There is no uploaded file in the request.
-                      name: file
-                    - type: https://docs.api.video/docs/multiplefilesuploaded
-                      title: There is more than one uploaded file in the request.
-                      name: file
+                      - type: https://docs.api.video/docs/filealreadyuploaded
+                        title: The source of the video is already uploaded.
+                        name: file
+                      - type: https://docs.api.video/docs/filealreadyuploaded
+                        title: The video xxxx has already been uploaded.
+                        name: video
+                      - type: https://docs.api.video/docs/filemissing
+                        title: There is no uploaded file in the request.
+                        name: file
+                      - type: https://docs.api.video/docs/multiplefilesuploaded
+                        title: There is more than one uploaded file in the request.
+                        name: file
         "404":
           description: Not Found
           content:
@@ -675,151 +699,161 @@ paths:
                     name: videoId
                     status: 404
       security:
-      - bearerAuth: []
+        - bearerAuth: []
       x-client-action: upload
       x-client-chunk-upload: true
       x-readme:
         code-samples:
-        - language: go
-          code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\n\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n\n      videoId := \"vi4k0jvEUuaTdRAEjQ4Jfrgz\" \n    // string | Enter the videoId you want to use to upload your video.\n      file := os.NewFile(1234, \"some_file\") \n    // *os.File | The path to the video you would like to upload. The path must be local. If you want to use a video from an online source, you must use the \\\\\\\"/videos\\\\\\\" endpoint and add the \\\\\\\"source\\\\\\\" parameter when you create a new video.\n    \n    \n      res, err := client.Videos.UploadFile(videoId, file)\n    \n      // you can also use a Reader instead of a File:\n      // client.Videos.Upload(videoId, fileName, fileReader, fileSize)\n    \n      if err != nil {\n          fmt.Fprintf(os.Stderr, \"Error when calling `Videos.Upload``: %v\\n\", err)\n      }\n      // response from `Upload`: Video\n      fmt.Fprintf(os.Stdout, \"Response from `Videos.Upload`: %v\\n\", res)\n    }\n      }\n"
-        - language: node
-          code: "//install the module with npm or yarn\n//npm install @api.video/nodejs-client --save\n//yarn add @api.video/nodejs-client\n(async () => {\n    try {\n      const client = new ApiVideoClient({ apiKey: \"YOUR_API_TOKEN\" });\n      \n      const videoId = 'vi4k0jvEUuaTdRAEjQ4Jfrgz'; // Enter the videoId you want to use to upload your video.\n      const file = 'BINARY_DATA_HERE'; // The path to the video you would like to upload. The path must be local. If you want to use a video from an online source, you must use the \\\\\\\"/videos\\\\\\\" endpoint and add the \\\\\\\"source\\\\\\\" parameter when you create a new video.\n      \n      // Video\n      const result = await client.videos.upload(videoId, file);\n      console.log(result);\n    } catch (e) {\n        console.error(e);\n    }\n})();\n"
-        - language: php
-          code: |
-            //install the PHP client
-            //composer require api-video/php-api-client
-            $httpClient = new \Symfony\Component\HttpClient\Psr18Client();
-            $client = new \ApiVideo\Client(
-                'https://sandbox.api.video',
-                'YOUR_API_TOKEN',
-                $httpClient
-            );
-            $payload = (new VideoCreationPayload())
-            ->setTitle('Test video creation');
+          - language: go
+            code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\n\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n\n      videoId := \"vi4k0jvEUuaTdRAEjQ4Jfrgz\" \n    // string | Enter the videoId you want to use to upload your video.\n      file := os.NewFile(1234, \"some_file\") \n    // *os.File | The path to the video you would like to upload. The path must be local. If you want to use a video from an online source, you must use the \\\\\\\"/videos\\\\\\\" endpoint and add the \\\\\\\"source\\\\\\\" parameter when you create a new video.\n    \n    \n      res, err := client.Videos.UploadFile(videoId, file)\n    \n      // you can also use a Reader instead of a File:\n      // client.Videos.Upload(videoId, fileName, fileReader, fileSize)\n    \n      if err != nil {\n          fmt.Fprintf(os.Stderr, \"Error when calling `Videos.Upload``: %v\\n\", err)\n      }\n      // response from `Upload`: Video\n      fmt.Fprintf(os.Stdout, \"Response from `Videos.Upload`: %v\\n\", res)\n    }\n      }\n"
+          - language: node
+            code: "//install the module with npm or yarn\n//npm install @api.video/nodejs-client --save\n//yarn add @api.video/nodejs-client\n(async () => {\n    try {\n      const client = new ApiVideoClient({ apiKey: \"YOUR_API_TOKEN\" });\n      \n      const videoId = 'vi4k0jvEUuaTdRAEjQ4Jfrgz'; // Enter the videoId you want to use to upload your video.\n      const file = 'BINARY_DATA_HERE'; // The path to the video you would like to upload. The path must be local. If you want to use a video from an online source, you must use the \\\\\\\"/videos\\\\\\\" endpoint and add the \\\\\\\"source\\\\\\\" parameter when you create a new video.\n      \n      // Video\n      const result = await client.videos.upload(videoId, file);\n      console.log(result);\n    } catch (e) {\n        console.error(e);\n    }\n})();\n"
+          - language: php
+            code: |
+              <?php
 
-            $video = $client->videos()->create($payload);
+              use ApiVideo\Client\Model\VideoCreationPayload;
 
-            $this->client->videos()->upload(
-                $video->getVideoId(),
-                new SplFileObject(__DIR__.'/../earth.mp4')
-            );
-        - language: python
-          code: |
-            #install the api.video API client library
-            #pip install api.video
+              require __DIR__ . '/vendor/autoload.php';
 
-            import apivideo
-            from apivideo.api import videos_api
-            from apivideo.model.bad_request import BadRequest
-            from apivideo.model.not_found import NotFound
-            from apivideo.model.video import Video
-            from apivideo.configuration import Configuration
-            from pprint import pprint
+              $httpClient = new \Symfony\Component\HttpClient\Psr18Client();
+              $client = new \ApiVideo\Client(
+                                  'https://sandbox.api.video',
+                                  'YOUR_API_TOKEN',
+                                  $httpClient
+                              );
 
-            # Enter a context with an instance of the API client
-            # When uploading a file you can change the chunk size (in octet)
-            configuration = Configuration(chunk_size=10 * 1024 * 1024)
-            with apivideo.AuthenticatedApiClient(__API_KEY__, configuration=configuration) as api_client:
-                # Create an instance of the API class
-                api_instance = videos_api.VideosApi(api_client)
-                video_id = "vi4k0jvEUuaTdRAEjQ4Jfrgz" # str | Enter the videoId you want to use to upload your video.
-                file = open('/path/to/file', 'rb') # file_type | The path to the video you would like to upload. The path must be local. If you want to use a video from an online source, you must use the \\\"/videos\\\" endpoint and add the \\\"source\\\" parameter when you create a new video.
+              // create a new video & upload a video file
+              $myVideo = $client->videos()->create((new VideoCreationPayload())->setTitle('Uploaded video'));
+              $client->videos()->upload($myVideo->getVideoId(), new SplFileObject(__DIR__ . '/../../../tests/resources/558k.mp4'));
 
-                # example passing only required values which don't have defaults set
-                try:
-                    # Upload a video
-                    api_response = api_instance.upload(video_id, file)
-                    pprint(api_response)
-                except apivideo.ApiException as e:
-                    print("Exception when calling VideosApi->upload: %s\n" % e)
-        - language: java
-          code: |
-            //dependency addition instructions
-            //https://github.com/apivideo/java-api-client
-            // Import classes:
-            import video.api.client.ApiVideoClient;
-            import video.api.client.api.ApiException;
-            import video.api.client.api.models.*;
-            import video.api.client.api.clients.VideosApi;
-            import java.util.*;
+              // create a new video & upload a video file using progressive upload (the file is uploaded by parts)
+              $myVideo2 = $client->videos()->create((new VideoCreationPayload())->setTitle('Uploaded video (progressive upload)'));
 
-            public class Example {
-              public static void main(String[] args) {
-                ApiVideoClient client = new ApiVideoClient("YOUR_API_TOKEN");
-                // if you rather like to use the sandbox environment:
-                // ApiVideoClient client = new ApiVideoClient("YOU_SANDBOX_API_TOKEN", ApiVideoClient.Environment.SANDBOX);
+              $progressiveSession = $client->videos()->createUploadProgressiveSession($myVideo2->getVideoId());
 
-                VideosApi apiInstance = client.videos();
+              $progressiveSession->uploadPart(new SplFileObject(__DIR__ . '/../../../tests/resources/10m.mp4.part.a'));
+              $progressiveSession->uploadPart(new SplFileObject(__DIR__ . '/../../../tests/resources/10m.mp4.part.b'));
 
-                String videoId = "vi4k0jvEUuaTdRAEjQ4Jfrgz"; // Enter the videoId you want to use to upload your video.
-                File file = new File("/path/to/file"); // The path to the video you would like to upload. The path must be local. If you want to use a video from an online source, you must use the \\\"/videos\\\" endpoint and add the \\\"source\\\" parameter when you create a new video.
+              $progressiveSession->uploadLastPart(new SplFileObject(__DIR__ . '/../../../tests/resources/10m.mp4.part.c'));
+          - language: python
+            code: |
+              #install the api.video API client library
+              #pip install api.video
 
-                try {
-                  Video result = apiInstance.upload(videoId, file);
-                  System.out.println(result);
-                } catch (ApiException e) {
-                  System.err.println("Exception when calling VideosApi#upload");
-                  System.err.println("Status code: " + e.getCode());
-                  System.err.println("Reason: " + e.getMessage());
-                  System.err.println("Response headers: " + e.getResponseHeaders());
-                  e.printStackTrace();
+              import apivideo
+              from apivideo.api import videos_api
+              from apivideo.model.bad_request import BadRequest
+              from apivideo.model.not_found import NotFound
+              from apivideo.model.video import Video
+              from apivideo.configuration import Configuration
+              from pprint import pprint
+
+              # Enter a context with an instance of the API client
+              # When uploading a file you can change the chunk size (in octet)
+              configuration = Configuration(chunk_size=10 * 1024 * 1024)
+              with apivideo.AuthenticatedApiClient(__API_KEY__, configuration=configuration) as api_client:
+                  # Create an instance of the API class
+                  api_instance = videos_api.VideosApi(api_client)
+                  video_id = "vi4k0jvEUuaTdRAEjQ4Jfrgz" # str | Enter the videoId you want to use to upload your video.
+                  file = open('/path/to/file', 'rb') # file_type | The path to the video you would like to upload. The path must be local. If you want to use a video from an online source, you must use the \\\"/videos\\\" endpoint and add the \\\"source\\\" parameter when you create a new video.
+
+                  # example passing only required values which don't have defaults set
+                  try:
+                      # Upload a video
+                      api_response = api_instance.upload(video_id, file)
+                      pprint(api_response)
+                  except apivideo.ApiException as e:
+                      print("Exception when calling VideosApi->upload: %s\n" % e)
+          - language: java
+            code: |
+              //dependency addition instructions
+              //https://github.com/apivideo/java-api-client
+              // Import classes:
+              import video.api.client.ApiVideoClient;
+              import video.api.client.api.ApiException;
+              import video.api.client.api.models.*;
+              import video.api.client.api.clients.VideosApi;
+              import java.util.*;
+
+              public class Example {
+                public static void main(String[] args) {
+                  ApiVideoClient client = new ApiVideoClient("YOUR_API_TOKEN");
+                  // if you rather like to use the sandbox environment:
+                  // ApiVideoClient client = new ApiVideoClient("YOU_SANDBOX_API_TOKEN", ApiVideoClient.Environment.SANDBOX);
+
+                  VideosApi apiInstance = client.videos();
+
+                  String videoId = "vi4k0jvEUuaTdRAEjQ4Jfrgz"; // Enter the videoId you want to use to upload your video.
+                  File file = new File("/path/to/file"); // The path to the video you would like to upload. The path must be local. If you want to use a video from an online source, you must use the \\\"/videos\\\" endpoint and add the \\\"source\\\" parameter when you create a new video.
+
+                  try {
+                    Video result = apiInstance.upload(videoId, file);
+                    System.out.println(result);
+                  } catch (ApiException e) {
+                    System.err.println("Exception when calling VideosApi#upload");
+                    System.err.println("Status code: " + e.getCode());
+                    System.err.println("Reason: " + e.getMessage());
+                    System.err.println("Response headers: " + e.getResponseHeaders());
+                    e.printStackTrace();
+                  }
                 }
               }
-            }
-        - language: csharp
-          code: |
-            //install via Nuget
-            //Install-Package ApiVideo
+          - language: csharp
+            code: |
+              //install via Nuget
+              //Install-Package ApiVideo
 
-            using System.Diagnostics;
-            using ApiVideo.Client;
+              using System.Diagnostics;
+              using ApiVideo.Client;
 
-            namespace Example
-            {
-                public class uploadExample
-                {
-                    public static void Main()
-                    {
-                        var basePath = ApiVideoClient.Client.Environment.SANDBOX;
-                        var apiKey = "YOUR_API_KEY";
+              namespace Example
+              {
+                  public class uploadExample
+                  {
+                      public static void Main()
+                      {
+                          var basePath = ApiVideoClient.Client.Environment.SANDBOX;
+                          var apiKey = "YOUR_API_KEY";
 
-                        var apiInstance = new ApiVideoClient(apiKey,basePath);
+                          var apiInstance = new ApiVideoClient(apiKey,basePath);
 
-                        var videoId = vi4k0jvEUuaTdRAEjQ4Jfrgz;  // string | Enter the videoId you want to use to upload your video.
-                        var file = BINARY_DATA_HERE;  // System.IO.Stream | The path to the video you would like to upload. The path must be local. If you want to use a video from an online source, you must use the \\\"/videos\\\" endpoint and add the \\\"source\\\" parameter when you create a new video.
-                        var apiVideosInstance = apiInstance.Videos();
-                        try
-                        {
-                            // Upload a video
-                            Video result = apiVideosInstance.upload(videoId, file);
-                            Debug.WriteLine(result);
-                        }
-                        catch (ApiException  e)
-                        {
-                            Debug.Print("Exception when calling VideosApi.upload: " + e.Message );
-                            Debug.Print("Status Code: "+ e.ErrorCode);
-                            Debug.Print(e.StackTrace);
-                        }
-                    }
-                }
-            }
+                          var videoId = vi4k0jvEUuaTdRAEjQ4Jfrgz;  // string | Enter the videoId you want to use to upload your video.
+                          var file = BINARY_DATA_HERE;  // System.IO.Stream | The path to the video you would like to upload. The path must be local. If you want to use a video from an online source, you must use the \\\"/videos\\\" endpoint and add the \\\"source\\\" parameter when you create a new video.
+                          var apiVideosInstance = apiInstance.Videos();
+                          try
+                          {
+                              // Upload a video
+                              Video result = apiVideosInstance.upload(videoId, file);
+                              Debug.WriteLine(result);
+                          }
+                          catch (ApiException  e)
+                          {
+                              Debug.Print("Exception when calling VideosApi.upload: " + e.Message );
+                              Debug.Print("Status Code: "+ e.ErrorCode);
+                              Debug.Print(e.StackTrace);
+                          }
+                      }
+                  }
+              }
   /videos/{videoId}/thumbnail:
     post:
       tags:
-      - Videos
+        - Videos
       summary: Upload a thumbnail
       description: "The thumbnail is the poster that appears in the player window before video playback begins.\nThis endpoint allows you to upload an image for the thumbnail.\nTo select a still frame from the video using a time stamp, use [Pick a Thumbnail](https://docs.api.video/reference#patch_videos-videoid-thumbnail) to pick a time in the video. \nNote: There may be a short delay before the new thumbnail is delivered to our CDN.\nTutorials using [Thumbnail upload](https://api.video/blog/endpoints/videos-upload-a-thumbnail)."
       operationId: POST_videos-videoId-thumbnail
       parameters:
-      - name: videoId
-        in: path
-        description: 'Unique identifier of the chosen video '
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
+        - name: videoId
+          in: path
+          description: 'Unique identifier of the chosen video '
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
       requestBody:
+        required: true
         content:
           multipart/form-data:
             schema:
@@ -842,16 +876,16 @@ paths:
                     panoramic: false
                     mp4Support: true
                     tags:
-                    - maths
-                    - string theory
-                    - video
+                      - maths
+                      - string theory
+                      - video
                     metadata:
-                    - key: Author
-                      value: John Doe
-                    - key: Format
-                      value: Tutorial
-                    scheduledAt: 2020-03-03T12:52:03.085Z
-                    publishedAt: 2020-07-14T23:36:18.598Z
+                      - key: Author
+                        value: John Doe
+                      - key: Format
+                        value: Tutorial
+                    scheduledAt: 2020-03-03T12:52:03.085+00:00
+                    publishedAt: 2020-07-14T23:36:18.598+00:00
                     source:
                       uri: /videos/vi4blUQJFrYWbaG44NChkH27/source
                     assets:
@@ -887,39 +921,40 @@ paths:
                     name: videoId
                     status: 404
       security:
-      - bearerAuth: []
+        - bearerAuth: []
       x-client-action: uploadThumbnail
       x-readme:
         code-samples:
-        - language: go
-          code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\n\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n\n    videoId := \"videoId_example\" // string | Unique identifier of the chosen video \n    file := os.NewFile(1234, \"some_file\") // *os.File | The image to be added as a thumbnail.\n\n\n    res, err := client.Videos.UploadThumbnailFile(videoId, file)\n\n    // you can also use a Reader instead of a File:\n    // client.Videos.UploadThumbnail(videoId, fileName, fileReader)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `Videos.UploadThumbnail``: %v\\n\", err)\n    }\n    // response from `UploadThumbnail`: Video\n    fmt.Fprintf(os.Stdout, \"Response from `Videos.UploadThumbnail`: %v\\n\", res)\n}\n"
-        - language: node
-          code: "//install the module with npm or yarn\n//npm install @api.video/nodejs-client --save\n//yarn add @api.video/nodejs-client\n(async () => {\n    try {\n        const client = new ApiVideoClient({ apiKey: \"YOUR_API_TOKEN\" });\n\n        const videoId = 'videoId_example'; // Unique identifier of the chosen video \n        const file = 'BINARY_DATA_HERE'; // The image to be added as a thumbnail.\n\n        // Video\n        const result = await client.videos.uploadThumbnail(videoId, file);\n        console.log(result);\n    } catch (e) {\n        console.error(e);\n    }\n})();\n"
-        - language: python
-          code: "#install the api.video API client library\n#pip install api.video\n\nimport apivideo\nfrom apivideo.api import videos_api\nfrom apivideo.model.bad_request import BadRequest\nfrom apivideo.model.not_found import NotFound\nfrom apivideo.model.video import Video\nfrom pprint import pprint\n\n# Enter a context with an instance of the API client\nwith apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:\n    # Create an instance of the API class\n    api_instance = videos_api.VideosApi(api_client)\n    video_id = \"videoId_example\" # str | Unique identifier of the chosen video \n    file = open('/path/to/file', 'rb') # file_type | The image to be added as a thumbnail.\n\n    # example passing only required values which don't have defaults set\n    try:\n        # Upload a thumbnail\n        api_response = api_instance.upload_thumbnail(video_id, file)\n        pprint(api_response)\n    except apivideo.ApiException as e:\n        print(\"Exception when calling VideosApi->upload_thumbnail: %s\\n\" % e)\n"
-        - language: java
-          code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.VideosApi;\nimport java.util.*;\n\npublic class Example {\n public static void main(String[] args) {\n   ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n   // if you rather like to use the sandbox environment:\n   // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n   VideosApi apiInstance = client.videos();\n\n   String videoId = \"videoId_example\"; // Unique identifier of the chosen video \n   File file = new File(\"/path/to/file\"); // The image to be added as a thumbnail.\n\n   try {\n     Video result = apiInstance.uploadThumbnail(videoId, file);\n     System.out.println(result);\n   } catch (ApiException e) {\n     System.err.println(\"Exception when calling VideosApi#uploadThumbnail\");\n     System.err.println(\"Status code: \" + e.getCode());\n     System.err.println(\"Reason: \" + e.getMessage());\n     System.err.println(\"Response headers: \" + e.getResponseHeaders());\n     e.printStackTrace();\n   }\n }\n}\n"
-        - language: csharp
-          code: "//install via Nuget\n//Install-Package ApiVideo\n\nusing System.Diagnostics;\nusing ApiVideo.Client;\n\nnamespace Example\n{\n    public class uploadThumbnailExample\n    {\n        public static void Main()\n        {\n            var basePath = ApiVideoClient.Client.Environment.SANDBOX;\n            var apiKey = \"YOUR_API_KEY\";\n\n            var apiInstance = new ApiVideoClient(apiKey,basePath);\n\n            var videoId = videoId_example;  // string | Unique identifier of the chosen video \n            var file = BINARY_DATA_HERE;  // System.IO.Stream | The image to be added as a thumbnail.\n            var apiVideosInstance = apiInstance.Videos();\n            try\n            {\n                // Upload a thumbnail\n                Video result = apiVideosInstance.uploadThumbnail(videoId, file);\n                Debug.WriteLine(result);\n            }\n            catch (ApiException  e)\n            {\n                Debug.Print(\"Exception when calling VideosApi.uploadThumbnail: \" + e.Message );\n                Debug.Print(\"Status Code: \"+ e.ErrorCode);\n                Debug.Print(e.StackTrace);\n            }\n        }\n    }\n}\n"
+          - language: go
+            code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\n\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n\n    videoId := \"videoId_example\" // string | Unique identifier of the chosen video \n    file := os.NewFile(1234, \"some_file\") // *os.File | The image to be added as a thumbnail.\n\n\n    res, err := client.Videos.UploadThumbnailFile(videoId, file)\n\n    // you can also use a Reader instead of a File:\n    // client.Videos.UploadThumbnail(videoId, fileName, fileReader)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `Videos.UploadThumbnail``: %v\\n\", err)\n    }\n    // response from `UploadThumbnail`: Video\n    fmt.Fprintf(os.Stdout, \"Response from `Videos.UploadThumbnail`: %v\\n\", res)\n}\n"
+          - language: node
+            code: "//install the module with npm or yarn\n//npm install @api.video/nodejs-client --save\n//yarn add @api.video/nodejs-client\n(async () => {\n    try {\n        const client = new ApiVideoClient({ apiKey: \"YOUR_API_TOKEN\" });\n\n        const videoId = 'videoId_example'; // Unique identifier of the chosen video \n        const file = 'BINARY_DATA_HERE'; // The image to be added as a thumbnail.\n\n        // Video\n        const result = await client.videos.uploadThumbnail(videoId, file);\n        console.log(result);\n    } catch (e) {\n        console.error(e);\n    }\n})();\n"
+          - language: python
+            code: "#install the api.video API client library\n#pip install api.video\n\nimport apivideo\nfrom apivideo.api import videos_api\nfrom apivideo.model.bad_request import BadRequest\nfrom apivideo.model.not_found import NotFound\nfrom apivideo.model.video import Video\nfrom pprint import pprint\n\n# Enter a context with an instance of the API client\nwith apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:\n    # Create an instance of the API class\n    api_instance = videos_api.VideosApi(api_client)\n    video_id = \"videoId_example\" # str | Unique identifier of the chosen video \n    file = open('/path/to/file', 'rb') # file_type | The image to be added as a thumbnail.\n\n    # example passing only required values which don't have defaults set\n    try:\n        # Upload a thumbnail\n        api_response = api_instance.upload_thumbnail(video_id, file)\n        pprint(api_response)\n    except apivideo.ApiException as e:\n        print(\"Exception when calling VideosApi->upload_thumbnail: %s\\n\" % e)\n"
+          - language: java
+            code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.VideosApi;\nimport java.util.*;\n\npublic class Example {\n public static void main(String[] args) {\n   ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n   // if you rather like to use the sandbox environment:\n   // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n   VideosApi apiInstance = client.videos();\n\n   String videoId = \"videoId_example\"; // Unique identifier of the chosen video \n   File file = new File(\"/path/to/file\"); // The image to be added as a thumbnail.\n\n   try {\n     Video result = apiInstance.uploadThumbnail(videoId, file);\n     System.out.println(result);\n   } catch (ApiException e) {\n     System.err.println(\"Exception when calling VideosApi#uploadThumbnail\");\n     System.err.println(\"Status code: \" + e.getCode());\n     System.err.println(\"Reason: \" + e.getMessage());\n     System.err.println(\"Response headers: \" + e.getResponseHeaders());\n     e.printStackTrace();\n   }\n }\n}\n"
+          - language: csharp
+            code: "//install via Nuget\n//Install-Package ApiVideo\n\nusing System.Diagnostics;\nusing ApiVideo.Client;\n\nnamespace Example\n{\n    public class uploadThumbnailExample\n    {\n        public static void Main()\n        {\n            var basePath = ApiVideoClient.Client.Environment.SANDBOX;\n            var apiKey = \"YOUR_API_KEY\";\n\n            var apiInstance = new ApiVideoClient(apiKey,basePath);\n\n            var videoId = videoId_example;  // string | Unique identifier of the chosen video \n            var file = BINARY_DATA_HERE;  // System.IO.Stream | The image to be added as a thumbnail.\n            var apiVideosInstance = apiInstance.Videos();\n            try\n            {\n                // Upload a thumbnail\n                Video result = apiVideosInstance.uploadThumbnail(videoId, file);\n                Debug.WriteLine(result);\n            }\n            catch (ApiException  e)\n            {\n                Debug.Print(\"Exception when calling VideosApi.uploadThumbnail: \" + e.Message );\n                Debug.Print(\"Status Code: \"+ e.ErrorCode);\n                Debug.Print(e.StackTrace);\n            }\n        }\n    }\n}\n"
     patch:
       tags:
-      - Videos
+        - Videos
       summary: Pick a thumbnail
       description: |-
         Pick a thumbnail from the given time code. If you'd like to upload an image for your thumbnail, use the [Upload a Thumbnail](https://docs.api.video/reference#post_videos-videoid-thumbnail) endpoint. There may be a short delay for the thumbnail to update.
         Tutorials using [Thumbnail picking](https://api.video/blog/endpoints/video-pick-a-thumbnail).
       operationId: PATCH_videos-videoId-thumbnail
       parameters:
-      - name: videoId
-        in: path
-        description: Unique identifier of the video you want to add a thumbnail to, where you use a section of your video as the thumbnail.
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-        example: vi4k0jvEUuaTdRAEjQ4Jfrgz
+        - name: videoId
+          in: path
+          description: Unique identifier of the video you want to add a thumbnail to, where you use a section of your video as the thumbnail.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: vi4k0jvEUuaTdRAEjQ4Jfrgz
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -942,15 +977,15 @@ paths:
                     panoramic: false
                     mp4Support: true
                     tags:
-                    - maths
-                    - string theory
-                    - video
+                      - maths
+                      - string theory
+                      - video
                     metadata:
-                    - key: Author
-                      value: John Doe
-                    - key: Format
-                      value: Tutorial
-                    publishedAt: 4665-07-14T23:36:18.598Z
+                      - key: Author
+                        value: John Doe
+                      - key: Format
+                        value: Tutorial
+                    publishedAt: 4665-07-14T23:36:18.598+00:00
                     source:
                       uri: /videos/vi4blUQJFrYWbaG44NChkH27/source
                     assets:
@@ -973,42 +1008,43 @@ paths:
                     name: videoId
                     status: 404
       security:
-      - bearerAuth: []
+        - bearerAuth: []
       x-client-action: pickThumbnail
       x-readme:
         code-samples:
-        - language: go
-          code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    videoId := \"vi4k0jvEUuaTdRAEjQ4Jfrgz\" // string | Unique identifier of the video you want to add a thumbnail to, where you use a section of your video as the thumbnail.\n    videoThumbnailPickPayload := *apivideosdk.NewVideoThumbnailPickPayload(\"Timecode_example\") // VideoThumbnailPickPayload | \n\n    \n    res, err := client.Videos.PickThumbnail(videoId, videoThumbnailPickPayload)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `Videos.PickThumbnail``: %v\\n\", err)\n    }\n    // response from `PickThumbnail`: Video\n    fmt.Fprintf(os.Stdout, \"Response from `Videos.PickThumbnail`: %v\\n\", res)\n}\n"
-        - language: node
-          code: "//install the module with npm or yarn\n//npm install @api.video/nodejs-client --save\n//yarn add @api.video/nodejs-client\n(async () => {\n  try {\n      const client = new ApiVideoClient({ apiKey: \"YOUR_API_TOKEN\" });\n\n      const videoId = 'vi4k0jvEUuaTdRAEjQ4Jfrgz'; // Unique identifier of the video you want to add a thumbnail to, where you use a section of your video as the thumbnail.\n      const videoThumbnailPickPayload = {\n      timecode: \"timecode_example\", \n      // Frame in video to be used as a placeholder before the video plays. \n      //Example: '\\\"00:01:00.000\\\" for 1 minute into the video.' Valid Patterns: \\\"hh:mm:ss.ms\\\" \\\"hh:mm:ss:frameNumber\\\" \\\"124\\\" (integer value is reported as seconds) If selection is out of range, \\\"00:00:00.00\\\" will be chosen.\n  }; \n\n      // Video\n      const result = await client.videos.pickThumbnail(videoId, videoThumbnailPickPayload);\n      console.log(result);\n  } catch (e) {\n      console.error(e);\n  }\n })();\n"
-        - language: python
-          code: "#install the api.video API client library\n#pip install api.video\nimport apivideo\nfrom apivideo.api import videos_api\nfrom apivideo.model.video_thumbnail_pick_payload import VideoThumbnailPickPayload\nfrom apivideo.model.not_found import NotFound\nfrom apivideo.model.video import Video\nfrom pprint import pprint\n\n# Enter a context with an instance of the API client\nwith apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:\n    # Create an instance of the API class\n    api_instance = videos_api.VideosApi(api_client)\n    video_id = \"vi4k0jvEUuaTdRAEjQ4Jfrgz\" # str | Unique identifier of the video you want to add a thumbnail to, where you use a section of your video as the thumbnail.\n    video_thumbnail_pick_payload = VideoThumbnailPickPayload(\n        timecode=\"04:80:72\",\n    ) # VideoThumbnailPickPayload | \n\n    # example passing only required values which don't have defaults set\n    try:\n        # Pick a thumbnail\n        api_response = api_instance.pick_thumbnail(video_id, video_thumbnail_pick_payload)\n        pprint(api_response)\n    except apivideo.ApiException as e:\n        print(\"Exception when calling VideosApi->pick_thumbnail: %s\\n\" % e)\n"
-        - language: java
-          code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.VideosApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    VideosApi apiInstance = client.videos();\n    \n    String videoId = \"vi4k0jvEUuaTdRAEjQ4Jfrgz\"; // Unique identifier of the video you want to add a thumbnail to, where you use a section of your video as the thumbnail.\n    VideoThumbnailPickPayload videoThumbnailPickPayload = new VideoThumbnailPickPayload(); // \n    videoThumbnailPickPayload.setTimecode(\"null\"); // Frame in video to be used as a placeholder before the video plays.\nExample: &#39;&quot;00:01:00.000&quot; for 1 minute into the video.&#39;\nValid Patterns:\n&quot;hh:mm:ss.ms&quot;\n&quot;hh:mm:ss:frameNumber&quot;\n&quot;124&quot; (integer value is reported as seconds)\nIf selection is out of range, &quot;00:00:00.00&quot; will be chosen.\n\n\n    try {\n      Video result = apiInstance.pickThumbnail(videoId, videoThumbnailPickPayload);\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling VideosApi#pickThumbnail\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}        \n"
-        - language: csharp
-          code: "//install via Nuget\n//Install-Package ApiVideo\nusing System.Diagnostics;\nusing ApiVideo.Client;\n\nnamespace Example\n{\n    public class pickThumbnailExample\n    {\n        public static void Main()\n        {\n            var basePath = ApiVideoClient.Client.Environment.SANDBOX;\n            var apiKey = \"YOUR_API_KEY\";\n\n            var apiInstance = new ApiVideoClient(apiKey,basePath);\n\n            var videoId = vi4k0jvEUuaTdRAEjQ4Jfrgz;  // string | Unique identifier of the video you want to add a thumbnail to, where you use a section of your video as the thumbnail.\n            var videoThumbnailPickPayload = new VideoThumbnailPickPayload(); // VideoThumbnailPickPayload | \n            var apiVideosInstance = apiInstance.Videos();\n            try\n            {\n                // Pick a thumbnail\n                Video result = apiVideosInstance.pickThumbnail(videoId, videoThumbnailPickPayload);\n                Debug.WriteLine(result);\n            }\n            catch (ApiException  e)\n            {\n                Debug.Print(\"Exception when calling VideosApi.pickThumbnail: \" + e.Message );\n                Debug.Print(\"Status Code: \"+ e.ErrorCode);\n                Debug.Print(e.StackTrace);\n            }\n        }\n    }\n}              \n"
+          - language: go
+            code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    videoId := \"vi4k0jvEUuaTdRAEjQ4Jfrgz\" // string | Unique identifier of the video you want to add a thumbnail to, where you use a section of your video as the thumbnail.\n    videoThumbnailPickPayload := *apivideosdk.NewVideoThumbnailPickPayload(\"Timecode_example\") // VideoThumbnailPickPayload | \n\n    \n    res, err := client.Videos.PickThumbnail(videoId, videoThumbnailPickPayload)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `Videos.PickThumbnail``: %v\\n\", err)\n    }\n    // response from `PickThumbnail`: Video\n    fmt.Fprintf(os.Stdout, \"Response from `Videos.PickThumbnail`: %v\\n\", res)\n}\n"
+          - language: node
+            code: "//install the module with npm or yarn\n//npm install @api.video/nodejs-client --save\n//yarn add @api.video/nodejs-client\n(async () => {\n  try {\n      const client = new ApiVideoClient({ apiKey: \"YOUR_API_TOKEN\" });\n\n      const videoId = 'vi4k0jvEUuaTdRAEjQ4Jfrgz'; // Unique identifier of the video you want to add a thumbnail to, where you use a section of your video as the thumbnail.\n      const videoThumbnailPickPayload = {\n      timecode: \"timecode_example\", \n      // Frame in video to be used as a placeholder before the video plays. \n      //Example: '\\\"00:01:00.000\\\" for 1 minute into the video.' Valid Patterns: \\\"hh:mm:ss.ms\\\" \\\"hh:mm:ss:frameNumber\\\" \\\"124\\\" (integer value is reported as seconds) If selection is out of range, \\\"00:00:00.00\\\" will be chosen.\n  }; \n\n      // Video\n      const result = await client.videos.pickThumbnail(videoId, videoThumbnailPickPayload);\n      console.log(result);\n  } catch (e) {\n      console.error(e);\n  }\n })();\n"
+          - language: python
+            code: "#install the api.video API client library\n#pip install api.video\nimport apivideo\nfrom apivideo.api import videos_api\nfrom apivideo.model.video_thumbnail_pick_payload import VideoThumbnailPickPayload\nfrom apivideo.model.not_found import NotFound\nfrom apivideo.model.video import Video\nfrom pprint import pprint\n\n# Enter a context with an instance of the API client\nwith apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:\n    # Create an instance of the API class\n    api_instance = videos_api.VideosApi(api_client)\n    video_id = \"vi4k0jvEUuaTdRAEjQ4Jfrgz\" # str | Unique identifier of the video you want to add a thumbnail to, where you use a section of your video as the thumbnail.\n    video_thumbnail_pick_payload = VideoThumbnailPickPayload(\n        timecode=\"04:80:72\",\n    ) # VideoThumbnailPickPayload | \n\n    # example passing only required values which don't have defaults set\n    try:\n        # Pick a thumbnail\n        api_response = api_instance.pick_thumbnail(video_id, video_thumbnail_pick_payload)\n        pprint(api_response)\n    except apivideo.ApiException as e:\n        print(\"Exception when calling VideosApi->pick_thumbnail: %s\\n\" % e)\n"
+          - language: java
+            code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.VideosApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    VideosApi apiInstance = client.videos();\n    \n    String videoId = \"vi4k0jvEUuaTdRAEjQ4Jfrgz\"; // Unique identifier of the video you want to add a thumbnail to, where you use a section of your video as the thumbnail.\n    VideoThumbnailPickPayload videoThumbnailPickPayload = new VideoThumbnailPickPayload(); // \n    videoThumbnailPickPayload.setTimecode(\"null\"); // Frame in video to be used as a placeholder before the video plays.\nExample: &#39;&quot;00:01:00.000&quot; for 1 minute into the video.&#39;\nValid Patterns:\n&quot;hh:mm:ss.ms&quot;\n&quot;hh:mm:ss:frameNumber&quot;\n&quot;124&quot; (integer value is reported as seconds)\nIf selection is out of range, &quot;00:00:00.00&quot; will be chosen.\n\n\n    try {\n      Video result = apiInstance.pickThumbnail(videoId, videoThumbnailPickPayload);\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling VideosApi#pickThumbnail\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}        \n"
+          - language: csharp
+            code: "//install via Nuget\n//Install-Package ApiVideo\nusing System.Diagnostics;\nusing ApiVideo.Client;\n\nnamespace Example\n{\n    public class pickThumbnailExample\n    {\n        public static void Main()\n        {\n            var basePath = ApiVideoClient.Client.Environment.SANDBOX;\n            var apiKey = \"YOUR_API_KEY\";\n\n            var apiInstance = new ApiVideoClient(apiKey,basePath);\n\n            var videoId = vi4k0jvEUuaTdRAEjQ4Jfrgz;  // string | Unique identifier of the video you want to add a thumbnail to, where you use a section of your video as the thumbnail.\n            var videoThumbnailPickPayload = new VideoThumbnailPickPayload(); // VideoThumbnailPickPayload | \n            var apiVideosInstance = apiInstance.Videos();\n            try\n            {\n                // Pick a thumbnail\n                Video result = apiVideosInstance.pickThumbnail(videoId, videoThumbnailPickPayload);\n                Debug.WriteLine(result);\n            }\n            catch (ApiException  e)\n            {\n                Debug.Print(\"Exception when calling VideosApi.pickThumbnail: \" + e.Message );\n                Debug.Print(\"Status Code: \"+ e.ErrorCode);\n                Debug.Print(e.StackTrace);\n            }\n        }\n    }\n}              \n"
   /videos/{videoId}:
     get:
       tags:
-      - Videos
+        - Videos
       summary: Show a video
       description: This call provides the same JSON information provided on video creation. For private videos, it will generate a unique token url. Use this to retrieve any details you need about a video, or set up a private viewing URL. Tutorials using [video GET](https://api.video/blog/endpoints/video-get).
       operationId: GET-video
       parameters:
-      - name: videoId
-        in: path
-        description: The unique identifier for the video you want details about.
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
+        - name: videoId
+          in: path
+          description: The unique identifier for the video you want details about.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
       responses:
         "200":
           description: Success
           content:
             application/json:
               schema:
+                type: object
                 $ref: '#/components/schemas/video'
               examples:
                 response:
@@ -1021,16 +1057,16 @@ paths:
                     panoramic: false
                     mp4Support: true
                     tags:
-                    - maths
-                    - string theory
-                    - video
+                      - maths
+                      - string theory
+                      - video
                     metadata:
-                    - key: Author
-                      value: John Doe
-                    - key: Format
-                      value: Tutorial
+                      - key: Author
+                        value: John Doe
+                      - key: Format
+                        value: Tutorial
                     publishedAt: 2019-12-16T08:25:51+00:00
-                    updateddAt: 2019-12-16T08:48:49+00:00
+                    updatedAt: 2019-12-16T08:48:49+00:00
                     source:
                       uri: /videos/vi4blUQJFrYWbaG44NChkH27/source
                     assets:
@@ -1053,73 +1089,73 @@ paths:
                     name: videoId
                     status: 404
       security:
-      - bearerAuth: []
+        - bearerAuth: []
       x-client-action: get
       x-readme:
         code-samples:
-        - language: go
-          code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    videoId := \"videoId_example\" // string | The unique identifier for the video you want details about.\n\n    \n    res, err := client.Videos.Get(videoId)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `Videos.Get``: %v\\n\", err)\n    }\n    // response from `Get`: Video\n    fmt.Fprintf(os.Stdout, \"Response from `Videos.Get`: %v\\n\", res)\n}\n"
-        - language: node
-          code: |
-            //install the module with npm or yarn
-            //npm install @api.video/nodejs-client --save
-            //yarn add @api.video/nodejs-client
-            (async () => {
-                try {
-                    const client = new ApiVideoClient({ apiKey: "YOUR_API_TOKEN" });
+          - language: go
+            code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    videoId := \"videoId_example\" // string | The unique identifier for the video you want details about.\n\n    \n    res, err := client.Videos.Get(videoId)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `Videos.Get``: %v\\n\", err)\n    }\n    // response from `Get`: Video\n    fmt.Fprintf(os.Stdout, \"Response from `Videos.Get`: %v\\n\", res)\n}\n"
+          - language: node
+            code: |
+              //install the module with npm or yarn
+              //npm install @api.video/nodejs-client --save
+              //yarn add @api.video/nodejs-client
+              (async () => {
+                  try {
+                      const client = new ApiVideoClient({ apiKey: "YOUR_API_TOKEN" });
 
-                    const videoId = 'videoId_example'; // The unique identifier for the video you want details about.
+                      const videoId = 'videoId_example'; // The unique identifier for the video you want details about.
 
-                    // Video
-                    const result = await client.videos.get(videoId);
-                    console.log(result);
-                } catch (e) {
-                    console.error(e);
-                }
-            })();
-        - language: python
-          code: |
-            #install the api.video API client library
-            #pip install api.video
-            import apivideo
-            from apivideo.api import videos_api
-            from apivideo.model.not_found import NotFound
-            from apivideo.model.video import Video
-            from pprint import pprint
+                      // Video
+                      const result = await client.videos.get(videoId);
+                      console.log(result);
+                  } catch (e) {
+                      console.error(e);
+                  }
+              })();
+          - language: python
+            code: |
+              #install the api.video API client library
+              #pip install api.video
+              import apivideo
+              from apivideo.api import videos_api
+              from apivideo.model.not_found import NotFound
+              from apivideo.model.video import Video
+              from pprint import pprint
 
-            # Enter a context with an instance of the API client
-            with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
-                # Create an instance of the API class
-                api_instance = videos_api.VideosApi(api_client)
-                video_id = "videoId_example" # str | The unique identifier for the video you want details about.
+              # Enter a context with an instance of the API client
+              with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
+                  # Create an instance of the API class
+                  api_instance = videos_api.VideosApi(api_client)
+                  video_id = "videoId_example" # str | The unique identifier for the video you want details about.
 
-                # example passing only required values which don't have defaults set
-                try:
-                    # Show a video
-                    api_response = api_instance.get(video_id)
-                    pprint(api_response)
-                except apivideo.ApiException as e:
-                    print("Exception when calling VideosApi->get: %s\n" % e)
-        - language: java
-          code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.VideosApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    VideosApi apiInstance = client.videos();\n    \n    String videoId = \"videoId_example\"; // The unique identifier for the video you want details about.\n\n    try {\n      Video result = apiInstance.get(videoId);\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling VideosApi#get\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}  \n"
-        - language: csharp
-          code: "//install via Nuget\n//Install-Package ApiVideo\nusing System.Diagnostics;\nusing ApiVideo.Client;\n\nnamespace Example\n{\n    public class getExample\n    {\n        public static void Main()\n        {\n            var basePath = ApiVideoClient.Client.Environment.SANDBOX;\n            var apiKey = \"YOUR_API_KEY\";\n\n            var apiInstance = new ApiVideoClient(apiKey,basePath);\n\n            var videoId = videoId_example;  // string | The unique identifier for the video you want details about.\n            var apiVideosInstance = apiInstance.Videos();\n            try\n            {\n                // Show a video\n                Video result = apiVideosInstance.get(videoId);\n                Debug.WriteLine(result);\n            }\n            catch (ApiException  e)\n            {\n                Debug.Print(\"Exception when calling VideosApi.get: \" + e.Message );\n                Debug.Print(\"Status Code: \"+ e.ErrorCode);\n                Debug.Print(e.StackTrace);\n            }\n        }\n    }\n} \n"
+                  # example passing only required values which don't have defaults set
+                  try:
+                      # Show a video
+                      api_response = api_instance.get(video_id)
+                      pprint(api_response)
+                  except apivideo.ApiException as e:
+                      print("Exception when calling VideosApi->get: %s\n" % e)
+          - language: java
+            code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.VideosApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    VideosApi apiInstance = client.videos();\n    \n    String videoId = \"videoId_example\"; // The unique identifier for the video you want details about.\n\n    try {\n      Video result = apiInstance.get(videoId);\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling VideosApi#get\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}  \n"
+          - language: csharp
+            code: "//install via Nuget\n//Install-Package ApiVideo\nusing System.Diagnostics;\nusing ApiVideo.Client;\n\nnamespace Example\n{\n    public class getExample\n    {\n        public static void Main()\n        {\n            var basePath = ApiVideoClient.Client.Environment.SANDBOX;\n            var apiKey = \"YOUR_API_KEY\";\n\n            var apiInstance = new ApiVideoClient(apiKey,basePath);\n\n            var videoId = videoId_example;  // string | The unique identifier for the video you want details about.\n            var apiVideosInstance = apiInstance.Videos();\n            try\n            {\n                // Show a video\n                Video result = apiVideosInstance.get(videoId);\n                Debug.WriteLine(result);\n            }\n            catch (ApiException  e)\n            {\n                Debug.Print(\"Exception when calling VideosApi.get: \" + e.Message );\n                Debug.Print(\"Status Code: \"+ e.ErrorCode);\n                Debug.Print(e.StackTrace);\n            }\n        }\n    }\n} \n"
     delete:
       tags:
-      - Videos
+        - Videos
       summary: Delete a video
       description: If you do not need a video any longer, you can send a request to delete it. All you need is the videoId. Tutorials using [video deletion](https://api.video/blog/endpoints/video-delete).
       operationId: DELETE-video
       parameters:
-      - name: videoId
-        in: path
-        description: The video ID for the video you want to delete.
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-        example: vi4k0jvEUuaTdRAEjQ4Jfrgz
+        - name: videoId
+          in: path
+          description: The video ID for the video you want to delete.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: vi4k0jvEUuaTdRAEjQ4Jfrgz
       responses:
         "204":
           description: No Content
@@ -1137,68 +1173,69 @@ paths:
                     name: videoId
                     status: 404
       security:
-      - bearerAuth: []
+        - bearerAuth: []
       x-client-action: delete
       x-readme:
         code-samples:
-        - language: go
-          code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    videoId := \"vi4k0jvEUuaTdRAEjQ4Jfrgz\" // string | The video ID for the video you want to delete.\n    err := client.Videos.Delete(videoId)\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `Videos.Delete``: %v\\n\", err)\n    }\n}  \n"
-        - language: node
-          code: |
-            //install the module with npm or yarn
-            //npm install @api.video/nodejs-client --save
-            //yarn add @api.video/nodejs-client
-            (async () => {
-                try {
-                    const client = new ApiVideoClient({ apiKey: "YOUR_API_TOKEN" });
-                    const videoId = 'vi4k0jvEUuaTdRAEjQ4Jfrgz'; // The video ID for the video you want to delete.
-                    // void
-                    const result = await client.videos.delete(videoId);
-                    console.log(result);
-                } catch (e) {
-                    console.error(e);
-                }
-            })();
-        - language: python
-          code: |
-            #install the api.video API client library
-            #pip install api.video
-            import apivideo
-            from apivideo.api import videos_api
-            from apivideo.model.not_found import NotFound
-            from pprint import pprint
-            # Enter a context with an instance of the API client
-            with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
-                # Create an instance of the API class
-                api_instance = videos_api.VideosApi(api_client)
-                video_id = "vi4k0jvEUuaTdRAEjQ4Jfrgz" # str | The video ID for the video you want to delete.
-                # example passing only required values which don't have defaults set
-                try:
-                    # Delete a video
-                    api_instance.delete(video_id)
-                except apivideo.ApiException as e:
-                    print("Exception when calling VideosApi->delete: %s\n" % e)
-        - language: java
-          code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.VideosApi;\nimport java.util.*;\n  \npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n    \n    VideosApi apiInstance = client.videos();\n    \n    String videoId = \"vi4k0jvEUuaTdRAEjQ4Jfrgz\"; // The video ID for the video you want to delete.\n    \n    try {\n      apiInstance.delete(videoId);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling VideosApi#delete\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
-        - language: csharp
-          code: "//install via Nuget\n//Install-Package ApiVideo\nusing System.Diagnostics;\nusing ApiVideo.Client;\n\nnamespace Example\n{\n    public class deleteExample\n    {\n        public static void Main()\n        {\n            var basePath = ApiVideoClient.Client.Environment.SANDBOX;\n            var apiKey = \"YOUR_API_KEY\";\n            var apiInstance = new ApiVideoClient(apiKey,basePath);\n            var videoId = vi4k0jvEUuaTdRAEjQ4Jfrgz;  // string | The video ID for the video you want to delete.\n            var apiVideosInstance = apiInstance.Videos();\n            try\n            {\n                // Delete a video\n                apiVideosInstance.delete(videoId);\n            }\n            catch (ApiException  e)\n            {\n                Debug.Print(\"Exception when calling VideosApi.delete: \" + e.Message );\n                Debug.Print(\"Status Code: \"+ e.ErrorCode);\n                Debug.Print(e.StackTrace);\n            }\n        }\n    }\n} \n"
+          - language: go
+            code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    videoId := \"vi4k0jvEUuaTdRAEjQ4Jfrgz\" // string | The video ID for the video you want to delete.\n    err := client.Videos.Delete(videoId)\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `Videos.Delete``: %v\\n\", err)\n    }\n}  \n"
+          - language: node
+            code: |
+              //install the module with npm or yarn
+              //npm install @api.video/nodejs-client --save
+              //yarn add @api.video/nodejs-client
+              (async () => {
+                  try {
+                      const client = new ApiVideoClient({ apiKey: "YOUR_API_TOKEN" });
+                      const videoId = 'vi4k0jvEUuaTdRAEjQ4Jfrgz'; // The video ID for the video you want to delete.
+                      // void
+                      const result = await client.videos.delete(videoId);
+                      console.log(result);
+                  } catch (e) {
+                      console.error(e);
+                  }
+              })();
+          - language: python
+            code: |
+              #install the api.video API client library
+              #pip install api.video
+              import apivideo
+              from apivideo.api import videos_api
+              from apivideo.model.not_found import NotFound
+              from pprint import pprint
+              # Enter a context with an instance of the API client
+              with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
+                  # Create an instance of the API class
+                  api_instance = videos_api.VideosApi(api_client)
+                  video_id = "vi4k0jvEUuaTdRAEjQ4Jfrgz" # str | The video ID for the video you want to delete.
+                  # example passing only required values which don't have defaults set
+                  try:
+                      # Delete a video
+                      api_instance.delete(video_id)
+                  except apivideo.ApiException as e:
+                      print("Exception when calling VideosApi->delete: %s\n" % e)
+          - language: java
+            code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.VideosApi;\nimport java.util.*;\n  \npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n    \n    VideosApi apiInstance = client.videos();\n    \n    String videoId = \"vi4k0jvEUuaTdRAEjQ4Jfrgz\"; // The video ID for the video you want to delete.\n    \n    try {\n      apiInstance.delete(videoId);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling VideosApi#delete\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
+          - language: csharp
+            code: "//install via Nuget\n//Install-Package ApiVideo\nusing System.Diagnostics;\nusing ApiVideo.Client;\n\nnamespace Example\n{\n    public class deleteExample\n    {\n        public static void Main()\n        {\n            var basePath = ApiVideoClient.Client.Environment.SANDBOX;\n            var apiKey = \"YOUR_API_KEY\";\n            var apiInstance = new ApiVideoClient(apiKey,basePath);\n            var videoId = vi4k0jvEUuaTdRAEjQ4Jfrgz;  // string | The video ID for the video you want to delete.\n            var apiVideosInstance = apiInstance.Videos();\n            try\n            {\n                // Delete a video\n                apiVideosInstance.delete(videoId);\n            }\n            catch (ApiException  e)\n            {\n                Debug.Print(\"Exception when calling VideosApi.delete: \" + e.Message );\n                Debug.Print(\"Status Code: \"+ e.ErrorCode);\n                Debug.Print(e.StackTrace);\n            }\n        }\n    }\n} \n"
     patch:
       tags:
-      - Videos
+        - Videos
       summary: Update a video
       description: 'Use this endpoint to update the parameters associated with your video. The video you are updating is determined by the video ID you provide in the path. For each parameter you want to update, include the update in the request body. NOTE: If you are updating an array, you must provide the entire array as what you provide here overwrites what is in the system rather than appending to it. Tutorials using [video update](https://api.video/blog/endpoints/video-update).'
       operationId: PATCH-video
       parameters:
-      - name: videoId
-        in: path
-        description: The video ID for the video you want to delete.
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-        example: vi4k0jvEUuaTdRAEjQ4Jfrgz
+        - name: videoId
+          in: path
+          description: The video ID for the video you want to delete.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: vi4k0jvEUuaTdRAEjQ4Jfrgz
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -1221,14 +1258,14 @@ paths:
                     panoramic: false
                     mp4Support: true
                     tags:
-                    - maths
-                    - string theory
-                    - video
+                      - maths
+                      - string theory
+                      - video
                     metadata:
-                    - key: Author
-                      value: John Doe
-                    - key: Format
-                      value: Tutorial
+                      - key: Author
+                        value: John Doe
+                      - key: Format
+                        value: Tutorial
                     publishedAt: 2019-12-16T08:25:51+00:00
                     updatedAt: 2019-12-16T08:48:49+00:00
                     source:
@@ -1253,15 +1290,15 @@ paths:
                     name: scheduledAt
                     status: 400
                     problems:
-                    - type: https://docs.api.video/docs/attributeinvalid
-                      title: This attribute must be a ISO-8601 date.
-                      name: scheduledAt
-                    - type: https://docs.api.video/docs/attributeinvalid
-                      title: This attribute must be an array.
-                      name: tags
-                    - type: https://docs.api.video/docs/attributeinvalid
-                      title: This attribute must be an array.
-                      name: metadata
+                      - type: https://docs.api.video/docs/attributeinvalid
+                        title: This attribute must be a ISO-8601 date.
+                        name: scheduledAt
+                      - type: https://docs.api.video/docs/attributeinvalid
+                        title: This attribute must be an array.
+                        name: tags
+                      - type: https://docs.api.video/docs/attributeinvalid
+                        title: This attribute must be an array.
+                        name: metadata
         "404":
           description: Not Found
           content:
@@ -1276,44 +1313,68 @@ paths:
                     name: videoId
                     status: 404
       security:
-      - bearerAuth: []
+        - bearerAuth: []
       x-client-action: update
       x-readme:
         code-samples:
-        - language: go
-          code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    videoId := \"vi4k0jvEUuaTdRAEjQ4Jfrgz\" // string | The video ID for the video you want to delete.\n    videoUpdatePayload := *apivideosdk.NewVideoUpdatePayload() // VideoUpdatePayload | \n\n    \n    res, err := client.Videos.Update(videoId, videoUpdatePayload)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `Videos.Update``: %v\\n\", err)\n    }\n    // response from `Update`: Video\n    fmt.Fprintf(os.Stdout, \"Response from `Videos.Update`: %v\\n\", res)\n}\n"
-        - language: node
-          code: "//install the module with npm or yarn\n//npm install @api.video/nodejs-client --save\n//yarn add @api.video/nodejs-client\n(async () => {\n    try {\n        const client = new ApiVideoClient({ apiKey: \"YOUR_API_TOKEN\" });\n\n        const videoId = 'vi4k0jvEUuaTdRAEjQ4Jfrgz'; // The video ID for the video you want to delete.\n        const videoUpdatePayload = {\n      playerId: \"pl4k0jvEUuaTdRAEjQ4Jfrgz\", // The unique ID for the player you want to associate with your video.\n      title: \"title_example\", // The title you want to use for your video.\n      description: \"A film about good books.\", // A brief description of the video.\n      _public: true, // Whether the video is publicly available or not. False means it is set to private.\n      panoramic: false, // Whether the video is a 360 degree or immersive video.\n      mp4Support: true, // Whether the player supports the mp4 format.\n      tags: [\"maths\", \"string theory\", \"video\"], // A list of terms or words you want to tag the video with. Make sure the list includes all the tags you want as whatever you send in this list will overwrite the existing list for the video.\n      metadata: null, // A list (array) of dictionaries where each dictionary contains a key value pair that describes the video. As with tags, you must send the complete list of metadata you want as whatever you send here will overwrite the existing metadata for the video.\n    }; \n\n        // Video\n        const result = await client.videos.update(videoId, videoUpdatePayload);\n        console.log(result);\n    } catch (e) {\n        console.error(e);\n    }\n})();\n"
-        - language: python
-          code: "#install the api.video API client library\n#pip install api.video\nimport apivideo\nfrom apivideo.api import videos_api\nfrom apivideo.model.video_update_payload import VideoUpdatePayload\nfrom apivideo.model.bad_request import BadRequest\nfrom apivideo.model.not_found import NotFound\nfrom apivideo.model.video import Video\nfrom pprint import pprint\n\n# Enter a context with an instance of the API client\nwith apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:\n    # Create an instance of the API class\n    api_instance = videos_api.VideosApi(api_client)\n    video_id = \"vi4k0jvEUuaTdRAEjQ4Jfrgz\" # str | The video ID for the video you want to delete.\n    video_update_payload = VideoUpdatePayload(\n        player_id=\"pl4k0jvEUuaTdRAEjQ4Jfrgz\",\n        title=\"title_example\",\n        description=\"A film about good books.\",\n        public=True,\n        panoramic=False,\n        mp4_support=True,\n        tags=[\"maths\", \"string theory\", \"video\"],\n        metadata=[\n            Metadata(\n                key=\"Color\",\n                value=\"Green\",\n            ),\n        ],\n    ) # VideoUpdatePayload | \n\n    # example passing only required values which don't have defaults set\n    try:\n        # Update a video\n        api_response = api_instance.update(video_id, video_update_payload)\n        pprint(api_response)\n    except apivideo.ApiException as e:\n        print(\"Exception when calling VideosApi->update: %s\\n\" % e)              \n"
-        - language: java
-          code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.VideosApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    VideosApi apiInstance = client.videos();\n    \n    String videoId = \"vi4k0jvEUuaTdRAEjQ4Jfrgz\"; // The video ID for the video you want to delete.\n    VideoUpdatePayload videoUpdatePayload = new VideoUpdatePayload(); // \n    videoUpdatePayload.setPlayerId(\"pl4k0jvEUuaTdRAEjQ4Jfrgz\"); // The unique ID for the player you want to associate with your video.\n    videoUpdatePayload.setTitle(\"null\"); // The title you want to use for your video.\n    videoUpdatePayload.setDescription(\"A film about good books.\"); // A brief description of the video.\n    videoUpdatePayload.setPublic(true); // Whether the video is publicly available or not. False means it is set to private.\n    videoUpdatePayload.setPanoramic(false); // Whether the video is a 360 degree or immersive video.\n    videoUpdatePayload.setMp4Support(true); // Whether the player supports the mp4 format.\n    videoUpdatePayload.setTags(Arrays.asList(\"maths\", \"string theory\", \"video\")); // A list of terms or words you want to tag the video with. Make sure the list includes all the tags you want as whatever you send in this list will overwrite the existing list for the video.\n    videoUpdatePayload.setMetadata(Collections.<Metadata>emptyList()); // A list (array) of dictionaries where each dictionary contains a key value pair that describes the video. As with tags, you must send the complete list of metadata you want as whatever you send here will overwrite the existing metadata for the video.\n\n\n    try {\n      Video result = apiInstance.update(videoId, videoUpdatePayload);\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling VideosApi#update\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
-        - language: csharp
-          code: "//install via Nuget\n//Install-Package ApiVideo\nusing System.Diagnostics;\nusing ApiVideo.Client;\n\nnamespace Example\n{\n    public class updateExample\n    {\n        public static void Main()\n        {\n            var basePath = ApiVideoClient.Client.Environment.SANDBOX;\n            var apiKey = \"YOUR_API_KEY\";\n\n            var apiInstance = new ApiVideoClient(apiKey,basePath);\n\n            var videoId = vi4k0jvEUuaTdRAEjQ4Jfrgz;  // string | The video ID for the video you want to delete.\n            var videoUpdatePayload = new VideoUpdatePayload(); // VideoUpdatePayload | \n            var apiVideosInstance = apiInstance.Videos();\n            try\n            {\n                // Update a video\n                Video result = apiVideosInstance.update(videoId, videoUpdatePayload);\n                Debug.WriteLine(result);\n            }\n            catch (ApiException  e)\n            {\n                Debug.Print(\"Exception when calling VideosApi.update: \" + e.Message );\n                Debug.Print(\"Status Code: \"+ e.ErrorCode);\n                Debug.Print(e.StackTrace);\n            }\n        }\n    }\n}\n"
+          - language: go
+            code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    videoId := \"vi4k0jvEUuaTdRAEjQ4Jfrgz\" // string | The video ID for the video you want to delete.\n    videoUpdatePayload := *apivideosdk.NewVideoUpdatePayload() // VideoUpdatePayload | \n\n    \n    res, err := client.Videos.Update(videoId, videoUpdatePayload)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `Videos.Update``: %v\\n\", err)\n    }\n    // response from `Update`: Video\n    fmt.Fprintf(os.Stdout, \"Response from `Videos.Update`: %v\\n\", res)\n}\n"
+          - language: node
+            code: "//install the module with npm or yarn\n//npm install @api.video/nodejs-client --save\n//yarn add @api.video/nodejs-client\n(async () => {\n    try {\n        const client = new ApiVideoClient({ apiKey: \"YOUR_API_TOKEN\" });\n\n        const videoId = 'vi4k0jvEUuaTdRAEjQ4Jfrgz'; // The video ID for the video you want to delete.\n        const videoUpdatePayload = {\n      playerId: \"pl4k0jvEUuaTdRAEjQ4Jfrgz\", // The unique ID for the player you want to associate with your video.\n      title: \"title_example\", // The title you want to use for your video.\n      description: \"A film about good books.\", // A brief description of the video.\n      _public: true, // Whether the video is publicly available or not. False means it is set to private.\n      panoramic: false, // Whether the video is a 360 degree or immersive video.\n      mp4Support: true, // Whether the player supports the mp4 format.\n      tags: [\"maths\", \"string theory\", \"video\"], // A list of terms or words you want to tag the video with. Make sure the list includes all the tags you want as whatever you send in this list will overwrite the existing list for the video.\n      metadata: null, // A list (array) of dictionaries where each dictionary contains a key value pair that describes the video. As with tags, you must send the complete list of metadata you want as whatever you send here will overwrite the existing metadata for the video.\n    }; \n\n        // Video\n        const result = await client.videos.update(videoId, videoUpdatePayload);\n        console.log(result);\n    } catch (e) {\n        console.error(e);\n    }\n})();\n"
+          - language: python
+            code: "#install the api.video API client library\n#pip install api.video\nimport apivideo\nfrom apivideo.api import videos_api\nfrom apivideo.model.video_update_payload import VideoUpdatePayload\nfrom apivideo.model.bad_request import BadRequest\nfrom apivideo.model.not_found import NotFound\nfrom apivideo.model.video import Video\nfrom pprint import pprint\n\n# Enter a context with an instance of the API client\nwith apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:\n    # Create an instance of the API class\n    api_instance = videos_api.VideosApi(api_client)\n    video_id = \"vi4k0jvEUuaTdRAEjQ4Jfrgz\" # str | The video ID for the video you want to delete.\n    video_update_payload = VideoUpdatePayload(\n        player_id=\"pl4k0jvEUuaTdRAEjQ4Jfrgz\",\n        title=\"title_example\",\n        description=\"A film about good books.\",\n        public=True,\n        panoramic=False,\n        mp4_support=True,\n        tags=[\"maths\", \"string theory\", \"video\"],\n        metadata=[\n            Metadata(\n                key=\"Color\",\n                value=\"Green\",\n            ),\n        ],\n    ) # VideoUpdatePayload | \n\n    # example passing only required values which don't have defaults set\n    try:\n        # Update a video\n        api_response = api_instance.update(video_id, video_update_payload)\n        pprint(api_response)\n    except apivideo.ApiException as e:\n        print(\"Exception when calling VideosApi->update: %s\\n\" % e)              \n"
+          - language: java
+            code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.VideosApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    VideosApi apiInstance = client.videos();\n    \n    String videoId = \"vi4k0jvEUuaTdRAEjQ4Jfrgz\"; // The video ID for the video you want to delete.\n    VideoUpdatePayload videoUpdatePayload = new VideoUpdatePayload(); // \n    videoUpdatePayload.setPlayerId(\"pl4k0jvEUuaTdRAEjQ4Jfrgz\"); // The unique ID for the player you want to associate with your video.\n    videoUpdatePayload.setTitle(\"null\"); // The title you want to use for your video.\n    videoUpdatePayload.setDescription(\"A film about good books.\"); // A brief description of the video.\n    videoUpdatePayload.setPublic(true); // Whether the video is publicly available or not. False means it is set to private.\n    videoUpdatePayload.setPanoramic(false); // Whether the video is a 360 degree or immersive video.\n    videoUpdatePayload.setMp4Support(true); // Whether the player supports the mp4 format.\n    videoUpdatePayload.setTags(Arrays.asList(\"maths\", \"string theory\", \"video\")); // A list of terms or words you want to tag the video with. Make sure the list includes all the tags you want as whatever you send in this list will overwrite the existing list for the video.\n    videoUpdatePayload.setMetadata(Collections.<Metadata>emptyList()); // A list (array) of dictionaries where each dictionary contains a key value pair that describes the video. As with tags, you must send the complete list of metadata you want as whatever you send here will overwrite the existing metadata for the video.\n\n\n    try {\n      Video result = apiInstance.update(videoId, videoUpdatePayload);\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling VideosApi#update\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
+          - language: csharp
+            code: "//install via Nuget\n//Install-Package ApiVideo\nusing System.Diagnostics;\nusing ApiVideo.Client;\n\nnamespace Example\n{\n    public class updateExample\n    {\n        public static void Main()\n        {\n            var basePath = ApiVideoClient.Client.Environment.SANDBOX;\n            var apiKey = \"YOUR_API_KEY\";\n\n            var apiInstance = new ApiVideoClient(apiKey,basePath);\n\n            var videoId = vi4k0jvEUuaTdRAEjQ4Jfrgz;  // string | The video ID for the video you want to delete.\n            var videoUpdatePayload = new VideoUpdatePayload(); // VideoUpdatePayload | \n            var apiVideosInstance = apiInstance.Videos();\n            try\n            {\n                // Update a video\n                Video result = apiVideosInstance.update(videoId, videoUpdatePayload);\n                Debug.WriteLine(result);\n            }\n            catch (ApiException  e)\n            {\n                Debug.Print(\"Exception when calling VideosApi.update: \" + e.Message );\n                Debug.Print(\"Status Code: \"+ e.ErrorCode);\n                Debug.Print(e.StackTrace);\n            }\n        }\n    }\n}\n"
+          - language: php
+            code: |
+              <?php
+
+              use ApiVideo\Client\Model\Metadata;
+              use ApiVideo\Client\Model\VideoUpdatePayload;
+
+              require __DIR__ . '/../../../vendor/autoload.php';
+
+              $httpClient = new \Symfony\Component\HttpClient\Psr18Client();
+              $client = new \ApiVideo\Client(
+                                  'https://sandbox.api.video',
+                                  'YOUR_API_TOKEN',
+                                  $httpClient
+                              );
+
+              $client->videos()->update("vi6DEWhlgoHU3Ig5tgPlYkBc", (new VideoUpdatePayload())
+                  ->setTitle("The new title")
+                  ->setPublic(false)
+                  ->setDescription("A new description")
+                  ->setTags(["tag1", "tag2"])
+                  ->setMetadata(array(
+                      new Metadata(["key" => "aa", 'value' => "bb"]),
+                      new Metadata(["key" => "aa2", 'value' => "bb2"]))));
   /videos/{videoId}/status:
     get:
       tags:
-      - Videos
+        - Videos
       summary: Show video status
       description: This API provides upload status & encoding status to determine when the video is uploaded or ready to playback. Once encoding is completed, the response also lists the available stream qualities. Tutorials using [video status](https://api.video/blog/endpoints/video-status).
       operationId: GET-video-status
       parameters:
-      - name: videoId
-        in: path
-        description: The unique identifier for the video you want the status for.
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-        example: vi4k0jvEUuaTdRAEjQ4Jfrgz
+        - name: videoId
+          in: path
+          description: The unique identifier for the video you want the status for.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: vi4k0jvEUuaTdRAEjQ4Jfrgz
       responses:
         "200":
           description: Success
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/videostatus'
+                $ref: '#/components/schemas/video-status'
               examples:
                 response:
                   value:
@@ -1321,28 +1382,28 @@ paths:
                       status: uploaded
                       filesize: 273579401
                       receivedBytes:
-                      - to: 134217727
-                        from: 0
-                        total: 273579401
-                      - to: 268435455
-                        from: 134217728
-                        total: 273579401
-                      - to: 273579400
-                        from: 268435456
-                        total: 273579401
+                        - to: 134217727
+                          from: 0
+                          total: 273579401
+                        - to: 268435455
+                          from: 134217728
+                          total: 273579401
+                        - to: 273579400
+                          from: 268435456
+                          total: 273579401
                     encoding:
                       playable: true
                       qualities:
-                      - quality: 360p
-                        status: encoded
-                      - quality: 480p
-                        status: encoded
-                      - quality: 720p
-                        status: encoded
-                      - quality: 1080p
-                        status: encoding
-                      - quality: 2160p
-                        status: waiting
+                        - quality: 360p
+                          status: encoded
+                        - quality: 480p
+                          status: encoded
+                        - quality: 720p
+                          status: encoded
+                        - quality: 1080p
+                          status: encoding
+                        - quality: 2160p
+                          status: waiting
                       metadata:
                         width: 424
                         height: 240
@@ -1367,144 +1428,126 @@ paths:
                     name: videoId
                     status: 404
       security:
-      - bearerAuth: []
-      x-client-action: getVideoStatus
+        - bearerAuth: []
+      x-client-action: getStatus
       x-readme:
         code-samples:
-        - language: go
-          code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\n package main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    videoId := \"vi4k0jvEUuaTdRAEjQ4Jfrgz\" // string | The unique identifier for the video you want the status for.\n\n    \n    res, err := client.Videos.GetStatus(videoId)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `Videos.GetStatus``: %v\\n\", err)\n    }\n    // response from `GetStatus`: VideoStatus\n    fmt.Fprintf(os.Stdout, \"Response from `Videos.GetStatus`: %v\\n\", res)\n}             \n"
-        - language: node
-          code: |
-            //install the module with npm or yarn
-            //npm install @api.video/nodejs-client --save
-            //yarn add @api.video/nodejs-client
-            (async () => {
-                try {
-                    const client = new ApiVideoClient({ apiKey: "YOUR_API_TOKEN" });
+          - language: go
+            code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\n package main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    videoId := \"vi4k0jvEUuaTdRAEjQ4Jfrgz\" // string | The unique identifier for the video you want the status for.\n\n    \n    res, err := client.Videos.GetStatus(videoId)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `Videos.GetStatus``: %v\\n\", err)\n    }\n    // response from `GetStatus`: VideoStatus\n    fmt.Fprintf(os.Stdout, \"Response from `Videos.GetStatus`: %v\\n\", res)\n}             \n"
+          - language: node
+            code: |
+              //install the module with npm or yarn
+              //npm install @api.video/nodejs-client --save
+              //yarn add @api.video/nodejs-client
+              (async () => {
+                  try {
+                      const client = new ApiVideoClient({ apiKey: "YOUR_API_TOKEN" });
 
-                    const videoId = 'vi4k0jvEUuaTdRAEjQ4Jfrgz'; // The unique identifier for the video you want the status for.
+                      const videoId = 'vi4k0jvEUuaTdRAEjQ4Jfrgz'; // The unique identifier for the video you want the status for.
 
-                    // VideoStatus
-                    const result = await client.videos.getStatus(videoId);
-                    console.log(result);
-                } catch (e) {
-                    console.error(e);
-                }
-            })();
-        - language: python
-          code: |
-            #install the api.video API client library
-            #pip install api.video
-            import apivideo
-            from apivideo.api import videos_api
-            from apivideo.model.video_status import VideoStatus
-            from apivideo.model.not_found import NotFound
-            from pprint import pprint
+                      // VideoStatus
+                      const result = await client.videos.getStatus(videoId);
+                      console.log(result);
+                  } catch (e) {
+                      console.error(e);
+                  }
+              })();
+          - language: python
+            code: |
+              #install the api.video API client library
+              #pip install api.video
+              import apivideo
+              from apivideo.api import videos_api
+              from apivideo.model.video_status import VideoStatus
+              from apivideo.model.not_found import NotFound
+              from pprint import pprint
 
-            # Enter a context with an instance of the API client
-            with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
-                # Create an instance of the API class
-                api_instance = videos_api.VideosApi(api_client)
-                video_id = "vi4k0jvEUuaTdRAEjQ4Jfrgz" # str | The unique identifier for the video you want the status for.
+              # Enter a context with an instance of the API client
+              with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
+                  # Create an instance of the API class
+                  api_instance = videos_api.VideosApi(api_client)
+                  video_id = "vi4k0jvEUuaTdRAEjQ4Jfrgz" # str | The unique identifier for the video you want the status for.
 
-                # example passing only required values which don't have defaults set
-                try:
-                    # Show video status
-                    api_response = api_instance.get_status(video_id)
-                    pprint(api_response)
-                except apivideo.ApiException as e:
-                    print("Exception when calling VideosApi->get_status: %s\n" % e)
-        - language: java
-          code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.VideosApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    VideosApi apiInstance = client.videos();\n    \n    String videoId = \"vi4k0jvEUuaTdRAEjQ4Jfrgz\"; // The unique identifier for the video you want the status for.\n\n    try {\n      VideoStatus result = apiInstance.getStatus(videoId);\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling VideosApi#getStatus\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
-        - language: csharp
-          code: |
-            //install via Nuget
-            //Install-Package ApiVideo
-            using System.Diagnostics;
-            using ApiVideo.Client;
+                  # example passing only required values which don't have defaults set
+                  try:
+                      # Show video status
+                      api_response = api_instance.get_status(video_id)
+                      pprint(api_response)
+                  except apivideo.ApiException as e:
+                      print("Exception when calling VideosApi->get_status: %s\n" % e)
+          - language: java
+            code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.VideosApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    VideosApi apiInstance = client.videos();\n    \n    String videoId = \"vi4k0jvEUuaTdRAEjQ4Jfrgz\"; // The unique identifier for the video you want the status for.\n\n    try {\n      VideoStatus result = apiInstance.getStatus(videoId);\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling VideosApi#getStatus\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
+          - language: csharp
+            code: |
+              //install via Nuget
+              //Install-Package ApiVideo
+              using System.Diagnostics;
+              using ApiVideo.Client;
 
-            namespace Example
-            {
-                public class getStatusExample
-                {
-                    public static void Main()
-                    {
-                        var basePath = ApiVideoClient.Client.Environment.SANDBOX;
-                        var apiKey = "YOUR_API_KEY";
+              namespace Example
+              {
+                  public class getStatusExample
+                  {
+                      public static void Main()
+                      {
+                          var basePath = ApiVideoClient.Client.Environment.SANDBOX;
+                          var apiKey = "YOUR_API_KEY";
 
-                        var apiInstance = new ApiVideoClient(apiKey,basePath);
+                          var apiInstance = new ApiVideoClient(apiKey,basePath);
 
-                        var videoId = vi4k0jvEUuaTdRAEjQ4Jfrgz;  // string | The unique identifier for the video you want the status for.
-                        var apiVideosInstance = apiInstance.Videos();
-                        try
-                        {
-                            // Show video status
-                            VideoStatus result = apiVideosInstance.getStatus(videoId);
-                            Debug.WriteLine(result);
-                        }
-                        catch (ApiException  e)
-                        {
-                            Debug.Print("Exception when calling VideosApi.getStatus: " + e.Message );
-                            Debug.Print("Status Code: "+ e.ErrorCode);
-                            Debug.Print(e.StackTrace);
-                        }
-                    }
-                }
-            }
+                          var videoId = vi4k0jvEUuaTdRAEjQ4Jfrgz;  // string | The unique identifier for the video you want the status for.
+                          var apiVideosInstance = apiInstance.Videos();
+                          try
+                          {
+                              // Show video status
+                              VideoStatus result = apiVideosInstance.getStatus(videoId);
+                              Debug.WriteLine(result);
+                          }
+                          catch (ApiException  e)
+                          {
+                              Debug.Print("Exception when calling VideosApi.getStatus: " + e.Message );
+                              Debug.Print("Status Code: "+ e.ErrorCode);
+                              Debug.Print(e.StackTrace);
+                          }
+                      }
+                  }
+              }
   /upload-tokens:
     get:
       tags:
-      - Videos - Delegated upload
+        - Upload Tokens
       summary: List all active upload tokens.
       description: |-
         A delegated token is used to allow secure uploads without exposing your API key. Use this endpoint to retrieve a list of all currently active delegated tokens.
         Tutorials using [delegated upload](https://api.video/blog/endpoints/delegated-upload).
       operationId: GET_upload-tokens
       parameters:
-      - name: sortBy
-        in: query
-        description: 'Allowed: createdAt, ttl. You can use these to sort by when a token was created, or how much longer the token will be active (ttl - time to live). Date and time is presented in ISO-8601 format.'
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-          enum:
-          - createdAt
-          - ttl
-        example: ttl
-      - name: sortOrder
-        in: query
-        description: 'Allowed: asc, desc. Ascending is 0-9 or A-Z. Descending is 9-0 or Z-A.'
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-          enum:
-          - asc
-          - desc
-        example: asc
-      - name: currentPage
-        in: query
-        description: 'Choose the number of search results to return per page. Minimum value: 1'
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          default: 1
-        example: 2
-      - name: pageSize
-        in: query
-        description: Results per page. Allowed values 1-100, default is 25.
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          default: 25
-        example: 30
+        - name: sortBy
+          in: query
+          description: 'Allowed: createdAt, ttl. You can use these to sort by when a token was created, or how much longer the token will be active (ttl - time to live). Date and time is presented in ISO-8601 format.'
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+            enum:
+              - createdAt
+              - ttl
+          example: ttl
+        - name: sortOrder
+          in: query
+          description: 'Allowed: asc, desc. Ascending is 0-9 or A-Z. Descending is 9-0 or Z-A.'
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+            enum:
+              - asc
+              - desc
+          example: asc
+        - $ref: '#/components/parameters/current-page'
+        - $ref: '#/components/parameters/page-size'
       responses:
         "200":
           description: Success
@@ -1516,13 +1559,13 @@ paths:
                 response:
                   value:
                     data:
-                    - token: to37YfoPDRR2pcDKa6LsUE0M
-                      ttl: 3600
-                      createdAt: 2020-12-02T10:26:46+00:00
-                      expiresAt: 2020-12-02T11:26:46+00:00
-                    - token: to1W3ZS9PdUBZWzzTEZr1B79
-                      ttl: 0
-                      createdAt: 2020-12-02T10:26:28+00:00
+                      - token: to37YfoPDRR2pcDKa6LsUE0M
+                        ttl: 3600
+                        createdAt: 2020-12-02T10:26:46+00:00
+                        expiresAt: 2020-12-02T11:26:46+00:00
+                      - token: to1W3ZS9PdUBZWzzTEZr1B79
+                        ttl: 0
+                        createdAt: 2020-12-02T10:26:28+00:00
                     pagination:
                       currentPage: 1
                       currentPageItems: 2
@@ -1530,110 +1573,112 @@ paths:
                       pagesTotal: 1
                       itemsTotal: 2
                       links:
-                      - rel: self
-                        uri: /upload-tokens?currentPage=1&pageSize=25
-                      - rel: first
-                        uri: /upload-tokens?currentPage=1&pageSize=25
-                      - rel: last
-                        uri: /upload-tokens?currentPage=1&pageSize=25
+                        - rel: self
+                          uri: /upload-tokens?currentPage=1&pageSize=25
+                        - rel: first
+                          uri: /upload-tokens?currentPage=1&pageSize=25
+                        - rel: last
+                          uri: /upload-tokens?currentPage=1&pageSize=25
       security:
-      - bearerAuth: []
+        - bearerAuth: []
       x-group-parameters: true
       x-client-paginated: true
-      x-client-action: listTokens
+      x-optional-object: true
+      x-client-action: list
       x-readme:
         code-samples:
-        - language: go
-          code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    uploadToken := \"to1tcmSFHeYY5KzyhOqVKMKb\" // string | The unique identifier for the token you want information about.\n\n    \n    res, err := client.UploadTokens.GetToken(uploadToken)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `UploadTokens.GetToken``: %v\\n\", err)\n    }\n    // response from `GetToken`: UploadToken\n    fmt.Fprintf(os.Stdout, \"Response from `UploadTokens.GetToken`: %v\\n\", res)\n}\n"
-        - language: node
-          code: |
-            //install the module with npm or yarn
-            //npm install @api.video/nodejs-client --save
-            //yarn add @api.video/nodejs-client
-            (async () => {
-                try {
-                    const client = new ApiVideoClient({ apiKey: "YOUR_API_TOKEN" });
+          - language: go
+            code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    uploadToken := \"to1tcmSFHeYY5KzyhOqVKMKb\" // string | The unique identifier for the token you want information about.\n\n    \n    res, err := client.UploadTokens.GetToken(uploadToken)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `UploadTokens.GetToken``: %v\\n\", err)\n    }\n    // response from `GetToken`: UploadToken\n    fmt.Fprintf(os.Stdout, \"Response from `UploadTokens.GetToken`: %v\\n\", res)\n}\n"
+          - language: node
+            code: |
+              //install the module with npm or yarn
+              //npm install @api.video/nodejs-client --save
+              //yarn add @api.video/nodejs-client
+              (async () => {
+                  try {
+                      const client = new ApiVideoClient({ apiKey: "YOUR_API_TOKEN" });
 
-                    const uploadToken = 'to1tcmSFHeYY5KzyhOqVKMKb'; // The unique identifier for the token you want information about.
+                      const uploadToken = 'to1tcmSFHeYY5KzyhOqVKMKb'; // The unique identifier for the token you want information about.
 
-                    // UploadToken
-                    const result = await client.uploadTokens.getToken(uploadToken);
-                    console.log(result);
-                } catch (e) {
-                    console.error(e);
-                }
-            })();
-        - language: python
-          code: |
-            #install the api.video API client library
-            #pip install api.video
-            import apivideo
-            from apivideo.api import upload_tokens_api
-            from apivideo.model.not_found import NotFound
-            from apivideo.model.upload_token import UploadToken
-            from pprint import pprint
+                      // UploadToken
+                      const result = await client.uploadTokens.getToken(uploadToken);
+                      console.log(result);
+                  } catch (e) {
+                      console.error(e);
+                  }
+              })();
+          - language: python
+            code: |
+              #install the api.video API client library
+              #pip install api.video
+              import apivideo
+              from apivideo.api import upload_tokens_api
+              from apivideo.model.not_found import NotFound
+              from apivideo.model.upload_token import UploadToken
+              from pprint import pprint
 
-            # Enter a context with an instance of the API client
-            with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
-                # Create an instance of the API class
-                api_instance = upload_tokens_api.UploadTokensApi(api_client)
-                upload_token = "to1tcmSFHeYY5KzyhOqVKMKb" # str | The unique identifier for the token you want information about.
+              # Enter a context with an instance of the API client
+              with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
+                  # Create an instance of the API class
+                  api_instance = upload_tokens_api.UploadTokensApi(api_client)
+                  upload_token = "to1tcmSFHeYY5KzyhOqVKMKb" # str | The unique identifier for the token you want information about.
 
-                # example passing only required values which don't have defaults set
-                try:
-                    # Show upload token
-                    api_response = api_instance.get_token(upload_token)
-                    pprint(api_response)
-                except apivideo.ApiException as e:
-                    print("Exception when calling UploadTokensApi->get_token: %s\n" % e)
-        - language: java
-          code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.UploadTokensApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    UploadTokensApi apiInstance = client.uploadTokens();\n    \n    String uploadToken = \"to1tcmSFHeYY5KzyhOqVKMKb\"; // The unique identifier for the token you want information about.\n\n    try {\n      UploadToken result = apiInstance.getToken(uploadToken);\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling UploadTokensApi#getToken\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
-        - language: csharp
-          code: |
-            //install via Nuget
-            //Install-Package ApiVideo
-            using System.Diagnostics;
-            using ApiVideo.Client;
+                  # example passing only required values which don't have defaults set
+                  try:
+                      # Show upload token
+                      api_response = api_instance.get_token(upload_token)
+                      pprint(api_response)
+                  except apivideo.ApiException as e:
+                      print("Exception when calling UploadTokensApi->get_token: %s\n" % e)
+          - language: java
+            code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.UploadTokensApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    UploadTokensApi apiInstance = client.uploadTokens();\n    \n    String uploadToken = \"to1tcmSFHeYY5KzyhOqVKMKb\"; // The unique identifier for the token you want information about.\n\n    try {\n      UploadToken result = apiInstance.getToken(uploadToken);\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling UploadTokensApi#getToken\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
+          - language: csharp
+            code: |
+              //install via Nuget
+              //Install-Package ApiVideo
+              using System.Diagnostics;
+              using ApiVideo.Client;
 
-            namespace Example
-            {
-                public class getTokenExample
-                {
-                    public static void Main()
-                    {
-                        var basePath = ApiVideoClient.Client.Environment.SANDBOX;
-                        var apiKey = "YOUR_API_KEY";
+              namespace Example
+              {
+                  public class getTokenExample
+                  {
+                      public static void Main()
+                      {
+                          var basePath = ApiVideoClient.Client.Environment.SANDBOX;
+                          var apiKey = "YOUR_API_KEY";
 
-                        var apiInstance = new ApiVideoClient(apiKey,basePath);
+                          var apiInstance = new ApiVideoClient(apiKey,basePath);
 
-                        var uploadToken = to1tcmSFHeYY5KzyhOqVKMKb;  // string | The unique identifier for the token you want information about.
-                        var apiUploadTokensInstance = apiInstance.UploadTokens();
-                        try
-                        {
-                            // Show upload token
-                            UploadToken result = apiUploadTokensInstance.getToken(uploadToken);
-                            Debug.WriteLine(result);
-                        }
-                        catch (ApiException  e)
-                        {
-                            Debug.Print("Exception when calling UploadTokensApi.getToken: " + e.Message );
-                            Debug.Print("Status Code: "+ e.ErrorCode);
-                            Debug.Print(e.StackTrace);
-                        }
-                    }
-                }
-            }
+                          var uploadToken = to1tcmSFHeYY5KzyhOqVKMKb;  // string | The unique identifier for the token you want information about.
+                          var apiUploadTokensInstance = apiInstance.UploadTokens();
+                          try
+                          {
+                              // Show upload token
+                              UploadToken result = apiUploadTokensInstance.getToken(uploadToken);
+                              Debug.WriteLine(result);
+                          }
+                          catch (ApiException  e)
+                          {
+                              Debug.Print("Exception when calling UploadTokensApi.getToken: " + e.Message );
+                              Debug.Print("Status Code: "+ e.ErrorCode);
+                              Debug.Print(e.StackTrace);
+                          }
+                      }
+                  }
+              }
     post:
       tags:
-      - Videos - Delegated upload
+        - Upload Tokens
       summary: Generate an upload token
       description: Use this endpoint to generate an upload token. You can use this token to authenticate video uploads while keeping your API key safe. Tutorials using [delegated upload](https://api.video/blog/endpoints/delegated-upload).
       operationId: POST_upload-tokens
       requestBody:
+        required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/token-create-payload'
+              $ref: '#/components/schemas/token-creation-payload'
       responses:
         "200":
           description: Success
@@ -1655,37 +1700,37 @@ paths:
               schema:
                 $ref: '#/components/schemas/bad-request'
       security:
-      - bearerAuth: []
+        - bearerAuth: []
       x-client-action: createToken
       x-readme:
         code-samples:
-        - language: go
-          code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    tokenCreationPayload := *apivideosdk.NewTokenCreationPayload() // TokenCreationPayload | \n\n    \n    res, err := client.UploadTokens.CreateToken(tokenCreationPayload)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `UploadTokens.CreateToken``: %v\\n\", err)\n    }\n    // response from `CreateToken`: UploadToken\n    fmt.Fprintf(os.Stdout, \"Response from `UploadTokens.CreateToken`: %v\\n\", res)\n}\n"
-        - language: node
-          code: "//install the module with npm or yarn\n//npm install @api.video/nodejs-client --save\n//yarn add @api.video/nodejs-client\n(async () => {\n    try {\n        const client = new ApiVideoClient({ apiKey: \"YOUR_API_TOKEN\" });\n\n        const tokenCreationPayload = {\n      ttl: 56, // Time in seconds that the token will be active. A value of 0 means that the token has no expiration date. The default is to have no expiration.\n    }; \n\n        // UploadToken\n        const result = await client.uploadTokens.createToken(tokenCreationPayload);\n        console.log(result);\n    } catch (e) {\n        console.error(e);\n    }\n})();\n"
-        - language: python
-          code: "#install the api.video API client library\n#pip install api.video\nimport apivideo\nfrom apivideo.api import upload_tokens_api\nfrom apivideo.model.bad_request import BadRequest\nfrom apivideo.model.upload_token import UploadToken\nfrom apivideo.model.token_creation_payload import TokenCreationPayload\nfrom pprint import pprint\n\n# Enter a context with an instance of the API client\nwith apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:\n    # Create an instance of the API class\n    api_instance = upload_tokens_api.UploadTokensApi(api_client)\n    token_creation_payload = TokenCreationPayload(\n        ttl=0,\n    ) # TokenCreationPayload | \n\n    # example passing only required values which don't have defaults set\n    try:\n        # Generate an upload token\n        api_response = api_instance.create_token(token_creation_payload)\n        pprint(api_response)\n    except apivideo.ApiException as e:\n        print(\"Exception when calling UploadTokensApi->create_token: %s\\n\" % e)\n"
-        - language: java
-          code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.UploadTokensApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    UploadTokensApi apiInstance = client.uploadTokens();\n    \n    TokenCreationPayload tokenCreationPayload = new TokenCreationPayload(); // \n    tokenCreationPayload.setTtl(); // Time in seconds that the token will be active. A value of 0 means that the token has no expiration date. The default is to have no expiration.\n\n\n    try {\n      UploadToken result = apiInstance.createToken(tokenCreationPayload);\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling UploadTokensApi#createToken\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
-        - language: csharp
-          code: "//install via Nuget\n//Install-Package ApiVideo\nusing System.Diagnostics;\nusing ApiVideo.Client;\n\nnamespace Example\n{\n    public class createTokenExample\n    {\n        public static void Main()\n        {\n            var basePath = ApiVideoClient.Client.Environment.SANDBOX;\n            var apiKey = \"YOUR_API_KEY\";\n\n            var apiInstance = new ApiVideoClient(apiKey,basePath);\n\n            var tokenCreationPayload = new TokenCreationPayload(); // TokenCreationPayload | \n            var apiUploadTokensInstance = apiInstance.UploadTokens();\n            try\n            {\n                // Generate an upload token\n                UploadToken result = apiUploadTokensInstance.createToken(tokenCreationPayload);\n                Debug.WriteLine(result);\n            }\n            catch (ApiException  e)\n            {\n                Debug.Print(\"Exception when calling UploadTokensApi.createToken: \" + e.Message );\n                Debug.Print(\"Status Code: \"+ e.ErrorCode);\n                Debug.Print(e.StackTrace);\n            }\n        }\n    }\n}\n"
+          - language: go
+            code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    tokenCreationPayload := *apivideosdk.NewTokenCreationPayload() // TokenCreationPayload | \n\n    \n    res, err := client.UploadTokens.CreateToken(tokenCreationPayload)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `UploadTokens.CreateToken``: %v\\n\", err)\n    }\n    // response from `CreateToken`: UploadToken\n    fmt.Fprintf(os.Stdout, \"Response from `UploadTokens.CreateToken`: %v\\n\", res)\n}\n"
+          - language: node
+            code: "//install the module with npm or yarn\n//npm install @api.video/nodejs-client --save\n//yarn add @api.video/nodejs-client\n(async () => {\n    try {\n        const client = new ApiVideoClient({ apiKey: \"YOUR_API_TOKEN\" });\n\n        const tokenCreationPayload = {\n      ttl: 56, // Time in seconds that the token will be active. A value of 0 means that the token has no expiration date. The default is to have no expiration.\n    }; \n\n        // UploadToken\n        const result = await client.uploadTokens.createToken(tokenCreationPayload);\n        console.log(result);\n    } catch (e) {\n        console.error(e);\n    }\n})();\n"
+          - language: python
+            code: "#install the api.video API client library\n#pip install api.video\nimport apivideo\nfrom apivideo.api import upload_tokens_api\nfrom apivideo.model.bad_request import BadRequest\nfrom apivideo.model.upload_token import UploadToken\nfrom apivideo.model.token_creation_payload import TokenCreationPayload\nfrom pprint import pprint\n\n# Enter a context with an instance of the API client\nwith apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:\n    # Create an instance of the API class\n    api_instance = upload_tokens_api.UploadTokensApi(api_client)\n    token_creation_payload = TokenCreationPayload(\n        ttl=0,\n    ) # TokenCreationPayload | \n\n    # example passing only required values which don't have defaults set\n    try:\n        # Generate an upload token\n        api_response = api_instance.create_token(token_creation_payload)\n        pprint(api_response)\n    except apivideo.ApiException as e:\n        print(\"Exception when calling UploadTokensApi->create_token: %s\\n\" % e)\n"
+          - language: java
+            code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.UploadTokensApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    UploadTokensApi apiInstance = client.uploadTokens();\n    \n    TokenCreationPayload tokenCreationPayload = new TokenCreationPayload(); // \n    tokenCreationPayload.setTtl(); // Time in seconds that the token will be active. A value of 0 means that the token has no expiration date. The default is to have no expiration.\n\n\n    try {\n      UploadToken result = apiInstance.createToken(tokenCreationPayload);\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling UploadTokensApi#createToken\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
+          - language: csharp
+            code: "//install via Nuget\n//Install-Package ApiVideo\nusing System.Diagnostics;\nusing ApiVideo.Client;\n\nnamespace Example\n{\n    public class createTokenExample\n    {\n        public static void Main()\n        {\n            var basePath = ApiVideoClient.Client.Environment.SANDBOX;\n            var apiKey = \"YOUR_API_KEY\";\n\n            var apiInstance = new ApiVideoClient(apiKey,basePath);\n\n            var tokenCreationPayload = new TokenCreationPayload(); // TokenCreationPayload | \n            var apiUploadTokensInstance = apiInstance.UploadTokens();\n            try\n            {\n                // Generate an upload token\n                UploadToken result = apiUploadTokensInstance.createToken(tokenCreationPayload);\n                Debug.WriteLine(result);\n            }\n            catch (ApiException  e)\n            {\n                Debug.Print(\"Exception when calling UploadTokensApi.createToken: \" + e.Message );\n                Debug.Print(\"Status Code: \"+ e.ErrorCode);\n                Debug.Print(e.StackTrace);\n            }\n        }\n    }\n}\n"
   /upload-tokens/{uploadToken}:
     get:
       tags:
-      - Videos - Delegated upload
+        - Upload Tokens
       summary: Show upload token
       description: You can retrieve details about a specific upload token if you have the unique identifier for the upload token. Add it in the path of the endpoint. Details include time-to-live (ttl), when the token was created, and when it will expire.
       operationId: GET_upload-tokens-uploadToken
       parameters:
-      - name: uploadToken
-        in: path
-        description: The unique identifier for the token you want information about.
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-        example: to1tcmSFHeYY5KzyhOqVKMKb
+        - name: uploadToken
+          in: path
+          description: The unique identifier for the token you want information about.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: to1tcmSFHeYY5KzyhOqVKMKb
       responses:
         "200":
           description: Success
@@ -1706,106 +1751,106 @@ paths:
               schema:
                 $ref: '#/components/schemas/not-found'
       security:
-      - bearerAuth: []
+        - bearerAuth: []
       x-client-action: getToken
       x-readme:
         code-samples:
-        - language: go
-          code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    uploadToken := \"to1tcmSFHeYY5KzyhOqVKMKb\" // string | The unique identifier for the token you want information about.\n\n    \n    res, err := client.UploadTokens.GetToken(uploadToken)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `UploadTokens.GetToken``: %v\\n\", err)\n    }\n    // response from `GetToken`: UploadToken\n    fmt.Fprintf(os.Stdout, \"Response from `UploadTokens.GetToken`: %v\\n\", res)\n}\n"
-        - language: node
-          code: |
-            //install the module with npm or yarn
-            //npm install @api.video/nodejs-client --save
-            //yarn add @api.video/nodejs-client
-            (async () => {
-                try {
-                    const client = new ApiVideoClient({ apiKey: "YOUR_API_TOKEN" });
+          - language: go
+            code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    uploadToken := \"to1tcmSFHeYY5KzyhOqVKMKb\" // string | The unique identifier for the token you want information about.\n\n    \n    res, err := client.UploadTokens.GetToken(uploadToken)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `UploadTokens.GetToken``: %v\\n\", err)\n    }\n    // response from `GetToken`: UploadToken\n    fmt.Fprintf(os.Stdout, \"Response from `UploadTokens.GetToken`: %v\\n\", res)\n}\n"
+          - language: node
+            code: |
+              //install the module with npm or yarn
+              //npm install @api.video/nodejs-client --save
+              //yarn add @api.video/nodejs-client
+              (async () => {
+                  try {
+                      const client = new ApiVideoClient({ apiKey: "YOUR_API_TOKEN" });
 
-                    const uploadToken = 'to1tcmSFHeYY5KzyhOqVKMKb'; // The unique identifier for the token you want information about.
+                      const uploadToken = 'to1tcmSFHeYY5KzyhOqVKMKb'; // The unique identifier for the token you want information about.
 
-                    // UploadToken
-                    const result = await client.uploadTokens.getToken(uploadToken);
-                    console.log(result);
-                } catch (e) {
-                    console.error(e);
-                }
-            })();
-        - language: python
-          code: |
-            #install the api.video API client library
-            #pip install api.video
-            import apivideo
-            from apivideo.api import upload_tokens_api
-            from apivideo.model.not_found import NotFound
-            from apivideo.model.upload_token import UploadToken
-            from pprint import pprint
+                      // UploadToken
+                      const result = await client.uploadTokens.getToken(uploadToken);
+                      console.log(result);
+                  } catch (e) {
+                      console.error(e);
+                  }
+              })();
+          - language: python
+            code: |
+              #install the api.video API client library
+              #pip install api.video
+              import apivideo
+              from apivideo.api import upload_tokens_api
+              from apivideo.model.not_found import NotFound
+              from apivideo.model.upload_token import UploadToken
+              from pprint import pprint
 
-            # Enter a context with an instance of the API client
-            with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
-                # Create an instance of the API class
-                api_instance = upload_tokens_api.UploadTokensApi(api_client)
-                upload_token = "to1tcmSFHeYY5KzyhOqVKMKb" # str | The unique identifier for the token you want information about.
+              # Enter a context with an instance of the API client
+              with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
+                  # Create an instance of the API class
+                  api_instance = upload_tokens_api.UploadTokensApi(api_client)
+                  upload_token = "to1tcmSFHeYY5KzyhOqVKMKb" # str | The unique identifier for the token you want information about.
 
-                # example passing only required values which don't have defaults set
-                try:
-                    # Show upload token
-                    api_response = api_instance.get_token(upload_token)
-                    pprint(api_response)
-                except apivideo.ApiException as e:
-                    print("Exception when calling UploadTokensApi->get_token: %s\n" % e)
-        - language: java
-          code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.UploadTokensApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    UploadTokensApi apiInstance = client.uploadTokens();\n    \n    String uploadToken = \"to1tcmSFHeYY5KzyhOqVKMKb\"; // The unique identifier for the token you want information about.\n\n    try {\n      UploadToken result = apiInstance.getToken(uploadToken);\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling UploadTokensApi#getToken\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
-        - language: csharp
-          code: |
-            //install via Nuget
-            //Install-Package ApiVideo
-            using System.Diagnostics;
-            using ApiVideo.Client;
+                  # example passing only required values which don't have defaults set
+                  try:
+                      # Show upload token
+                      api_response = api_instance.get_token(upload_token)
+                      pprint(api_response)
+                  except apivideo.ApiException as e:
+                      print("Exception when calling UploadTokensApi->get_token: %s\n" % e)
+          - language: java
+            code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.UploadTokensApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    UploadTokensApi apiInstance = client.uploadTokens();\n    \n    String uploadToken = \"to1tcmSFHeYY5KzyhOqVKMKb\"; // The unique identifier for the token you want information about.\n\n    try {\n      UploadToken result = apiInstance.getToken(uploadToken);\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling UploadTokensApi#getToken\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
+          - language: csharp
+            code: |
+              //install via Nuget
+              //Install-Package ApiVideo
+              using System.Diagnostics;
+              using ApiVideo.Client;
 
-            namespace Example
-            {
-                public class getTokenExample
-                {
-                    public static void Main()
-                    {
-                        var basePath = ApiVideoClient.Client.Environment.SANDBOX;
-                        var apiKey = "YOUR_API_KEY";
+              namespace Example
+              {
+                  public class getTokenExample
+                  {
+                      public static void Main()
+                      {
+                          var basePath = ApiVideoClient.Client.Environment.SANDBOX;
+                          var apiKey = "YOUR_API_KEY";
 
-                        var apiInstance = new ApiVideoClient(apiKey,basePath);
+                          var apiInstance = new ApiVideoClient(apiKey,basePath);
 
-                        var uploadToken = to1tcmSFHeYY5KzyhOqVKMKb;  // string | The unique identifier for the token you want information about.
-                        var apiUploadTokensInstance = apiInstance.UploadTokens();
-                        try
-                        {
-                            // Show upload token
-                            UploadToken result = apiUploadTokensInstance.getToken(uploadToken);
-                            Debug.WriteLine(result);
-                        }
-                        catch (ApiException  e)
-                        {
-                            Debug.Print("Exception when calling UploadTokensApi.getToken: " + e.Message );
-                            Debug.Print("Status Code: "+ e.ErrorCode);
-                            Debug.Print(e.StackTrace);
-                        }
-                    }
-                }
-            }
+                          var uploadToken = to1tcmSFHeYY5KzyhOqVKMKb;  // string | The unique identifier for the token you want information about.
+                          var apiUploadTokensInstance = apiInstance.UploadTokens();
+                          try
+                          {
+                              // Show upload token
+                              UploadToken result = apiUploadTokensInstance.getToken(uploadToken);
+                              Debug.WriteLine(result);
+                          }
+                          catch (ApiException  e)
+                          {
+                              Debug.Print("Exception when calling UploadTokensApi.getToken: " + e.Message );
+                              Debug.Print("Status Code: "+ e.ErrorCode);
+                              Debug.Print(e.StackTrace);
+                          }
+                      }
+                  }
+              }
     delete:
       tags:
-      - Videos - Delegated upload
+        - Upload Tokens
       summary: Delete an upload token
       description: Delete an existing upload token. This is especially useful for tokens you may have created that do not expire.
       operationId: DELETE_upload-tokens-uploadToken
       parameters:
-      - name: uploadToken
-        in: path
-        description: The unique identifier for the upload token you want to delete. Deleting a token will make it so the token can no longer be used for authentication.
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-        example: to1tcmSFHeYY5KzyhOqVKMKb
+        - name: uploadToken
+          in: path
+          description: The unique identifier for the upload token you want to delete. Deleting a token will make it so the token can no longer be used for authentication.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: to1tcmSFHeYY5KzyhOqVKMKb
       responses:
         "204":
           description: No Content
@@ -1816,116 +1861,117 @@ paths:
               schema:
                 $ref: '#/components/schemas/not-found'
       security:
-      - bearerAuth: []
+        - bearerAuth: []
       x-client-action: deleteToken
       x-readme:
         code-samples:
-        - language: go
-          code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    uploadToken := \"to1tcmSFHeYY5KzyhOqVKMKb\" // string | The unique identifier for the upload token you want to delete. Deleting a token will make it so the token can no longer be used for authentication.\n\n    \n    err := client.UploadTokens.DeleteToken(uploadToken)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `UploadTokens.DeleteToken``: %v\\n\", err)\n    }\n}\n"
-        - language: node
-          code: |
-            //install the module with npm or yarn
-            //npm install @api.video/nodejs-client --save
-            //yarn add @api.video/nodejs-client
-            (async () => {
-                try {
-                    const client = new ApiVideoClient({ apiKey: "YOUR_API_TOKEN" });
+          - language: go
+            code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    uploadToken := \"to1tcmSFHeYY5KzyhOqVKMKb\" // string | The unique identifier for the upload token you want to delete. Deleting a token will make it so the token can no longer be used for authentication.\n\n    \n    err := client.UploadTokens.DeleteToken(uploadToken)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `UploadTokens.DeleteToken``: %v\\n\", err)\n    }\n}\n"
+          - language: node
+            code: |
+              //install the module with npm or yarn
+              //npm install @api.video/nodejs-client --save
+              //yarn add @api.video/nodejs-client
+              (async () => {
+                  try {
+                      const client = new ApiVideoClient({ apiKey: "YOUR_API_TOKEN" });
 
-                    const uploadToken = 'to1tcmSFHeYY5KzyhOqVKMKb'; // The unique identifier for the upload token you want to delete. Deleting a token will make it so the token can no longer be used for authentication.
+                      const uploadToken = 'to1tcmSFHeYY5KzyhOqVKMKb'; // The unique identifier for the upload token you want to delete. Deleting a token will make it so the token can no longer be used for authentication.
 
-                    // void
-                    const result = await client.uploadTokens.deleteToken(uploadToken);
-                    console.log(result);
-                } catch (e) {
-                    console.error(e);
-                }
-            })();
-        - language: python
-          code: |
-            #install the api.video API client library
-            #pip install api.video
-            import apivideo
-            from apivideo.api import upload_tokens_api
-            from apivideo.model.not_found import NotFound
-            from pprint import pprint
+                      // void
+                      const result = await client.uploadTokens.deleteToken(uploadToken);
+                      console.log(result);
+                  } catch (e) {
+                      console.error(e);
+                  }
+              })();
+          - language: python
+            code: |
+              #install the api.video API client library
+              #pip install api.video
+              import apivideo
+              from apivideo.api import upload_tokens_api
+              from apivideo.model.not_found import NotFound
+              from pprint import pprint
 
-            # Enter a context with an instance of the API client
-            with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
-                # Create an instance of the API class
-                api_instance = upload_tokens_api.UploadTokensApi(api_client)
-                upload_token = "to1tcmSFHeYY5KzyhOqVKMKb" # str | The unique identifier for the upload token you want to delete. Deleting a token will make it so the token can no longer be used for authentication.
+              # Enter a context with an instance of the API client
+              with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
+                  # Create an instance of the API class
+                  api_instance = upload_tokens_api.UploadTokensApi(api_client)
+                  upload_token = "to1tcmSFHeYY5KzyhOqVKMKb" # str | The unique identifier for the upload token you want to delete. Deleting a token will make it so the token can no longer be used for authentication.
 
-                # example passing only required values which don't have defaults set
-                try:
-                    # Delete an upload token
-                    api_instance.delete_token(upload_token)
-                except apivideo.ApiException as e:
-                    print("Exception when calling UploadTokensApi->delete_token: %s\n" % e)
-        - language: java
-          code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.UploadTokensApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    UploadTokensApi apiInstance = client.uploadTokens();\n    \n    String uploadToken = \"to1tcmSFHeYY5KzyhOqVKMKb\"; // The unique identifier for the upload token you want to delete. Deleting a token will make it so the token can no longer be used for authentication.\n\n    try {\n      apiInstance.deleteToken(uploadToken);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling UploadTokensApi#deleteToken\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
-        - language: csharp
-          code: |
-            //install via Nuget
-            //Install-Package ApiVideo
-            using System.Diagnostics;
-            using ApiVideo.Client;
+                  # example passing only required values which don't have defaults set
+                  try:
+                      # Delete an upload token
+                      api_instance.delete_token(upload_token)
+                  except apivideo.ApiException as e:
+                      print("Exception when calling UploadTokensApi->delete_token: %s\n" % e)
+          - language: java
+            code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.UploadTokensApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    UploadTokensApi apiInstance = client.uploadTokens();\n    \n    String uploadToken = \"to1tcmSFHeYY5KzyhOqVKMKb\"; // The unique identifier for the upload token you want to delete. Deleting a token will make it so the token can no longer be used for authentication.\n\n    try {\n      apiInstance.deleteToken(uploadToken);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling UploadTokensApi#deleteToken\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
+          - language: csharp
+            code: |
+              //install via Nuget
+              //Install-Package ApiVideo
+              using System.Diagnostics;
+              using ApiVideo.Client;
 
-            namespace Example
-            {
-                public class deleteTokenExample
-                {
-                    public static void Main()
-                    {
-                        var basePath = ApiVideoClient.Client.Environment.SANDBOX;
-                        var apiKey = "YOUR_API_KEY";
+              namespace Example
+              {
+                  public class deleteTokenExample
+                  {
+                      public static void Main()
+                      {
+                          var basePath = ApiVideoClient.Client.Environment.SANDBOX;
+                          var apiKey = "YOUR_API_KEY";
 
-                        var apiInstance = new ApiVideoClient(apiKey,basePath);
+                          var apiInstance = new ApiVideoClient(apiKey,basePath);
 
-                        var uploadToken = to1tcmSFHeYY5KzyhOqVKMKb;  // string | The unique identifier for the upload token you want to delete. Deleting a token will make it so the token can no longer be used for authentication.
-                        var apiUploadTokensInstance = apiInstance.UploadTokens();
-                        try
-                        {
-                            // Delete an upload token
-                            apiUploadTokensInstance.deleteToken(uploadToken);
-                        }
-                        catch (ApiException  e)
-                        {
-                            Debug.Print("Exception when calling UploadTokensApi.deleteToken: " + e.Message );
-                            Debug.Print("Status Code: "+ e.ErrorCode);
-                            Debug.Print(e.StackTrace);
-                        }
-                    }
-                }
-            }
+                          var uploadToken = to1tcmSFHeYY5KzyhOqVKMKb;  // string | The unique identifier for the upload token you want to delete. Deleting a token will make it so the token can no longer be used for authentication.
+                          var apiUploadTokensInstance = apiInstance.UploadTokens();
+                          try
+                          {
+                              // Delete an upload token
+                              apiUploadTokensInstance.deleteToken(uploadToken);
+                          }
+                          catch (ApiException  e)
+                          {
+                              Debug.Print("Exception when calling UploadTokensApi.deleteToken: " + e.Message );
+                              Debug.Print("Status Code: "+ e.ErrorCode);
+                              Debug.Print(e.StackTrace);
+                          }
+                      }
+                  }
+              }
   /upload:
     post:
       tags:
-      - Videos - Delegated upload
+        - Videos
       summary: Upload with an upload token
       description: "When given a token, anyone can upload a file to the URI `https://ws.api.video/upload?token=<tokenId>`.\n\nExample with cURL:\n\n```curl\n$ curl  --request POST --url 'https://ws.api.video/upload?token=toXXX'\n --header 'content-type: multipart/form-data'\n -F file=@video.mp4\n```\n\nOr in an HTML form, with a little JavaScript to convert the form into JSON:\n```html\n<!--form for user interaction-->\n<form name=\"videoUploadForm\" >\n  <label for=video>Video:</label>\n  <input type=file name=source/><br/>\n  <input value=\"Submit\" type=\"submit\">\n</form>\n<div></div>\n<!--JS takes the form data \n    uses FormData to turn the response into JSON.\n    then uses POST to upload the video file.\n    Update the token parameter in the url to your upload token.\n    -->\n<script>\n   var form = document.forms.namedItem(\"videoUploadForm\");\t\n   form.addEventListener('submit', function(ev) {\n\t ev.preventDefault();\n     var oOutput = document.querySelector(\"div\"),\n         oData = new FormData(form);\n     var oReq = new XMLHttpRequest();\n\t \n     oReq.open(\"POST\", \"https://ws.api.video/upload?token=toXXX\", true);\n     oReq.send(oData);\n\t oReq.onload = function(oEvent) {\n       if (oReq.status ==201) {\n         oOutput.innerHTML = \"Your video is uploaded!<br/>\"  + oReq.response;\n       } else {\n         oOutput.innerHTML = \"Error \" + oReq.status + \" occurred when trying to upload your file.<br \\/>\";\n       }\n     };\n   }, false);\t\n</script>\n```\n\n\n### Dealing with large files\n\nWe have created a <a href='https://api.video/blog/tutorials/uploading-large-files-with-javascript'>tutorial</a> to walk through the steps required."
       operationId: POST_upload
       parameters:
-      - name: token
-        in: query
-        description: The unique identifier for the token you want to use to upload a video.
-        required: true
-        style: form
-        explode: true
-        schema:
-          type: string
-        example: to1tcmSFHeYY5KzyhOqVKMKb
-      - name: Content-Range
-        in: header
-        description: Content-Range represents the range of bytes that will be returned as a result of the request. Byte ranges are inclusive, meaning that bytes 0-999 represents the first 1000 bytes in a file or object.
-        required: false
-        style: simple
-        explode: false
-        schema:
-          pattern: ^bytes [0-9]*-[0-9]*\/[0-9]*$
-          type: string
-        example: 'Content-Range: bytes 200-100/5000'
-        x-client-ignore: true
+        - name: token
+          in: query
+          description: The unique identifier for the token you want to use to upload a video.
+          required: true
+          style: form
+          explode: true
+          schema:
+            type: string
+          example: to1tcmSFHeYY5KzyhOqVKMKb
+        - name: Content-Range
+          in: header
+          description: Content-Range represents the range of bytes that will be returned as a result of the request. Byte ranges are inclusive, meaning that bytes 0-999 represents the first 1000 bytes in a file or object.
+          required: false
+          style: simple
+          explode: false
+          schema:
+            pattern: ^bytes [0-9]*-[0-9]*\/[0-9]*$
+            type: string
+          example: 'Content-Range: bytes 200-100/5000'
+          x-client-ignore: true
       requestBody:
+        required: true
         content:
           multipart/form-data:
             schema:
@@ -1947,14 +1993,14 @@ paths:
                     public: false
                     panoramic: false
                     tags:
-                    - maths
-                    - string theory
-                    - video
+                      - maths
+                      - string theory
+                      - video
                     metadata:
-                    - key: Author
-                      value: John Doe
-                    - key: Format
-                      value: Tutorial
+                      - key: Author
+                        value: John Doe
+                      - key: Format
+                        value: Tutorial
                     publishedAt: 4665-07-14T23:36:18.598Z
                     source:
                       uri: /videos/vi4k0jvEUuaTdRAEjQ4Jfrgz/source
@@ -1971,87 +2017,69 @@ paths:
               schema:
                 $ref: '#/components/schemas/bad-request'
       security: []
-      x-client-action: upload
+      x-client-action: uploadWithUploadToken
       x-client-chunk-upload: true
       x-readme:
         code-samples:
-        - language: go
-          code: "//The upload will happen on the front end, and not on the backend code.  \n//Our [JavaScript uploader(https://docs.api.video/docs/video-uploader) is a great place to look for uploading videos with the delegated token.\n//We also have uploaders for a number of [mobile languages](https://docs.api.video/docs/flutter-uploader).\n"
-        - language: node
-          code: "//The upload will happen on the front end, and not on the backend code.  \n//Our [JavaScript uploader(https://docs.api.video/docs/video-uploader) is a great place to look for uploading videos with the delegated token.\n//We also have uploaders for a number of [mobile languages](https://docs.api.video/docs/flutter-uploader).\n"
-        - language: python
-          code: "#The upload will happen on the front end, and not on the backend code.  \n#Our [JavaScript uploader(https://docs.api.video/docs/video-uploader) is a great place to look for uploading videos with the delegated token.\n#We also have uploaders for a number of [mobile languages](https://docs.api.video/docs/flutter-uploader).\n"
-        - language: java
-          code: "//The upload will happen on the front end, and not on the backend code.  \n//Our [JavaScript uploader(https://docs.api.video/docs/video-uploader) is a great place to look for uploading videos with the delegated token.\n//We also have uploaders for a number of [mobile languages](https://docs.api.video/docs/flutter-uploader).\n"
-        - language: csharp
-          code: "//The upload will happen on the front end, and not on the backend code.  \n//Our [JavaScript uploader(https://docs.api.video/docs/video-uploader) is a great place to look for uploading videos with the delegated token.\n//We also have uploaders for a number of [mobile languages](https://docs.api.video/docs/flutter-uploader).\n"
+          - language: go
+            code: "//The upload will happen on the front end, and not on the backend code.  \n//Our [JavaScript uploader(https://docs.api.video/docs/video-uploader) is a great place to look for uploading videos with the delegated token.\n//We also have uploaders for a number of [mobile languages](https://docs.api.video/docs/flutter-uploader).\n"
+          - language: node
+            code: "//The upload will happen on the front end, and not on the backend code.  \n//Our [JavaScript uploader(https://docs.api.video/docs/video-uploader) is a great place to look for uploading videos with the delegated token.\n//We also have uploaders for a number of [mobile languages](https://docs.api.video/docs/flutter-uploader).\n"
+          - language: python
+            code: "#The upload will happen on the front end, and not on the backend code.  \n#Our [JavaScript uploader(https://docs.api.video/docs/video-uploader) is a great place to look for uploading videos with the delegated token.\n#We also have uploaders for a number of [mobile languages](https://docs.api.video/docs/flutter-uploader).\n"
+          - language: java
+            code: "//The upload will happen on the front end, and not on the backend code.  \n//Our [JavaScript uploader(https://docs.api.video/docs/video-uploader) is a great place to look for uploading videos with the delegated token.\n//We also have uploaders for a number of [mobile languages](https://docs.api.video/docs/flutter-uploader).\n"
+          - language: csharp
+            code: "//The upload will happen on the front end, and not on the backend code.  \n//Our [JavaScript uploader(https://docs.api.video/docs/video-uploader) is a great place to look for uploading videos with the delegated token.\n//We also have uploaders for a number of [mobile languages](https://docs.api.video/docs/flutter-uploader).\n"
   /live-streams:
     get:
       tags:
-      - Live
+        - Live Streams
       summary: List all live streams
       description: With no parameters added to the url, this will return all livestreams. Query by name or key to limit the list.
       operationId: GET_live-streams
       parameters:
-      - name: streamKey
-        in: query
-        description: The unique stream key that allows you to stream videos.
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-        example: 30087931-229e-42cf-b5f9-e91bcc1f7332
-      - name: name
-        in: query
-        description: You can filter live streams by their name or a part of their name.
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-        example: My Video
-      - name: sortBy
-        in: query
-        description: 'Allowed: createdAt, publishedAt, name. createdAt - the time a livestream was created using the specified streamKey. publishedAt - the time a livestream was published using the specified streamKey. name - the name of the livestream. If you choose one of the time based options, the time is presented in ISO-8601 format.'
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-        example: createdAt
-      - name: sortOrder
-        in: query
-        description: 'Allowed: asc, desc. Ascending for date and time means that earlier values precede later ones. Descending means that later values preced earlier ones. For title, it is 0-9 and A-Z ascending and Z-A, 9-0 descending.'
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-          enum:
-          - asc
-          - desc
-        example: desc
-      - name: currentPage
-        in: query
-        description: 'Choose the number of search results to return per page. Minimum value: 1'
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          default: 1
-        example: 2
-      - name: pageSize
-        in: query
-        description: Results per page. Allowed values 1-100, default is 25.
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          default: 25
-        example: 30
+        - name: streamKey
+          in: query
+          description: The unique stream key that allows you to stream videos.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+          example: 30087931-229e-42cf-b5f9-e91bcc1f7332
+        - name: name
+          in: query
+          description: You can filter live streams by their name or a part of their name.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+          example: My Video
+        - name: sortBy
+          in: query
+          description: 'Allowed: createdAt, publishedAt, name. createdAt - the time a livestream was created using the specified streamKey. publishedAt - the time a livestream was published using the specified streamKey. name - the name of the livestream. If you choose one of the time based options, the time is presented in ISO-8601 format.'
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+          example: createdAt
+        - name: sortOrder
+          in: query
+          description: 'Allowed: asc, desc. Ascending for date and time means that earlier values precede later ones. Descending means that later values preced earlier ones. For title, it is 0-9 and A-Z ascending and Z-A, 9-0 descending.'
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+            enum:
+              - asc
+              - desc
+          example: desc
+        - $ref: '#/components/parameters/current-page'
+        - $ref: '#/components/parameters/page-size'
       responses:
         "200":
           description: Success
@@ -2063,32 +2091,32 @@ paths:
                 response:
                   value:
                     data:
-                    - liveStreamId: li400mYKSgQ6xs7taUeSaEKr
-                      createdAt: 2020-01-31T10:17:47+00:00
-                      updatedAt: 2020-03-09T13:19:43+00:00
-                      streamKey: 30087931-229e-42cf-b5f9-e91bcc1f7332
-                      name: Live Stream From the browser
-                      public: true
-                      record: true
-                      broadcasting: false
-                      assets:
-                        iframe: <iframe src="https://embed.api.video/live/li400mYKSgQ6xs7taUeSaEKr" width="100%" height="100%" frameborder="0" scrolling="no" allowfullscreen=""></iframe>
-                        player: https://embed.api.video/live/li400mYKSgQ6xs7taUeSaEKr
-                        hls: https://live.api.video/li400mYKSgQ6xs7taUeSaEKr.m3u8
-                        thumbnail: https://cdn.api.video/live/li400mYKSgQ6xs7taUeSaEKr/thumbnail.jpg
-                    - liveStreamId: li4pqNqGUkhKfWcBGpZVLRY5
-                      createdAt: 2020-07-29T10:45:35+00:00
-                      updatedAt: 2020-07-29T10:45:35+00:00
-                      streamKey: cc1b4df0-d1c5-4064-a8f9-9f0368385135
-                      name: Live From New York
-                      public: true
-                      record: true
-                      broadcasting: false
-                      assets:
-                        iframe: <iframe src="https://embed.api.video/live/li4pqNqGUkhKfWcBGpZVLRY5" width="100%" height="100%" frameborder="0" scrolling="no" allowfullscreen=""></iframe>
-                        player: https://embed.api.video/live/li4pqNqGUkhKfWcBGpZVLRY5
-                        hls: https://live.api.video/li4pqNqGUkhKfWcBGpZVLRY5.m3u8
-                        thumbnail: https://cdn.api.video/live/li4pqNqGUkhKfWcBGpZVLRY5/thumbnail.jpg
+                      - liveStreamId: li400mYKSgQ6xs7taUeSaEKr
+                        createdAt: 2020-01-31T10:17:47+00:00
+                        updatedAt: 2020-03-09T13:19:43+00:00
+                        streamKey: 30087931-229e-42cf-b5f9-e91bcc1f7332
+                        name: Live Stream From the browser
+                        public: true
+                        record: true
+                        broadcasting: false
+                        assets:
+                          iframe: <iframe src="https://embed.api.video/live/li400mYKSgQ6xs7taUeSaEKr" width="100%" height="100%" frameborder="0" scrolling="no" allowfullscreen=""></iframe>
+                          player: https://embed.api.video/live/li400mYKSgQ6xs7taUeSaEKr
+                          hls: https://live.api.video/li400mYKSgQ6xs7taUeSaEKr.m3u8
+                          thumbnail: https://cdn.api.video/live/li400mYKSgQ6xs7taUeSaEKr/thumbnail.jpg
+                      - liveStreamId: li4pqNqGUkhKfWcBGpZVLRY5
+                        createdAt: 2020-07-29T10:45:35+00:00
+                        updatedAt: 2020-07-29T10:45:35+00:00
+                        streamKey: cc1b4df0-d1c5-4064-a8f9-9f0368385135
+                        name: Live From New York
+                        public: true
+                        record: true
+                        broadcasting: false
+                        assets:
+                          iframe: <iframe src="https://embed.api.video/live/li4pqNqGUkhKfWcBGpZVLRY5" width="100%" height="100%" frameborder="0" scrolling="no" allowfullscreen=""></iframe>
+                          player: https://embed.api.video/live/li4pqNqGUkhKfWcBGpZVLRY5
+                          hls: https://live.api.video/li4pqNqGUkhKfWcBGpZVLRY5.m3u8
+                          thumbnail: https://cdn.api.video/live/li4pqNqGUkhKfWcBGpZVLRY5/thumbnail.jpg
                     pagination:
                       currentPage: 1
                       currentPageItems: 19
@@ -2096,116 +2124,118 @@ paths:
                       pagesTotal: 1
                       itemsTotal: 19
                       links:
-                      - rel: self
-                        uri: /live-streams?currentPage=1&pageSize=25
-                      - rel: first
-                        uri: /live-streams?currentPage=1&pageSize=25
-                      - rel: last
-                        uri: /live-streams?currentPage=1&pageSize=25
+                        - rel: self
+                          uri: /live-streams?currentPage=1&pageSize=25
+                        - rel: first
+                          uri: /live-streams?currentPage=1&pageSize=25
+                        - rel: last
+                          uri: /live-streams?currentPage=1&pageSize=25
       security:
-      - bearerAuth: []
+        - bearerAuth: []
       x-client-action: list
       x-group-parameters: true
       x-client-paginated: true
+      x-optional-object: true
       x-readme:
         code-samples:
-        - language: go
-          code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n  \n  import (\n      \"context\"\n      \"fmt\"\n      \"os\"\n      apivideosdk \"github.com/apivideo/go-api-client\"\n  )\n  \n  func main() {\n      client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n      // if you rather like to use the sandbox environment:\n      // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n      req := apivideosdk.LiveStreamsApiListRequest{}\n      \n      req.StreamKey(\"30087931-229e-42cf-b5f9-e91bcc1f7332\") // string | The unique stream key that allows you to stream videos.\n      req.Name(\"My Video\") // string | You can filter live streams by their name or a part of their name.\n      req.SortBy(\"createdAt\") // string | Allowed: createdAt, publishedAt, name. createdAt - the time a livestream was created using the specified streamKey. publishedAt - the time a livestream was published using the specified streamKey. name - the name of the livestream. If you choose one of the time based options, the time is presented in ISO-8601 format.\n      req.SortOrder(\"desc\") // string | Allowed: asc, desc. Ascending for date and time means that earlier values precede later ones. Descending means that later values preced earlier ones. For title, it is 0-9 and A-Z ascending and Z-A, 9-0 descending.\n      req.CurrentPage(int32(2)) // int32 | Choose the number of search results to return per page. Minimum value: 1 (default to 1)\n      req.PageSize(int32(30)) // int32 | Results per page. Allowed values 1-100, default is 25. (default to 25)\n  \n      res, err := client.LiveStreams.List(req)\n      \n  \n      if err != nil {\n          fmt.Fprintf(os.Stderr, \"Error when calling `LiveStreams.List``: %v\\n\", err)\n      }\n      // response from `List`: LiveStreamListResponse\n      fmt.Fprintf(os.Stdout, \"Response from `LiveStreams.List`: %v\\n\", res)\n  }\n"
-        - language: node
-          code: |
-            //install the module with npm or yarn
-            //npm install @api.video/nodejs-client --save
-            //yarn add @api.video/nodejs-client
-            (async () => {
-                try {
-                    const client = new ApiVideoClient({ apiKey: "YOUR_API_TOKEN" });
+          - language: go
+            code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n  \n  import (\n      \"context\"\n      \"fmt\"\n      \"os\"\n      apivideosdk \"github.com/apivideo/go-api-client\"\n  )\n  \n  func main() {\n      client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n      // if you rather like to use the sandbox environment:\n      // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n      req := apivideosdk.LiveStreamsApiListRequest{}\n      \n      req.StreamKey(\"30087931-229e-42cf-b5f9-e91bcc1f7332\") // string | The unique stream key that allows you to stream videos.\n      req.Name(\"My Video\") // string | You can filter live streams by their name or a part of their name.\n      req.SortBy(\"createdAt\") // string | Allowed: createdAt, publishedAt, name. createdAt - the time a livestream was created using the specified streamKey. publishedAt - the time a livestream was published using the specified streamKey. name - the name of the livestream. If you choose one of the time based options, the time is presented in ISO-8601 format.\n      req.SortOrder(\"desc\") // string | Allowed: asc, desc. Ascending for date and time means that earlier values precede later ones. Descending means that later values preced earlier ones. For title, it is 0-9 and A-Z ascending and Z-A, 9-0 descending.\n      req.CurrentPage(int32(2)) // int32 | Choose the number of search results to return per page. Minimum value: 1 (default to 1)\n      req.PageSize(int32(30)) // int32 | Results per page. Allowed values 1-100, default is 25. (default to 25)\n  \n      res, err := client.LiveStreams.List(req)\n      \n  \n      if err != nil {\n          fmt.Fprintf(os.Stderr, \"Error when calling `LiveStreams.List``: %v\\n\", err)\n      }\n      // response from `List`: LiveStreamListResponse\n      fmt.Fprintf(os.Stdout, \"Response from `LiveStreams.List`: %v\\n\", res)\n  }\n"
+          - language: node
+            code: |
+              //install the module with npm or yarn
+              //npm install @api.video/nodejs-client --save
+              //yarn add @api.video/nodejs-client
+              (async () => {
+                  try {
+                      const client = new ApiVideoClient({ apiKey: "YOUR_API_TOKEN" });
 
-                    const streamKey = '30087931-229e-42cf-b5f9-e91bcc1f7332'; // The unique stream key that allows you to stream videos.
-                    const name = 'My Video'; // You can filter live streams by their name or a part of their name.
-                    const sortBy = 'createdAt'; // Allowed: createdAt, publishedAt, name. createdAt - the time a livestream was created using the specified streamKey. publishedAt - the time a livestream was published using the specified streamKey. name - the name of the livestream. If you choose one of the time based options, the time is presented in ISO-8601 format.
-                    const sortOrder = 'desc'; // Allowed: asc, desc. Ascending for date and time means that earlier values precede later ones. Descending means that later values preced earlier ones. For title, it is 0-9 and A-Z ascending and Z-A, 9-0 descending.
-                    const currentPage = '2'; // Choose the number of search results to return per page. Minimum value: 1
-                    const pageSize = '30'; // Results per page. Allowed values 1-100, default is 25.
+                      const streamKey = '30087931-229e-42cf-b5f9-e91bcc1f7332'; // The unique stream key that allows you to stream videos.
+                      const name = 'My Video'; // You can filter live streams by their name or a part of their name.
+                      const sortBy = 'createdAt'; // Allowed: createdAt, publishedAt, name. createdAt - the time a livestream was created using the specified streamKey. publishedAt - the time a livestream was published using the specified streamKey. name - the name of the livestream. If you choose one of the time based options, the time is presented in ISO-8601 format.
+                      const sortOrder = 'desc'; // Allowed: asc, desc. Ascending for date and time means that earlier values precede later ones. Descending means that later values preced earlier ones. For title, it is 0-9 and A-Z ascending and Z-A, 9-0 descending.
+                      const currentPage = '2'; // Choose the number of search results to return per page. Minimum value: 1
+                      const pageSize = '30'; // Results per page. Allowed values 1-100, default is 25.
 
-                    // LiveStreamListResponse
-                    const result = await client.liveStreams.list({ streamKey, name, sortBy, sortOrder, currentPage, pageSize })
-                    console.log(result);
-                } catch (e) {
-                    console.error(e);
-                }
-            })();
-        - language: python
-          code: |
-            #install the api.video API client library
-            #pip install api.video
-            import apivideo
-            from apivideo.api import live_streams_api
-            from apivideo.model.live_stream import LiveStream
-            from pprint import pprint
+                      // LiveStreamListResponse
+                      const result = await client.liveStreams.list({ streamKey, name, sortBy, sortOrder, currentPage, pageSize })
+                      console.log(result);
+                  } catch (e) {
+                      console.error(e);
+                  }
+              })();
+          - language: python
+            code: |
+              #install the api.video API client library
+              #pip install api.video
+              import apivideo
+              from apivideo.api import live_streams_api
+              from apivideo.model.live_stream import LiveStream
+              from pprint import pprint
 
-            # Enter a context with an instance of the API client
-            with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
-                # Create an instance of the API class
-                api_instance = live_streams_api.LiveStreamsApi(api_client)
-                live_stream_id = "li400mYKSgQ6xs7taUeSaEKr" # str | The unique ID for the live stream you want to watch.
+              # Enter a context with an instance of the API client
+              with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
+                  # Create an instance of the API class
+                  api_instance = live_streams_api.LiveStreamsApi(api_client)
+                  live_stream_id = "li400mYKSgQ6xs7taUeSaEKr" # str | The unique ID for the live stream you want to watch.
 
-                # example passing only required values which don't have defaults set
-                try:
-                    # Show live stream
-                    api_response = api_instance.get(live_stream_id)
-                    pprint(api_response)
-                except apivideo.ApiException as e:
-                    print("Exception when calling LiveStreamsApi->get: %s\n" % e)
-        - language: java
-          code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.LiveStreamsApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    LiveStreamsApi apiInstance = client.liveStreams();\n    \n    String streamKey = \"30087931-229e-42cf-b5f9-e91bcc1f7332\"; // The unique stream key that allows you to stream videos.\n    String name = \"My Video\"; // You can filter live streams by their name or a part of their name.\n    String sortBy = \"createdAt\"; // Allowed: createdAt, publishedAt, name. createdAt - the time a livestream was created using the specified streamKey. publishedAt - the time a livestream was published using the specified streamKey. name - the name of the livestream. If you choose one of the time based options, the time is presented in ISO-8601 format.\n    String sortOrder = \"desc\"; // Allowed: asc, desc. Ascending for date and time means that earlier values precede later ones. Descending means that later values preced earlier ones. For title, it is 0-9 and A-Z ascending and Z-A, 9-0 descending.\n    Integer currentPage = 1; // Choose the number of search results to return per page. Minimum value: 1\n    Integer pageSize = 25; // Results per page. Allowed values 1-100, default is 25.\n\n    try {\n      Page<LiveStream> result = apiInstance.list()\n            .streamKey(streamKey)\n            .name(name)\n            .sortBy(sortBy)\n            .sortOrder(sortOrder)\n            .currentPage(currentPage)\n            .pageSize(pageSize)\n            .execute();\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling LiveStreamsApi#list\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
-        - language: csharp
-          code: |
-            //install via Nuget
-            //Install-Package ApiVideo
-            using System.Diagnostics;
-            using ApiVideo.Client;
+                  # example passing only required values which don't have defaults set
+                  try:
+                      # Show live stream
+                      api_response = api_instance.get(live_stream_id)
+                      pprint(api_response)
+                  except apivideo.ApiException as e:
+                      print("Exception when calling LiveStreamsApi->get: %s\n" % e)
+          - language: java
+            code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.LiveStreamsApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    LiveStreamsApi apiInstance = client.liveStreams();\n    \n    String streamKey = \"30087931-229e-42cf-b5f9-e91bcc1f7332\"; // The unique stream key that allows you to stream videos.\n    String name = \"My Video\"; // You can filter live streams by their name or a part of their name.\n    String sortBy = \"createdAt\"; // Allowed: createdAt, publishedAt, name. createdAt - the time a livestream was created using the specified streamKey. publishedAt - the time a livestream was published using the specified streamKey. name - the name of the livestream. If you choose one of the time based options, the time is presented in ISO-8601 format.\n    String sortOrder = \"desc\"; // Allowed: asc, desc. Ascending for date and time means that earlier values precede later ones. Descending means that later values preced earlier ones. For title, it is 0-9 and A-Z ascending and Z-A, 9-0 descending.\n    Integer currentPage = 1; // Choose the number of search results to return per page. Minimum value: 1\n    Integer pageSize = 25; // Results per page. Allowed values 1-100, default is 25.\n\n    try {\n      Page<LiveStream> result = apiInstance.list()\n            .streamKey(streamKey)\n            .name(name)\n            .sortBy(sortBy)\n            .sortOrder(sortOrder)\n            .currentPage(currentPage)\n            .pageSize(pageSize)\n            .execute();\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling LiveStreamsApi#list\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
+          - language: csharp
+            code: |
+              //install via Nuget
+              //Install-Package ApiVideo
+              using System.Diagnostics;
+              using ApiVideo.Client;
 
-            namespace Example
-            {
-                public class getExample
-                {
-                    public static void Main()
-                    {
-                        var basePath = ApiVideoClient.Client.Environment.SANDBOX;
-                        var apiKey = "YOUR_API_KEY";
+              namespace Example
+              {
+                  public class getExample
+                  {
+                      public static void Main()
+                      {
+                          var basePath = ApiVideoClient.Client.Environment.SANDBOX;
+                          var apiKey = "YOUR_API_KEY";
 
-                        var apiInstance = new ApiVideoClient(apiKey,basePath);
+                          var apiInstance = new ApiVideoClient(apiKey,basePath);
 
-                        var liveStreamId = li400mYKSgQ6xs7taUeSaEKr;  // string | The unique ID for the live stream you want to watch.
-                        var apiLiveStreamsInstance = apiInstance.LiveStreams();
-                        try
-                        {
-                            // Show live stream
-                            LiveStream result = apiLiveStreamsInstance.get(liveStreamId);
-                            Debug.WriteLine(result);
-                        }
-                        catch (ApiException  e)
-                        {
-                            Debug.Print("Exception when calling LiveStreamsApi.get: " + e.Message );
-                            Debug.Print("Status Code: "+ e.ErrorCode);
-                            Debug.Print(e.StackTrace);
-                        }
-                    }
-                }
-            }
+                          var liveStreamId = li400mYKSgQ6xs7taUeSaEKr;  // string | The unique ID for the live stream you want to watch.
+                          var apiLiveStreamsInstance = apiInstance.LiveStreams();
+                          try
+                          {
+                              // Show live stream
+                              LiveStream result = apiLiveStreamsInstance.get(liveStreamId);
+                              Debug.WriteLine(result);
+                          }
+                          catch (ApiException  e)
+                          {
+                              Debug.Print("Exception when calling LiveStreamsApi.get: " + e.Message );
+                              Debug.Print("Status Code: "+ e.ErrorCode);
+                              Debug.Print(e.StackTrace);
+                          }
+                      }
+                  }
+              }
     post:
       tags:
-      - Live
+        - Live Streams
       summary: Create live stream
       description: |-
         A live stream will give you the 'connection point' to RTMP your video stream to api.video. It will also give you the details for viewers to watch the same livestream.  The public=false 'private livestream' is available as a BETA feature, and should be limited to livestreams of 3,000 viewers or fewer. See our [Live Stream Tutorial](https://api.video/blog/tutorials/live-stream-tutorial) for a walkthrough of this API with OBS. Your RTMP endpoint for the livestream is rtmp://broadcast.api.video/s/{streamKey}
         Tutorials that [create live streams](https://api.video/blog/endpoints/live-create).
       operationId: POST_live-streams
       requestBody:
+        required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/live-stream-create-payload'
+              $ref: '#/components/schemas/live-stream-creation-payload'
       responses:
         "200":
           description: Success
@@ -2236,37 +2266,37 @@ paths:
               schema:
                 $ref: '#/components/schemas/bad-request'
       security:
-      - bearerAuth: []
+        - bearerAuth: []
       x-client-action: create
       x-readme:
         code-samples:
-        - language: go
-          code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    liveStreamCreationPayload := *apivideosdk.NewLiveStreamCreationPayload(\"My Live Stream Video\") // LiveStreamCreationPayload | \n\n    \n    res, err := client.LiveStreams.Create(liveStreamCreationPayload)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `LiveStreams.Create``: %v\\n\", err)\n    }\n    // response from `Create`: LiveStream\n    fmt.Fprintf(os.Stdout, \"Response from `LiveStreams.Create`: %v\\n\", res)\n}\n"
-        - language: node
-          code: "//install the module with npm or yarn\n//npm install @api.video/nodejs-client --save\n//yarn add @api.video/nodejs-client\n(async () => {\n    try {\n        const client = new ApiVideoClient({ apiKey: \"YOUR_API_TOKEN\" });\n\n        const liveStreamCreationPayload = {\n      name: \"My Live Stream Video\", // Add a name for your live stream here.\n      record: true, // Whether you are recording or not. True for record, false for not record.\n      _public: true, // BETA FEATURE Please limit all public = false (\\\"private\\\") livestreams to 3,000 users. Whether your video can be viewed by everyone, or requires authentication to see it. A setting of false will require a unique token for each view.\n      playerId: \"pl4f4ferf5erfr5zed4fsdd\", // The unique identifier for the player.\n    }; \n\n        // LiveStream\n        const result = await client.liveStreams.create(liveStreamCreationPayload);\n        console.log(result);\n    } catch (e) {\n        console.error(e);\n    }\n})();\n"
-        - language: python
-          code: "#install the api.video API client library\n#pip install api.video\nimport apivideo\nfrom apivideo.api import live_streams_api\nfrom apivideo.model.bad_request import BadRequest\nfrom apivideo.model.live_stream_creation_payload import LiveStreamCreationPayload\nfrom apivideo.model.live_stream import LiveStream\nfrom pprint import pprint\n\n# Enter a context with an instance of the API client\nwith apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:\n    # Create an instance of the API class\n    api_instance = live_streams_api.LiveStreamsApi(api_client)\n    live_stream_creation_payload = LiveStreamCreationPayload(\n        name=\"My Live Stream Video\",\n        record=True,\n        public=True,\n        player_id=\"pl4f4ferf5erfr5zed4fsdd\",\n    ) # LiveStreamCreationPayload | \n\n    # example passing only required values which don't have defaults set\n    try:\n        # Create live stream\n        api_response = api_instance.create(live_stream_creation_payload)\n        pprint(api_response)\n    except apivideo.ApiException as e:\n        print(\"Exception when calling LiveStreamsApi->create: %s\\n\" % e)\n"
-        - language: java
-          code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.LiveStreamsApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    LiveStreamsApi apiInstance = client.liveStreams();\n    \n    LiveStreamCreationPayload liveStreamCreationPayload = new LiveStreamCreationPayload(); // \n    liveStreamCreationPayload.setName(\"My Live Stream Video\"); // Add a name for your live stream here.\n    liveStreamCreationPayload.setRecord(true); // Whether you are recording or not. True for record, false for not record.\n    liveStreamCreationPayload.setPublic(); // BETA FEATURE Please limit all public &#x3D; false (&quot;private&quot;) livestreams to 3,000 users. Whether your video can be viewed by everyone, or requires authentication to see it. A setting of false will require a unique token for each view.\n    liveStreamCreationPayload.setPlayerId(\"pl4f4ferf5erfr5zed4fsdd\"); // The unique identifier for the player.\n\n\n    try {\n      LiveStream result = apiInstance.create(liveStreamCreationPayload);\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling LiveStreamsApi#create\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
-        - language: csharp
-          code: "//install via Nuget\n//Install-Package ApiVideo\nusing System.Diagnostics;\nusing ApiVideo.Client;\n\nnamespace Example\n{\n    public class createExample\n    {\n        public static void Main()\n        {\n            var basePath = ApiVideoClient.Client.Environment.SANDBOX;\n            var apiKey = \"YOUR_API_KEY\";\n\n            var apiInstance = new ApiVideoClient(apiKey,basePath);\n\n            var liveStreamCreationPayload = new LiveStreamCreationPayload(); // LiveStreamCreationPayload | \n            var apiLiveStreamsInstance = apiInstance.LiveStreams();\n            try\n            {\n                // Create live stream\n                LiveStream result = apiLiveStreamsInstance.create(liveStreamCreationPayload);\n                Debug.WriteLine(result);\n            }\n            catch (ApiException  e)\n            {\n                Debug.Print(\"Exception when calling LiveStreamsApi.create: \" + e.Message );\n                Debug.Print(\"Status Code: \"+ e.ErrorCode);\n                Debug.Print(e.StackTrace);\n            }\n        }\n    }\n}\n"
+          - language: go
+            code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    liveStreamCreationPayload := *apivideosdk.NewLiveStreamCreationPayload(\"My Live Stream Video\") // LiveStreamCreationPayload | \n\n    \n    res, err := client.LiveStreams.Create(liveStreamCreationPayload)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `LiveStreams.Create``: %v\\n\", err)\n    }\n    // response from `Create`: LiveStream\n    fmt.Fprintf(os.Stdout, \"Response from `LiveStreams.Create`: %v\\n\", res)\n}\n"
+          - language: node
+            code: "//install the module with npm or yarn\n//npm install @api.video/nodejs-client --save\n//yarn add @api.video/nodejs-client\n(async () => {\n    try {\n        const client = new ApiVideoClient({ apiKey: \"YOUR_API_TOKEN\" });\n\n        const liveStreamCreationPayload = {\n      name: \"My Live Stream Video\", // Add a name for your live stream here.\n      record: true, // Whether you are recording or not. True for record, false for not record.\n      _public: true, // BETA FEATURE Please limit all public = false (\\\"private\\\") livestreams to 3,000 users. Whether your video can be viewed by everyone, or requires authentication to see it. A setting of false will require a unique token for each view.\n      playerId: \"pl4f4ferf5erfr5zed4fsdd\", // The unique identifier for the player.\n    }; \n\n        // LiveStream\n        const result = await client.liveStreams.create(liveStreamCreationPayload);\n        console.log(result);\n    } catch (e) {\n        console.error(e);\n    }\n})();\n"
+          - language: python
+            code: "#install the api.video API client library\n#pip install api.video\nimport apivideo\nfrom apivideo.api import live_streams_api\nfrom apivideo.model.bad_request import BadRequest\nfrom apivideo.model.live_stream_creation_payload import LiveStreamCreationPayload\nfrom apivideo.model.live_stream import LiveStream\nfrom pprint import pprint\n\n# Enter a context with an instance of the API client\nwith apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:\n    # Create an instance of the API class\n    api_instance = live_streams_api.LiveStreamsApi(api_client)\n    live_stream_creation_payload = LiveStreamCreationPayload(\n        name=\"My Live Stream Video\",\n        record=True,\n        public=True,\n        player_id=\"pl4f4ferf5erfr5zed4fsdd\",\n    ) # LiveStreamCreationPayload | \n\n    # example passing only required values which don't have defaults set\n    try:\n        # Create live stream\n        api_response = api_instance.create(live_stream_creation_payload)\n        pprint(api_response)\n    except apivideo.ApiException as e:\n        print(\"Exception when calling LiveStreamsApi->create: %s\\n\" % e)\n"
+          - language: java
+            code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.LiveStreamsApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    LiveStreamsApi apiInstance = client.liveStreams();\n    \n    LiveStreamCreationPayload liveStreamCreationPayload = new LiveStreamCreationPayload(); // \n    liveStreamCreationPayload.setName(\"My Live Stream Video\"); // Add a name for your live stream here.\n    liveStreamCreationPayload.setRecord(true); // Whether you are recording or not. True for record, false for not record.\n    liveStreamCreationPayload.setPublic(); // BETA FEATURE Please limit all public &#x3D; false (&quot;private&quot;) livestreams to 3,000 users. Whether your video can be viewed by everyone, or requires authentication to see it. A setting of false will require a unique token for each view.\n    liveStreamCreationPayload.setPlayerId(\"pl4f4ferf5erfr5zed4fsdd\"); // The unique identifier for the player.\n\n\n    try {\n      LiveStream result = apiInstance.create(liveStreamCreationPayload);\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling LiveStreamsApi#create\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
+          - language: csharp
+            code: "//install via Nuget\n//Install-Package ApiVideo\nusing System.Diagnostics;\nusing ApiVideo.Client;\n\nnamespace Example\n{\n    public class createExample\n    {\n        public static void Main()\n        {\n            var basePath = ApiVideoClient.Client.Environment.SANDBOX;\n            var apiKey = \"YOUR_API_KEY\";\n\n            var apiInstance = new ApiVideoClient(apiKey,basePath);\n\n            var liveStreamCreationPayload = new LiveStreamCreationPayload(); // LiveStreamCreationPayload | \n            var apiLiveStreamsInstance = apiInstance.LiveStreams();\n            try\n            {\n                // Create live stream\n                LiveStream result = apiLiveStreamsInstance.create(liveStreamCreationPayload);\n                Debug.WriteLine(result);\n            }\n            catch (ApiException  e)\n            {\n                Debug.Print(\"Exception when calling LiveStreamsApi.create: \" + e.Message );\n                Debug.Print(\"Status Code: \"+ e.ErrorCode);\n                Debug.Print(e.StackTrace);\n            }\n        }\n    }\n}\n"
   /live-streams/{liveStreamId}:
     get:
       tags:
-      - Live
+        - Live Streams
       summary: Show live stream
       description: Supply a LivestreamId, and you'll get all the details for streaming into, and watching the livestream. Tutorials that use the [show livestream endpoint](https://api.video/blog/endpoints/live-stream-status).
       operationId: GET_live-streams-liveStreamId
       parameters:
-      - name: liveStreamId
-        in: path
-        description: The unique ID for the live stream you want to watch.
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-        example: li400mYKSgQ6xs7taUeSaEKr
+        - name: liveStreamId
+          in: path
+          description: The unique ID for the live stream you want to watch.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: li400mYKSgQ6xs7taUeSaEKr
       responses:
         "200":
           description: Success
@@ -2291,205 +2321,206 @@ paths:
                       hls: https://live.api.video/li400mYKSgQ6xs7taUeSaEKr.m3u8
                       thumbnail: https://cdn.api.video/live/li400mYKSgQ6xs7taUeSaEKr/thumbnail.jpg
       security:
-      - bearerAuth: []
+        - bearerAuth: []
       x-client-action: get
       x-readme:
         code-samples:
-        - language: go
-          code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    liveStreamId := \"li400mYKSgQ6xs7taUeSaEKr\" // string | The unique ID for the live stream you want to watch.\n\n    \n    res, err := client.LiveStreams.Get(liveStreamId)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `LiveStreams.Get``: %v\\n\", err)\n    }\n    // response from `Get`: LiveStream\n    fmt.Fprintf(os.Stdout, \"Response from `LiveStreams.Get`: %v\\n\", res)\n}\n"
-        - language: node
-          code: |
-            //install the module with npm or yarn
-            //npm install @api.video/nodejs-client --save
-            //yarn add @api.video/nodejs-client
-            (async () => {
-                try {
-                    const client = new ApiVideoClient({ apiKey: "YOUR_API_TOKEN" });
+          - language: go
+            code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    liveStreamId := \"li400mYKSgQ6xs7taUeSaEKr\" // string | The unique ID for the live stream you want to watch.\n\n    \n    res, err := client.LiveStreams.Get(liveStreamId)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `LiveStreams.Get``: %v\\n\", err)\n    }\n    // response from `Get`: LiveStream\n    fmt.Fprintf(os.Stdout, \"Response from `LiveStreams.Get`: %v\\n\", res)\n}\n"
+          - language: node
+            code: |
+              //install the module with npm or yarn
+              //npm install @api.video/nodejs-client --save
+              //yarn add @api.video/nodejs-client
+              (async () => {
+                  try {
+                      const client = new ApiVideoClient({ apiKey: "YOUR_API_TOKEN" });
 
-                    const liveStreamId = 'li400mYKSgQ6xs7taUeSaEKr'; // The unique ID for the live stream you want to watch.
+                      const liveStreamId = 'li400mYKSgQ6xs7taUeSaEKr'; // The unique ID for the live stream you want to watch.
 
-                    // LiveStream
-                    const result = await client.liveStreams.get(liveStreamId);
-                    console.log(result);
-                } catch (e) {
-                    console.error(e);
-                }
-            })();
-        - language: python
-          code: |
-            #install the api.video API client library
-            #pip install api.video
-            import apivideo
-            from apivideo.api import live_streams_api
-            from apivideo.model.live_stream import LiveStream
-            from pprint import pprint
+                      // LiveStream
+                      const result = await client.liveStreams.get(liveStreamId);
+                      console.log(result);
+                  } catch (e) {
+                      console.error(e);
+                  }
+              })();
+          - language: python
+            code: |
+              #install the api.video API client library
+              #pip install api.video
+              import apivideo
+              from apivideo.api import live_streams_api
+              from apivideo.model.live_stream import LiveStream
+              from pprint import pprint
 
-            # Enter a context with an instance of the API client
-            with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
-                # Create an instance of the API class
-                api_instance = live_streams_api.LiveStreamsApi(api_client)
-                live_stream_id = "li400mYKSgQ6xs7taUeSaEKr" # str | The unique ID for the live stream you want to watch.
+              # Enter a context with an instance of the API client
+              with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
+                  # Create an instance of the API class
+                  api_instance = live_streams_api.LiveStreamsApi(api_client)
+                  live_stream_id = "li400mYKSgQ6xs7taUeSaEKr" # str | The unique ID for the live stream you want to watch.
 
-                # example passing only required values which don't have defaults set
-                try:
-                    # Show live stream
-                    api_response = api_instance.get(live_stream_id)
-                    pprint(api_response)
-                except apivideo.ApiException as e:
-                    print("Exception when calling LiveStreamsApi->get: %s\n" % e)
-        - language: java
-          code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.LiveStreamsApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    LiveStreamsApi apiInstance = client.liveStreams();\n    \n    String liveStreamId = \"li400mYKSgQ6xs7taUeSaEKr\"; // The unique ID for the live stream you want to watch.\n\n    try {\n      LiveStream result = apiInstance.get(liveStreamId);\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling LiveStreamsApi#get\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
-        - language: csharp
-          code: |
-            //install via Nuget
-            //Install-Package ApiVideo
-            using System.Diagnostics;
-            using ApiVideo.Client;
+                  # example passing only required values which don't have defaults set
+                  try:
+                      # Show live stream
+                      api_response = api_instance.get(live_stream_id)
+                      pprint(api_response)
+                  except apivideo.ApiException as e:
+                      print("Exception when calling LiveStreamsApi->get: %s\n" % e)
+          - language: java
+            code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.LiveStreamsApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    LiveStreamsApi apiInstance = client.liveStreams();\n    \n    String liveStreamId = \"li400mYKSgQ6xs7taUeSaEKr\"; // The unique ID for the live stream you want to watch.\n\n    try {\n      LiveStream result = apiInstance.get(liveStreamId);\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling LiveStreamsApi#get\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
+          - language: csharp
+            code: |
+              //install via Nuget
+              //Install-Package ApiVideo
+              using System.Diagnostics;
+              using ApiVideo.Client;
 
-            namespace Example
-            {
-                public class getExample
-                {
-                    public static void Main()
-                    {
-                        var basePath = ApiVideoClient.Client.Environment.SANDBOX;
-                        var apiKey = "YOUR_API_KEY";
+              namespace Example
+              {
+                  public class getExample
+                  {
+                      public static void Main()
+                      {
+                          var basePath = ApiVideoClient.Client.Environment.SANDBOX;
+                          var apiKey = "YOUR_API_KEY";
 
-                        var apiInstance = new ApiVideoClient(apiKey,basePath);
+                          var apiInstance = new ApiVideoClient(apiKey,basePath);
 
-                        var liveStreamId = li400mYKSgQ6xs7taUeSaEKr;  // string | The unique ID for the live stream you want to watch.
-                        var apiLiveStreamsInstance = apiInstance.LiveStreams();
-                        try
-                        {
-                            // Show live stream
-                            LiveStream result = apiLiveStreamsInstance.get(liveStreamId);
-                            Debug.WriteLine(result);
-                        }
-                        catch (ApiException  e)
-                        {
-                            Debug.Print("Exception when calling LiveStreamsApi.get: " + e.Message );
-                            Debug.Print("Status Code: "+ e.ErrorCode);
-                            Debug.Print(e.StackTrace);
-                        }
-                    }
-                }
-            }
+                          var liveStreamId = li400mYKSgQ6xs7taUeSaEKr;  // string | The unique ID for the live stream you want to watch.
+                          var apiLiveStreamsInstance = apiInstance.LiveStreams();
+                          try
+                          {
+                              // Show live stream
+                              LiveStream result = apiLiveStreamsInstance.get(liveStreamId);
+                              Debug.WriteLine(result);
+                          }
+                          catch (ApiException  e)
+                          {
+                              Debug.Print("Exception when calling LiveStreamsApi.get: " + e.Message );
+                              Debug.Print("Status Code: "+ e.ErrorCode);
+                              Debug.Print(e.StackTrace);
+                          }
+                      }
+                  }
+              }
     delete:
       tags:
-      - Live
+        - Live Streams
       summary: Delete a live stream
       operationId: DELETE_live-streams-liveStreamId
       parameters:
-      - name: liveStreamId
-        in: path
-        description: The unique ID for the live stream that you want to remove.
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-        example: li400mYKSgQ6xs7taUeSaEKr
+        - name: liveStreamId
+          in: path
+          description: The unique ID for the live stream that you want to remove.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: li400mYKSgQ6xs7taUeSaEKr
       responses:
         "204":
           description: No Content
       security:
-      - bearerAuth: []
+        - bearerAuth: []
       x-client-action: delete
       x-readme:
         code-samples:
-        - language: go
-          code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    liveStreamId := \"li400mYKSgQ6xs7taUeSaEKr\" // string | The unique ID for the live stream that you want to remove.\n\n    \n    err := client.LiveStreams.Delete(liveStreamId)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `LiveStreams.Delete``: %v\\n\", err)\n    }\n}\n"
-        - language: node
-          code: |
-            //install the module with npm or yarn
-            //npm install @api.video/nodejs-client --save
-            //yarn add @api.video/nodejs-client
-            (async () => {
-                try {
-                    const client = new ApiVideoClient({ apiKey: "YOUR_API_TOKEN" });
+          - language: go
+            code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    liveStreamId := \"li400mYKSgQ6xs7taUeSaEKr\" // string | The unique ID for the live stream that you want to remove.\n\n    \n    err := client.LiveStreams.Delete(liveStreamId)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `LiveStreams.Delete``: %v\\n\", err)\n    }\n}\n"
+          - language: node
+            code: |
+              //install the module with npm or yarn
+              //npm install @api.video/nodejs-client --save
+              //yarn add @api.video/nodejs-client
+              (async () => {
+                  try {
+                      const client = new ApiVideoClient({ apiKey: "YOUR_API_TOKEN" });
 
-                    const liveStreamId = 'li400mYKSgQ6xs7taUeSaEKr'; // The unique ID for the live stream that you want to remove.
+                      const liveStreamId = 'li400mYKSgQ6xs7taUeSaEKr'; // The unique ID for the live stream that you want to remove.
 
-                    // void
-                    const result = await client.liveStreams.delete(liveStreamId);
-                    console.log(result);
-                } catch (e) {
-                    console.error(e);
-                }
-            })();
-        - language: python
-          code: |
-            #install the api.video API client library
-            #pip install api.video
-            import apivideo
-            from apivideo.api import live_streams_api
-            from pprint import pprint
+                      // void
+                      const result = await client.liveStreams.delete(liveStreamId);
+                      console.log(result);
+                  } catch (e) {
+                      console.error(e);
+                  }
+              })();
+          - language: python
+            code: |
+              #install the api.video API client library
+              #pip install api.video
+              import apivideo
+              from apivideo.api import live_streams_api
+              from pprint import pprint
 
-            # Enter a context with an instance of the API client
-            with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
-                # Create an instance of the API class
-                api_instance = live_streams_api.LiveStreamsApi(api_client)
-                live_stream_id = "li400mYKSgQ6xs7taUeSaEKr" # str | The unique ID for the live stream that you want to remove.
+              # Enter a context with an instance of the API client
+              with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
+                  # Create an instance of the API class
+                  api_instance = live_streams_api.LiveStreamsApi(api_client)
+                  live_stream_id = "li400mYKSgQ6xs7taUeSaEKr" # str | The unique ID for the live stream that you want to remove.
 
-                # example passing only required values which don't have defaults set
-                try:
-                    # Delete a live stream
-                    api_instance.delete(live_stream_id)
-                except apivideo.ApiException as e:
-                    print("Exception when calling LiveStreamsApi->delete: %s\n" % e)
-        - language: java
-          code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\n  import video.api.client.ApiVideoClient;\n  import video.api.client.api.ApiException;\n  import video.api.client.api.models.*;\n  import video.api.client.api.clients.LiveStreamsApi;\n  import java.util.*;\n  \n  public class Example {\n    public static void main(String[] args) {\n      ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n      // if you rather like to use the sandbox environment:\n      // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n  \n      LiveStreamsApi apiInstance = client.liveStreams();\n      \n      String liveStreamId = \"li400mYKSgQ6xs7taUeSaEKr\"; // The unique ID for the live stream that you want to remove.\n  \n      try {\n        apiInstance.delete(liveStreamId);\n      } catch (ApiException e) {\n        System.err.println(\"Exception when calling LiveStreamsApi#delete\");\n        System.err.println(\"Status code: \" + e.getCode());\n        System.err.println(\"Reason: \" + e.getMessage());\n        System.err.println(\"Response headers: \" + e.getResponseHeaders());\n        e.printStackTrace();\n      }\n    }\n  }\n"
-        - language: csharp
-          code: |
-            //install via Nuget
-            //Install-Package ApiVideo
-            using System.Diagnostics;
-            using ApiVideo.Client;
+                  # example passing only required values which don't have defaults set
+                  try:
+                      # Delete a live stream
+                      api_instance.delete(live_stream_id)
+                  except apivideo.ApiException as e:
+                      print("Exception when calling LiveStreamsApi->delete: %s\n" % e)
+          - language: java
+            code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\n  import video.api.client.ApiVideoClient;\n  import video.api.client.api.ApiException;\n  import video.api.client.api.models.*;\n  import video.api.client.api.clients.LiveStreamsApi;\n  import java.util.*;\n  \n  public class Example {\n    public static void main(String[] args) {\n      ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n      // if you rather like to use the sandbox environment:\n      // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n  \n      LiveStreamsApi apiInstance = client.liveStreams();\n      \n      String liveStreamId = \"li400mYKSgQ6xs7taUeSaEKr\"; // The unique ID for the live stream that you want to remove.\n  \n      try {\n        apiInstance.delete(liveStreamId);\n      } catch (ApiException e) {\n        System.err.println(\"Exception when calling LiveStreamsApi#delete\");\n        System.err.println(\"Status code: \" + e.getCode());\n        System.err.println(\"Reason: \" + e.getMessage());\n        System.err.println(\"Response headers: \" + e.getResponseHeaders());\n        e.printStackTrace();\n      }\n    }\n  }\n"
+          - language: csharp
+            code: |
+              //install via Nuget
+              //Install-Package ApiVideo
+              using System.Diagnostics;
+              using ApiVideo.Client;
 
-            namespace Example
-            {
-                public class deleteExample
-                {
-                    public static void Main()
-                    {
-                        var basePath = ApiVideoClient.Client.Environment.SANDBOX;
-                        var apiKey = "YOUR_API_KEY";
+              namespace Example
+              {
+                  public class deleteExample
+                  {
+                      public static void Main()
+                      {
+                          var basePath = ApiVideoClient.Client.Environment.SANDBOX;
+                          var apiKey = "YOUR_API_KEY";
 
-                        var apiInstance = new ApiVideoClient(apiKey,basePath);
+                          var apiInstance = new ApiVideoClient(apiKey,basePath);
 
-                        var liveStreamId = li400mYKSgQ6xs7taUeSaEKr;  // string | The unique ID for the live stream that you want to remove.
-                        var apiLiveStreamsInstance = apiInstance.LiveStreams();
-                        try
-                        {
-                            // Delete a live stream
-                            apiLiveStreamsInstance.delete(liveStreamId);
-                        }
-                        catch (ApiException  e)
-                        {
-                            Debug.Print("Exception when calling LiveStreamsApi.delete: " + e.Message );
-                            Debug.Print("Status Code: "+ e.ErrorCode);
-                            Debug.Print(e.StackTrace);
-                        }
-                    }
-                }
-            }
+                          var liveStreamId = li400mYKSgQ6xs7taUeSaEKr;  // string | The unique ID for the live stream that you want to remove.
+                          var apiLiveStreamsInstance = apiInstance.LiveStreams();
+                          try
+                          {
+                              // Delete a live stream
+                              apiLiveStreamsInstance.delete(liveStreamId);
+                          }
+                          catch (ApiException  e)
+                          {
+                              Debug.Print("Exception when calling LiveStreamsApi.delete: " + e.Message );
+                              Debug.Print("Status Code: "+ e.ErrorCode);
+                              Debug.Print(e.StackTrace);
+                          }
+                      }
+                  }
+              }
     patch:
       tags:
-      - Live
+        - Live Streams
       summary: Update a live stream
       description: 'Use this endpoint to update the player, or to turn recording on/off (saving a copy of the livestream). NOTE: If the livestream is actively streaming, changing the recording status will only affect the NEXT stream.    The public=false ''private livestream'' is available as a BETA feature, and should be limited to livestreams of 3,000 viewers or fewer.'
       operationId: PATCH_live-streams-liveStreamId
       parameters:
-      - name: liveStreamId
-        in: path
-        description: The unique ID for the live stream that you want to update information for such as player details, or whether you want the recording on or off.
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-        example: li400mYKSgQ6xs7taUeSaEKr
+        - name: liveStreamId
+          in: path
+          description: The unique ID for the live stream that you want to update information for such as player details, or whether you want the recording on or off.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: li400mYKSgQ6xs7taUeSaEKr
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -2524,38 +2555,39 @@ paths:
               schema:
                 $ref: '#/components/schemas/bad-request'
       security:
-      - bearerAuth: []
+        - bearerAuth: []
       x-client-action: update
       x-readme:
         code-samples:
-        - language: go
-          code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    liveStreamId := \"li400mYKSgQ6xs7taUeSaEKr\" // string | The unique ID for the live stream that you want to update information for such as player details, or whether you want the recording on or off.\n    liveStreamUpdatePayload := *apivideosdk.NewLiveStreamUpdatePayload() // LiveStreamUpdatePayload | \n\n    \n    res, err := client.LiveStreams.Update(liveStreamId, liveStreamUpdatePayload)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `LiveStreams.Update``: %v\\n\", err)\n    }\n    // response from `Update`: LiveStream\n    fmt.Fprintf(os.Stdout, \"Response from `LiveStreams.Update`: %v\\n\", res)\n}\n"
-        - language: node
-          code: "//install the module with npm or yarn\n//npm install @api.video/nodejs-client --save\n//yarn add @api.video/nodejs-client\n(async () => {\n    try {\n        const client = new ApiVideoClient({ apiKey: \"YOUR_API_TOKEN\" });\n\n        const liveStreamId = 'li400mYKSgQ6xs7taUeSaEKr'; // The unique ID for the live stream that you want to update information for such as player details, or whether you want the recording on or off.\n        const liveStreamUpdatePayload = {\n      name: \"My Live Stream Video\", // The name you want to use for your live stream.\n      _public: true, // BETA FEATURE Please limit all public = false (\\\"private\\\") livestreams to 3,000 users. Whether your video can be viewed by everyone, or requires authentication to see it. A setting of false will require a unique token for each view.\n      record: true, // Use this to indicate whether you want the recording on or off. On is true, off is false.\n      playerId: \"pl45KFKdlddgk654dspkze\", // The unique ID for the player associated with a live stream that you want to update.\n    }; \n\n        // LiveStream\n        const result = await client.liveStreams.update(liveStreamId, liveStreamUpdatePayload);\n        console.log(result);\n    } catch (e) {\n        console.error(e);\n    }\n})();\n"
-        - language: python
-          code: "#install the api.video API client library\n#pip install api.video\nimport apivideo\nfrom apivideo.api import live_streams_api\nfrom apivideo.model.bad_request import BadRequest\nfrom apivideo.model.live_stream_update_payload import LiveStreamUpdatePayload\nfrom apivideo.model.live_stream import LiveStream\nfrom pprint import pprint\n\n# Enter a context with an instance of the API client\nwith apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:\n    # Create an instance of the API class\n    api_instance = live_streams_api.LiveStreamsApi(api_client)\n    live_stream_id = \"li400mYKSgQ6xs7taUeSaEKr\" # str | The unique ID for the live stream that you want to update information for such as player details, or whether you want the recording on or off.\n    live_stream_update_payload = LiveStreamUpdatePayload(\n        name=\"My Live Stream Video\",\n        public=True,\n        record=True,\n        player_id=\"pl45KFKdlddgk654dspkze\",\n    ) # LiveStreamUpdatePayload | \n\n    # example passing only required values which don't have defaults set\n    try:\n        # Update a live stream\n        api_response = api_instance.update(live_stream_id, live_stream_update_payload)\n        pprint(api_response)\n    except apivideo.ApiException as e:\n        print(\"Exception when calling LiveStreamsApi->update: %s\\n\" % e)\n"
-        - language: java
-          code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.LiveStreamsApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    LiveStreamsApi apiInstance = client.liveStreams();\n    \n    String liveStreamId = \"li400mYKSgQ6xs7taUeSaEKr\"; // The unique ID for the live stream that you want to update information for such as player details, or whether you want the recording on or off.\n    LiveStreamUpdatePayload liveStreamUpdatePayload = new LiveStreamUpdatePayload(); // \n    liveStreamUpdatePayload.setName(\"My Live Stream Video\"); // The name you want to use for your live stream.\n    liveStreamUpdatePayload.setPublic(); // BETA FEATURE Please limit all public &#x3D; false (&quot;private&quot;) livestreams to 3,000 users.\nWhether your video can be viewed by everyone, or requires authentication to see it. A setting of false will require a unique token for each view.\n    liveStreamUpdatePayload.setRecord(true); // Use this to indicate whether you want the recording on or off. On is true, off is false.\n    liveStreamUpdatePayload.setPlayerId(\"pl45KFKdlddgk654dspkze\"); // The unique ID for the player associated with a live stream that you want to update.\n\n\n    try {\n      LiveStream result = apiInstance.update(liveStreamId, liveStreamUpdatePayload);\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling LiveStreamsApi#update\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
-        - language: csharp
-          code: "//install via Nuget\n//Install-Package ApiVideo\nusing System.Diagnostics;\nusing ApiVideo.Client;\n\nnamespace Example\n{\n    public class updateExample\n    {\n        public static void Main()\n        {\n            var basePath = ApiVideoClient.Client.Environment.SANDBOX;\n            var apiKey = \"YOUR_API_KEY\";\n\n            var apiInstance = new ApiVideoClient(apiKey,basePath);\n\n            var liveStreamId = li400mYKSgQ6xs7taUeSaEKr;  // string | The unique ID for the live stream that you want to update information for such as player details, or whether you want the recording on or off.\n            var liveStreamUpdatePayload = new LiveStreamUpdatePayload(); // LiveStreamUpdatePayload | \n            var apiLiveStreamsInstance = apiInstance.LiveStreams();\n            try\n            {\n                // Update a live stream\n                LiveStream result = apiLiveStreamsInstance.update(liveStreamId, liveStreamUpdatePayload);\n                Debug.WriteLine(result);\n            }\n            catch (ApiException  e)\n            {\n                Debug.Print(\"Exception when calling LiveStreamsApi.update: \" + e.Message );\n                Debug.Print(\"Status Code: \"+ e.ErrorCode);\n                Debug.Print(e.StackTrace);\n            }\n        }\n    }\n}\n"
+          - language: go
+            code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    liveStreamId := \"li400mYKSgQ6xs7taUeSaEKr\" // string | The unique ID for the live stream that you want to update information for such as player details, or whether you want the recording on or off.\n    liveStreamUpdatePayload := *apivideosdk.NewLiveStreamUpdatePayload() // LiveStreamUpdatePayload | \n\n    \n    res, err := client.LiveStreams.Update(liveStreamId, liveStreamUpdatePayload)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `LiveStreams.Update``: %v\\n\", err)\n    }\n    // response from `Update`: LiveStream\n    fmt.Fprintf(os.Stdout, \"Response from `LiveStreams.Update`: %v\\n\", res)\n}\n"
+          - language: node
+            code: "//install the module with npm or yarn\n//npm install @api.video/nodejs-client --save\n//yarn add @api.video/nodejs-client\n(async () => {\n    try {\n        const client = new ApiVideoClient({ apiKey: \"YOUR_API_TOKEN\" });\n\n        const liveStreamId = 'li400mYKSgQ6xs7taUeSaEKr'; // The unique ID for the live stream that you want to update information for such as player details, or whether you want the recording on or off.\n        const liveStreamUpdatePayload = {\n      name: \"My Live Stream Video\", // The name you want to use for your live stream.\n      _public: true, // BETA FEATURE Please limit all public = false (\\\"private\\\") livestreams to 3,000 users. Whether your video can be viewed by everyone, or requires authentication to see it. A setting of false will require a unique token for each view.\n      record: true, // Use this to indicate whether you want the recording on or off. On is true, off is false.\n      playerId: \"pl45KFKdlddgk654dspkze\", // The unique ID for the player associated with a live stream that you want to update.\n    }; \n\n        // LiveStream\n        const result = await client.liveStreams.update(liveStreamId, liveStreamUpdatePayload);\n        console.log(result);\n    } catch (e) {\n        console.error(e);\n    }\n})();\n"
+          - language: python
+            code: "#install the api.video API client library\n#pip install api.video\nimport apivideo\nfrom apivideo.api import live_streams_api\nfrom apivideo.model.bad_request import BadRequest\nfrom apivideo.model.live_stream_update_payload import LiveStreamUpdatePayload\nfrom apivideo.model.live_stream import LiveStream\nfrom pprint import pprint\n\n# Enter a context with an instance of the API client\nwith apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:\n    # Create an instance of the API class\n    api_instance = live_streams_api.LiveStreamsApi(api_client)\n    live_stream_id = \"li400mYKSgQ6xs7taUeSaEKr\" # str | The unique ID for the live stream that you want to update information for such as player details, or whether you want the recording on or off.\n    live_stream_update_payload = LiveStreamUpdatePayload(\n        name=\"My Live Stream Video\",\n        public=True,\n        record=True,\n        player_id=\"pl45KFKdlddgk654dspkze\",\n    ) # LiveStreamUpdatePayload | \n\n    # example passing only required values which don't have defaults set\n    try:\n        # Update a live stream\n        api_response = api_instance.update(live_stream_id, live_stream_update_payload)\n        pprint(api_response)\n    except apivideo.ApiException as e:\n        print(\"Exception when calling LiveStreamsApi->update: %s\\n\" % e)\n"
+          - language: java
+            code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.LiveStreamsApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    LiveStreamsApi apiInstance = client.liveStreams();\n    \n    String liveStreamId = \"li400mYKSgQ6xs7taUeSaEKr\"; // The unique ID for the live stream that you want to update information for such as player details, or whether you want the recording on or off.\n    LiveStreamUpdatePayload liveStreamUpdatePayload = new LiveStreamUpdatePayload(); // \n    liveStreamUpdatePayload.setName(\"My Live Stream Video\"); // The name you want to use for your live stream.\n    liveStreamUpdatePayload.setPublic(); // BETA FEATURE Please limit all public &#x3D; false (&quot;private&quot;) livestreams to 3,000 users.\nWhether your video can be viewed by everyone, or requires authentication to see it. A setting of false will require a unique token for each view.\n    liveStreamUpdatePayload.setRecord(true); // Use this to indicate whether you want the recording on or off. On is true, off is false.\n    liveStreamUpdatePayload.setPlayerId(\"pl45KFKdlddgk654dspkze\"); // The unique ID for the player associated with a live stream that you want to update.\n\n\n    try {\n      LiveStream result = apiInstance.update(liveStreamId, liveStreamUpdatePayload);\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling LiveStreamsApi#update\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
+          - language: csharp
+            code: "//install via Nuget\n//Install-Package ApiVideo\nusing System.Diagnostics;\nusing ApiVideo.Client;\n\nnamespace Example\n{\n    public class updateExample\n    {\n        public static void Main()\n        {\n            var basePath = ApiVideoClient.Client.Environment.SANDBOX;\n            var apiKey = \"YOUR_API_KEY\";\n\n            var apiInstance = new ApiVideoClient(apiKey,basePath);\n\n            var liveStreamId = li400mYKSgQ6xs7taUeSaEKr;  // string | The unique ID for the live stream that you want to update information for such as player details, or whether you want the recording on or off.\n            var liveStreamUpdatePayload = new LiveStreamUpdatePayload(); // LiveStreamUpdatePayload | \n            var apiLiveStreamsInstance = apiInstance.LiveStreams();\n            try\n            {\n                // Update a live stream\n                LiveStream result = apiLiveStreamsInstance.update(liveStreamId, liveStreamUpdatePayload);\n                Debug.WriteLine(result);\n            }\n            catch (ApiException  e)\n            {\n                Debug.Print(\"Exception when calling LiveStreamsApi.update: \" + e.Message );\n                Debug.Print(\"Status Code: \"+ e.ErrorCode);\n                Debug.Print(e.StackTrace);\n            }\n        }\n    }\n}\n"
   /live-streams/{liveStreamId}/thumbnail:
     post:
       tags:
-      - Live
+        - Live Streams
       summary: Upload a thumbnail
       description: Upload an image to use as a backdrop for your livestream. Tutorials that [update live stream thumbnails](https://api.video/blog/endpoints/live-upload-a-thumbnail).
       operationId: POST_live-streams-liveStreamId-thumbnail
       parameters:
-      - name: liveStreamId
-        in: path
-        description: The unique ID for the live stream you want to upload.
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-        example: vi4k0jvEUuaTdRAEjQ4Jfrgz
+        - name: liveStreamId
+          in: path
+          description: The unique ID for the live stream you want to upload.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: vi4k0jvEUuaTdRAEjQ4Jfrgz
       requestBody:
+        required: true
         content:
           multipart/form-data:
             schema:
@@ -2594,110 +2626,110 @@ paths:
                     name: liveStreamId
                     status: 404
       security:
-      - bearerAuth: []
+        - bearerAuth: []
       x-client-action: uploadThumbnail
       x-readme:
         code-samples:
-        - language: go
-          code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    liveStreamId := \"vi4k0jvEUuaTdRAEjQ4Jfrgz\" // string | The unique ID for the live stream you want to upload.\n    file := os.NewFile(1234, \"some_file\") // *os.File | The image to be added as a thumbnail.\n\n    \n    res, err := client.LiveStreams.UploadThumbnailFile(liveStreamId, file)\n\n    // you can also use a Reader instead of a File:\n    // client.LiveStreams.UploadThumbnail(liveStreamId, fileName, fileReader)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `LiveStreams.UploadThumbnail``: %v\\n\", err)\n    }\n    // response from `UploadThumbnail`: LiveStream\n    fmt.Fprintf(os.Stdout, \"Response from `LiveStreams.UploadThumbnail`: %v\\n\", res)\n}\n"
-        - language: node
-          code: |
-            //install the module with npm or yarn
-            //npm install @api.video/nodejs-client --save
-            //yarn add @api.video/nodejs-client
-            (async () => {
-                try {
-                    const client = new ApiVideoClient({ apiKey: "YOUR_API_TOKEN" });
+          - language: go
+            code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    liveStreamId := \"vi4k0jvEUuaTdRAEjQ4Jfrgz\" // string | The unique ID for the live stream you want to upload.\n    file := os.NewFile(1234, \"some_file\") // *os.File | The image to be added as a thumbnail.\n\n    \n    res, err := client.LiveStreams.UploadThumbnailFile(liveStreamId, file)\n\n    // you can also use a Reader instead of a File:\n    // client.LiveStreams.UploadThumbnail(liveStreamId, fileName, fileReader)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `LiveStreams.UploadThumbnail``: %v\\n\", err)\n    }\n    // response from `UploadThumbnail`: LiveStream\n    fmt.Fprintf(os.Stdout, \"Response from `LiveStreams.UploadThumbnail`: %v\\n\", res)\n}\n"
+          - language: node
+            code: |
+              //install the module with npm or yarn
+              //npm install @api.video/nodejs-client --save
+              //yarn add @api.video/nodejs-client
+              (async () => {
+                  try {
+                      const client = new ApiVideoClient({ apiKey: "YOUR_API_TOKEN" });
 
-                    const liveStreamId = 'vi4k0jvEUuaTdRAEjQ4Jfrgz'; // The unique ID for the live stream you want to upload.
-                    const file = 'BINARY_DATA_HERE'; // The image to be added as a thumbnail.
+                      const liveStreamId = 'vi4k0jvEUuaTdRAEjQ4Jfrgz'; // The unique ID for the live stream you want to upload.
+                      const file = 'BINARY_DATA_HERE'; // The image to be added as a thumbnail.
 
-                    // LiveStream
-                    const result = await client.liveStreams.uploadThumbnail(liveStreamId, file);
-                    console.log(result);
-                } catch (e) {
-                    console.error(e);
-                }
-            })();
-        - language: python
-          code: |
-            #install the api.video API client library
-            #pip install api.video
-            import apivideo
-            from apivideo.api import live_streams_api
-            from apivideo.model.bad_request import BadRequest
-            from apivideo.model.not_found import NotFound
-            from apivideo.model.live_stream import LiveStream
-            from pprint import pprint
+                      // LiveStream
+                      const result = await client.liveStreams.uploadThumbnail(liveStreamId, file);
+                      console.log(result);
+                  } catch (e) {
+                      console.error(e);
+                  }
+              })();
+          - language: python
+            code: |
+              #install the api.video API client library
+              #pip install api.video
+              import apivideo
+              from apivideo.api import live_streams_api
+              from apivideo.model.bad_request import BadRequest
+              from apivideo.model.not_found import NotFound
+              from apivideo.model.live_stream import LiveStream
+              from pprint import pprint
 
-            # Enter a context with an instance of the API client
-            with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
-                # Create an instance of the API class
-                api_instance = live_streams_api.LiveStreamsApi(api_client)
-                live_stream_id = "vi4k0jvEUuaTdRAEjQ4Jfrgz" # str | The unique ID for the live stream you want to upload.
-                file = open('/path/to/file', 'rb') # file_type | The image to be added as a thumbnail.
+              # Enter a context with an instance of the API client
+              with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
+                  # Create an instance of the API class
+                  api_instance = live_streams_api.LiveStreamsApi(api_client)
+                  live_stream_id = "vi4k0jvEUuaTdRAEjQ4Jfrgz" # str | The unique ID for the live stream you want to upload.
+                  file = open('/path/to/file', 'rb') # file_type | The image to be added as a thumbnail.
 
-                # example passing only required values which don't have defaults set
-                try:
-                    # Upload a thumbnail
-                    api_response = api_instance.upload_thumbnail(live_stream_id, file)
-                    pprint(api_response)
-                except apivideo.ApiException as e:
-                    print("Exception when calling LiveStreamsApi->upload_thumbnail: %s\n" % e)
-        - language: java
-          code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.LiveStreamsApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    LiveStreamsApi apiInstance = client.liveStreams();\n    \n    String liveStreamId = \"vi4k0jvEUuaTdRAEjQ4Jfrgz\"; // The unique ID for the live stream you want to upload.\n    File file = new File(\"/path/to/file\"); // The image to be added as a thumbnail.\n\n    try {\n      LiveStream result = apiInstance.uploadThumbnail(liveStreamId, file);\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling LiveStreamsApi#uploadThumbnail\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
-        - language: csharp
-          code: |
-            //install via Nuget
-            //Install-Package ApiVideo
-            using System.Diagnostics;
-            using ApiVideo.Client;
+                  # example passing only required values which don't have defaults set
+                  try:
+                      # Upload a thumbnail
+                      api_response = api_instance.upload_thumbnail(live_stream_id, file)
+                      pprint(api_response)
+                  except apivideo.ApiException as e:
+                      print("Exception when calling LiveStreamsApi->upload_thumbnail: %s\n" % e)
+          - language: java
+            code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.LiveStreamsApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    LiveStreamsApi apiInstance = client.liveStreams();\n    \n    String liveStreamId = \"vi4k0jvEUuaTdRAEjQ4Jfrgz\"; // The unique ID for the live stream you want to upload.\n    File file = new File(\"/path/to/file\"); // The image to be added as a thumbnail.\n\n    try {\n      LiveStream result = apiInstance.uploadThumbnail(liveStreamId, file);\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling LiveStreamsApi#uploadThumbnail\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
+          - language: csharp
+            code: |
+              //install via Nuget
+              //Install-Package ApiVideo
+              using System.Diagnostics;
+              using ApiVideo.Client;
 
-            namespace Example
-            {
-                public class uploadThumbnailExample
-                {
-                    public static void Main()
-                    {
-                        var basePath = ApiVideoClient.Client.Environment.SANDBOX;
-                        var apiKey = "YOUR_API_KEY";
+              namespace Example
+              {
+                  public class uploadThumbnailExample
+                  {
+                      public static void Main()
+                      {
+                          var basePath = ApiVideoClient.Client.Environment.SANDBOX;
+                          var apiKey = "YOUR_API_KEY";
 
-                        var apiInstance = new ApiVideoClient(apiKey,basePath);
+                          var apiInstance = new ApiVideoClient(apiKey,basePath);
 
-                        var liveStreamId = vi4k0jvEUuaTdRAEjQ4Jfrgz;  // string | The unique ID for the live stream you want to upload.
-                        var file = BINARY_DATA_HERE;  // System.IO.Stream | The image to be added as a thumbnail.
-                        var apiLiveStreamsInstance = apiInstance.LiveStreams();
-                        try
-                        {
-                            // Upload a thumbnail
-                            LiveStream result = apiLiveStreamsInstance.uploadThumbnail(liveStreamId, file);
-                            Debug.WriteLine(result);
-                        }
-                        catch (ApiException  e)
-                        {
-                            Debug.Print("Exception when calling LiveStreamsApi.uploadThumbnail: " + e.Message );
-                            Debug.Print("Status Code: "+ e.ErrorCode);
-                            Debug.Print(e.StackTrace);
-                        }
-                    }
-                }
-            }
+                          var liveStreamId = vi4k0jvEUuaTdRAEjQ4Jfrgz;  // string | The unique ID for the live stream you want to upload.
+                          var file = BINARY_DATA_HERE;  // System.IO.Stream | The image to be added as a thumbnail.
+                          var apiLiveStreamsInstance = apiInstance.LiveStreams();
+                          try
+                          {
+                              // Upload a thumbnail
+                              LiveStream result = apiLiveStreamsInstance.uploadThumbnail(liveStreamId, file);
+                              Debug.WriteLine(result);
+                          }
+                          catch (ApiException  e)
+                          {
+                              Debug.Print("Exception when calling LiveStreamsApi.uploadThumbnail: " + e.Message );
+                              Debug.Print("Status Code: "+ e.ErrorCode);
+                              Debug.Print(e.StackTrace);
+                          }
+                      }
+                  }
+              }
     delete:
       tags:
-      - Live
+        - Live Streams
       summary: Delete a thumbnail
       description: Send the unique identifier for a live stream to delete it from the system.
       operationId: DELETE_live-streams-liveStreamId-thumbnail
       parameters:
-      - name: liveStreamId
-        in: path
-        description: 'The unique identifier for the live stream you want to delete. '
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-        example: li400mYKSgQ6xs7taUeSaEKr
+        - name: liveStreamId
+          in: path
+          description: 'The unique identifier for the live stream you want to delete. '
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: li400mYKSgQ6xs7taUeSaEKr
       responses:
         "200":
           description: Success
@@ -2719,55 +2751,55 @@ paths:
                     name: liveStreamId
                     status: 404
       security:
-      - bearerAuth: []
+        - bearerAuth: []
       x-client-action: deleteThumbnail
       x-readme:
         code-samples:
-        - language: go
-          code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    liveStreamId := \"li400mYKSgQ6xs7taUeSaEKr\" // string | The unique identifier for the live stream you want to delete. \n\n    \n    res, err := client.LiveStreams.DeleteThumbnail(liveStreamId)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `LiveStreams.DeleteThumbnail``: %v\\n\", err)\n    }\n    // response from `DeleteThumbnail`: LiveStream\n    fmt.Fprintf(os.Stdout, \"Response from `LiveStreams.DeleteThumbnail`: %v\\n\", res)\n}\n"
-        - language: node
-          code: "//install the module with npm or yarn\n//npm install @api.video/nodejs-client --save\n//yarn add @api.video/nodejs-client\n(async () => {\n    try {\n        const client = new ApiVideoClient({ apiKey: \"YOUR_API_TOKEN\" });\n\n        const liveStreamId = 'li400mYKSgQ6xs7taUeSaEKr'; // The unique identifier for the live stream you want to delete. \n\n        // LiveStream\n        const result = await client.liveStreams.deleteThumbnail(liveStreamId);\n        console.log(result);\n    } catch (e) {\n        console.error(e);\n    }\n})();\n"
-        - language: python
-          code: "#install the api.video API client library\n#pip install api.video\nimport apivideo\nfrom apivideo.api import live_streams_api\nfrom apivideo.model.not_found import NotFound\nfrom apivideo.model.live_stream import LiveStream\nfrom pprint import pprint\n\n# Enter a context with an instance of the API client\nwith apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:\n    # Create an instance of the API class\n    api_instance = live_streams_api.LiveStreamsApi(api_client)\n    live_stream_id = \"li400mYKSgQ6xs7taUeSaEKr\" # str | The unique identifier for the live stream you want to delete. \n\n    # example passing only required values which don't have defaults set\n    try:\n        # Delete a thumbnail\n        api_response = api_instance.delete_thumbnail(live_stream_id)\n        pprint(api_response)\n    except apivideo.ApiException as e:\n        print(\"Exception when calling LiveStreamsApi->delete_thumbnail: %s\\n\" % e)\n"
-        - language: java
-          code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.LiveStreamsApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    LiveStreamsApi apiInstance = client.liveStreams();\n    \n    String liveStreamId = \"li400mYKSgQ6xs7taUeSaEKr\"; // The unique identifier for the live stream you want to delete. \n\n    try {\n      LiveStream result = apiInstance.deleteThumbnail(liveStreamId);\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling LiveStreamsApi#deleteThumbnail\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
-        - language: csharp
-          code: "//install via Nuget\n//Install-Package ApiVideo\nusing System.Diagnostics;\nusing ApiVideo.Client;\n\nnamespace Example\n{\n    public class deleteThumbnailExample\n    {\n        public static void Main()\n        {\n            var basePath = ApiVideoClient.Client.Environment.SANDBOX;\n            var apiKey = \"YOUR_API_KEY\";\n\n            var apiInstance = new ApiVideoClient(apiKey,basePath);\n\n            var liveStreamId = li400mYKSgQ6xs7taUeSaEKr;  // string | The unique identifier for the live stream you want to delete. \n            var apiLiveStreamsInstance = apiInstance.LiveStreams();\n            try\n            {\n                // Delete a thumbnail\n                LiveStream result = apiLiveStreamsInstance.deleteThumbnail(liveStreamId);\n                Debug.WriteLine(result);\n            }\n            catch (ApiException  e)\n            {\n                Debug.Print(\"Exception when calling LiveStreamsApi.deleteThumbnail: \" + e.Message );\n                Debug.Print(\"Status Code: \"+ e.ErrorCode);\n                Debug.Print(e.StackTrace);\n            }\n        }\n    }\n}\n"
+          - language: go
+            code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    liveStreamId := \"li400mYKSgQ6xs7taUeSaEKr\" // string | The unique identifier for the live stream you want to delete. \n\n    \n    res, err := client.LiveStreams.DeleteThumbnail(liveStreamId)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `LiveStreams.DeleteThumbnail``: %v\\n\", err)\n    }\n    // response from `DeleteThumbnail`: LiveStream\n    fmt.Fprintf(os.Stdout, \"Response from `LiveStreams.DeleteThumbnail`: %v\\n\", res)\n}\n"
+          - language: node
+            code: "//install the module with npm or yarn\n//npm install @api.video/nodejs-client --save\n//yarn add @api.video/nodejs-client\n(async () => {\n    try {\n        const client = new ApiVideoClient({ apiKey: \"YOUR_API_TOKEN\" });\n\n        const liveStreamId = 'li400mYKSgQ6xs7taUeSaEKr'; // The unique identifier for the live stream you want to delete. \n\n        // LiveStream\n        const result = await client.liveStreams.deleteThumbnail(liveStreamId);\n        console.log(result);\n    } catch (e) {\n        console.error(e);\n    }\n})();\n"
+          - language: python
+            code: "#install the api.video API client library\n#pip install api.video\nimport apivideo\nfrom apivideo.api import live_streams_api\nfrom apivideo.model.not_found import NotFound\nfrom apivideo.model.live_stream import LiveStream\nfrom pprint import pprint\n\n# Enter a context with an instance of the API client\nwith apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:\n    # Create an instance of the API class\n    api_instance = live_streams_api.LiveStreamsApi(api_client)\n    live_stream_id = \"li400mYKSgQ6xs7taUeSaEKr\" # str | The unique identifier for the live stream you want to delete. \n\n    # example passing only required values which don't have defaults set\n    try:\n        # Delete a thumbnail\n        api_response = api_instance.delete_thumbnail(live_stream_id)\n        pprint(api_response)\n    except apivideo.ApiException as e:\n        print(\"Exception when calling LiveStreamsApi->delete_thumbnail: %s\\n\" % e)\n"
+          - language: java
+            code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.LiveStreamsApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    LiveStreamsApi apiInstance = client.liveStreams();\n    \n    String liveStreamId = \"li400mYKSgQ6xs7taUeSaEKr\"; // The unique identifier for the live stream you want to delete. \n\n    try {\n      LiveStream result = apiInstance.deleteThumbnail(liveStreamId);\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling LiveStreamsApi#deleteThumbnail\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
+          - language: csharp
+            code: "//install via Nuget\n//Install-Package ApiVideo\nusing System.Diagnostics;\nusing ApiVideo.Client;\n\nnamespace Example\n{\n    public class deleteThumbnailExample\n    {\n        public static void Main()\n        {\n            var basePath = ApiVideoClient.Client.Environment.SANDBOX;\n            var apiKey = \"YOUR_API_KEY\";\n\n            var apiInstance = new ApiVideoClient(apiKey,basePath);\n\n            var liveStreamId = li400mYKSgQ6xs7taUeSaEKr;  // string | The unique identifier for the live stream you want to delete. \n            var apiLiveStreamsInstance = apiInstance.LiveStreams();\n            try\n            {\n                // Delete a thumbnail\n                LiveStream result = apiLiveStreamsInstance.deleteThumbnail(liveStreamId);\n                Debug.WriteLine(result);\n            }\n            catch (ApiException  e)\n            {\n                Debug.Print(\"Exception when calling LiveStreamsApi.deleteThumbnail: \" + e.Message );\n                Debug.Print(\"Status Code: \"+ e.ErrorCode);\n                Debug.Print(e.StackTrace);\n            }\n        }\n    }\n}\n"
   /videos/{videoId}/captions/{language}:
     get:
       tags:
-      - Captions
+        - Captions
       summary: Show a caption
       description: |-
         Display a caption for a video in a specific language. If the language is available, the caption is returned. Otherwise, you will get a response indicating the caption was not found.
         Tutorials that use the [captions endpoint](https://api.video/blog/endpoints/captions).
       operationId: GET_videos-videoId-captions-language
       parameters:
-      - name: videoId
-        in: path
-        description: The unique identifier for the video you want captions for.
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-        example: vi4k0jvEUuaTdRAEjQ4Prklg
-      - name: language
-        in: path
-        description: A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-        example: en
+        - name: videoId
+          in: path
+          description: The unique identifier for the video you want captions for.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: vi4k0jvEUuaTdRAEjQ4Prklg
+        - name: language
+          in: path
+          description: A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: en
       responses:
         "200":
           description: Success
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/subtitle'
+                $ref: '#/components/schemas/caption'
               examples:
                 response:
                   value:
@@ -2782,121 +2814,122 @@ paths:
               schema:
                 $ref: '#/components/schemas/not-found'
       security:
-      - bearerAuth: []
+        - bearerAuth: []
       x-client-action: get
       x-readme:
         code-samples:
-        - language: go
-          code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    videoId := \"vi4k0jvEUuaTdRAEjQ4Prklg\" // string | The unique identifier for the video you want captions for.\n    language := \"en\" // string | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation\n\n    \n    res, err := client.Captions.Get(videoId, language)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `Captions.Get``: %v\\n\", err)\n    }\n    // response from `Get`: Caption\n    fmt.Fprintf(os.Stdout, \"Response from `Captions.Get`: %v\\n\", res)\n}\n"
-        - language: node
-          code: |
-            //install the module with npm or yarn
-            //npm install @api.video/nodejs-client --save
-            //yarn add @api.video/nodejs-client
-            (async () => {
-                try {
-                    const client = new ApiVideoClient({ apiKey: "YOUR_API_TOKEN" });
+          - language: go
+            code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    videoId := \"vi4k0jvEUuaTdRAEjQ4Prklg\" // string | The unique identifier for the video you want captions for.\n    language := \"en\" // string | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation\n\n    \n    res, err := client.Captions.Get(videoId, language)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `Captions.Get``: %v\\n\", err)\n    }\n    // response from `Get`: Caption\n    fmt.Fprintf(os.Stdout, \"Response from `Captions.Get`: %v\\n\", res)\n}\n"
+          - language: node
+            code: |
+              //install the module with npm or yarn
+              //npm install @api.video/nodejs-client --save
+              //yarn add @api.video/nodejs-client
+              (async () => {
+                  try {
+                      const client = new ApiVideoClient({ apiKey: "YOUR_API_TOKEN" });
 
-                    const videoId = 'vi4k0jvEUuaTdRAEjQ4Prklg'; // The unique identifier for the video you want captions for.
-                    const language = 'en'; // A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation
+                      const videoId = 'vi4k0jvEUuaTdRAEjQ4Prklg'; // The unique identifier for the video you want captions for.
+                      const language = 'en'; // A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation
 
-                    // Caption
-                    const result = await client.captions.get(videoId, language);
-                    console.log(result);
-                } catch (e) {
-                    console.error(e);
-                }
-            })();
-        - language: python
-          code: |
-            #install the api.video API client library
-            #pip install api.video
-            import apivideo
-            from apivideo.api import captions_api
-            from apivideo.model.not_found import NotFound
-            from apivideo.model.caption import Caption
-            from pprint import pprint
+                      // Caption
+                      const result = await client.captions.get(videoId, language);
+                      console.log(result);
+                  } catch (e) {
+                      console.error(e);
+                  }
+              })();
+          - language: python
+            code: |
+              #install the api.video API client library
+              #pip install api.video
+              import apivideo
+              from apivideo.api import captions_api
+              from apivideo.model.not_found import NotFound
+              from apivideo.model.caption import Caption
+              from pprint import pprint
 
-            # Enter a context with an instance of the API client
-            with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
-                # Create an instance of the API class
-                api_instance = captions_api.CaptionsApi(api_client)
-                video_id = "vi4k0jvEUuaTdRAEjQ4Prklg" # str | The unique identifier for the video you want captions for.
-                language = "en" # str | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation
+              # Enter a context with an instance of the API client
+              with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
+                  # Create an instance of the API class
+                  api_instance = captions_api.CaptionsApi(api_client)
+                  video_id = "vi4k0jvEUuaTdRAEjQ4Prklg" # str | The unique identifier for the video you want captions for.
+                  language = "en" # str | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation
 
-                # example passing only required values which don't have defaults set
-                try:
-                    # Show a caption
-                    api_response = api_instance.get(video_id, language)
-                    pprint(api_response)
-                except apivideo.ApiException as e:
-                    print("Exception when calling CaptionsApi->get: %s\n" % e)
-        - language: java
-          code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.CaptionsApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    CaptionsApi apiInstance = client.captions();\n    \n    String videoId = \"vi4k0jvEUuaTdRAEjQ4Prklg\"; // The unique identifier for the video you want captions for.\n    String language = \"en\"; // A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation\n\n    try {\n      Caption result = apiInstance.get(videoId, language);\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling CaptionsApi#get\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
-        - language: csharp
-          code: |
-            //install via Nuget
-            //Install-Package ApiVideo
-            using System.Diagnostics;
-            using ApiVideo.Client;
+                  # example passing only required values which don't have defaults set
+                  try:
+                      # Show a caption
+                      api_response = api_instance.get(video_id, language)
+                      pprint(api_response)
+                  except apivideo.ApiException as e:
+                      print("Exception when calling CaptionsApi->get: %s\n" % e)
+          - language: java
+            code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.CaptionsApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    CaptionsApi apiInstance = client.captions();\n    \n    String videoId = \"vi4k0jvEUuaTdRAEjQ4Prklg\"; // The unique identifier for the video you want captions for.\n    String language = \"en\"; // A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation\n\n    try {\n      Caption result = apiInstance.get(videoId, language);\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling CaptionsApi#get\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
+          - language: csharp
+            code: |
+              //install via Nuget
+              //Install-Package ApiVideo
+              using System.Diagnostics;
+              using ApiVideo.Client;
 
-            namespace Example
-            {
-                public class getExample
-                {
-                    public static void Main()
-                    {
-                        var basePath = ApiVideoClient.Client.Environment.SANDBOX;
-                        var apiKey = "YOUR_API_KEY";
+              namespace Example
+              {
+                  public class getExample
+                  {
+                      public static void Main()
+                      {
+                          var basePath = ApiVideoClient.Client.Environment.SANDBOX;
+                          var apiKey = "YOUR_API_KEY";
 
-                        var apiInstance = new ApiVideoClient(apiKey,basePath);
+                          var apiInstance = new ApiVideoClient(apiKey,basePath);
 
-                        var videoId = vi4k0jvEUuaTdRAEjQ4Prklg;  // string | The unique identifier for the video you want captions for.
-                        var language = en;  // string | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation
-                        var apiCaptionsInstance = apiInstance.Captions();
-                        try
-                        {
-                            // Show a caption
-                            Caption result = apiCaptionsInstance.get(videoId, language);
-                            Debug.WriteLine(result);
-                        }
-                        catch (ApiException  e)
-                        {
-                            Debug.Print("Exception when calling CaptionsApi.get: " + e.Message );
-                            Debug.Print("Status Code: "+ e.ErrorCode);
-                            Debug.Print(e.StackTrace);
-                        }
-                    }
-                }
-            }
+                          var videoId = vi4k0jvEUuaTdRAEjQ4Prklg;  // string | The unique identifier for the video you want captions for.
+                          var language = en;  // string | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation
+                          var apiCaptionsInstance = apiInstance.Captions();
+                          try
+                          {
+                              // Show a caption
+                              Caption result = apiCaptionsInstance.get(videoId, language);
+                              Debug.WriteLine(result);
+                          }
+                          catch (ApiException  e)
+                          {
+                              Debug.Print("Exception when calling CaptionsApi.get: " + e.Message );
+                              Debug.Print("Status Code: "+ e.ErrorCode);
+                              Debug.Print(e.StackTrace);
+                          }
+                      }
+                  }
+              }
     post:
       tags:
-      - Captions
+        - Captions
       summary: Upload a caption
       description: |-
         Upload a VTT file to add captions to your video.
          Read our [captioning tutorial](https://api.video/blog/tutorials/adding-captions) for more details.
       operationId: POST_videos-videoId-captions-language
       parameters:
-      - name: videoId
-        in: path
-        description: The unique identifier for the video you want to add a caption to.
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-        example: vi4k0jvEUuaTdRAEjQ4Prklg
-      - name: language
-        in: path
-        description: A valid BCP 47 language representation.
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-        example: en
+        - name: videoId
+          in: path
+          description: The unique identifier for the video you want to add a caption to.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: vi4k0jvEUuaTdRAEjQ4Prklg
+        - name: language
+          in: path
+          description: A valid BCP 47 language representation.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: en
       requestBody:
+        required: true
         content:
           multipart/form-data:
             schema:
@@ -2907,7 +2940,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/subtitle'
+                $ref: '#/components/schemas/caption'
               examples:
                 response:
                   value:
@@ -2928,122 +2961,122 @@ paths:
               schema:
                 $ref: '#/components/schemas/not-found'
       security:
-      - bearerAuth: []
+        - bearerAuth: []
       x-client-action: upload
       x-readme:
         code-samples:
-        - language: go
-          code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    videoId := \"vi4k0jvEUuaTdRAEjQ4Prklg\" // string | The unique identifier for the video you want to add a caption to.\n    language := \"en\" // string | A valid BCP 47 language representation.\n    file := os.NewFile(1234, \"some_file\") // *os.File | The video text track (VTT) you want to upload.\n\n    \n    res, err := client.Captions.UploadFile(videoId, language, file)\n\n    // you can also use a Reader instead of a File:\n    // client.Captions.Upload(videoId, language, fileName, fileReader)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `Captions.Upload``: %v\\n\", err)\n    }\n    // response from `Upload`: Caption\n    fmt.Fprintf(os.Stdout, \"Response from `Captions.Upload`: %v\\n\", res)\n}\n"
-        - language: node
-          code: |
-            //install the module with npm or yarn
-            //npm install @api.video/nodejs-client --save
-            //yarn add @api.video/nodejs-client
-            (async () => {
-                try {
-                    const client = new ApiVideoClient({ apiKey: "YOUR_API_TOKEN" });
+          - language: go
+            code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    videoId := \"vi4k0jvEUuaTdRAEjQ4Prklg\" // string | The unique identifier for the video you want to add a caption to.\n    language := \"en\" // string | A valid BCP 47 language representation.\n    file := os.NewFile(1234, \"some_file\") // *os.File | The video text track (VTT) you want to upload.\n\n    \n    res, err := client.Captions.UploadFile(videoId, language, file)\n\n    // you can also use a Reader instead of a File:\n    // client.Captions.Upload(videoId, language, fileName, fileReader)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `Captions.Upload``: %v\\n\", err)\n    }\n    // response from `Upload`: Caption\n    fmt.Fprintf(os.Stdout, \"Response from `Captions.Upload`: %v\\n\", res)\n}\n"
+          - language: node
+            code: |
+              //install the module with npm or yarn
+              //npm install @api.video/nodejs-client --save
+              //yarn add @api.video/nodejs-client
+              (async () => {
+                  try {
+                      const client = new ApiVideoClient({ apiKey: "YOUR_API_TOKEN" });
 
-                    const videoId = 'vi4k0jvEUuaTdRAEjQ4Prklg'; // The unique identifier for the video you want to add a caption to.
-                    const language = 'en'; // A valid BCP 47 language representation.
-                    const file = 'BINARY_DATA_HERE'; // The video text track (VTT) you want to upload.
+                      const videoId = 'vi4k0jvEUuaTdRAEjQ4Prklg'; // The unique identifier for the video you want to add a caption to.
+                      const language = 'en'; // A valid BCP 47 language representation.
+                      const file = 'BINARY_DATA_HERE'; // The video text track (VTT) you want to upload.
 
-                    // Caption
-                    const result = await client.captions.upload(videoId, language, file);
-                    console.log(result);
-                } catch (e) {
-                    console.error(e);
-                }
-            })();
-        - language: python
-          code: |
-            #install the api.video API client library
-            #pip install api.video
-            import apivideo
-            from apivideo.api import captions_api
-            from apivideo.model.bad_request import BadRequest
-            from apivideo.model.not_found import NotFound
-            from apivideo.model.caption import Caption
-            from pprint import pprint
+                      // Caption
+                      const result = await client.captions.upload(videoId, language, file);
+                      console.log(result);
+                  } catch (e) {
+                      console.error(e);
+                  }
+              })();
+          - language: python
+            code: |
+              #install the api.video API client library
+              #pip install api.video
+              import apivideo
+              from apivideo.api import captions_api
+              from apivideo.model.bad_request import BadRequest
+              from apivideo.model.not_found import NotFound
+              from apivideo.model.caption import Caption
+              from pprint import pprint
 
-            # Enter a context with an instance of the API client
-            with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
-                # Create an instance of the API class
-                api_instance = captions_api.CaptionsApi(api_client)
-                video_id = "vi4k0jvEUuaTdRAEjQ4Prklg" # str | The unique identifier for the video you want to add a caption to.
-                language = "en" # str | A valid BCP 47 language representation.
-                file = open('/path/to/file', 'rb') # file_type | The video text track (VTT) you want to upload.
+              # Enter a context with an instance of the API client
+              with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
+                  # Create an instance of the API class
+                  api_instance = captions_api.CaptionsApi(api_client)
+                  video_id = "vi4k0jvEUuaTdRAEjQ4Prklg" # str | The unique identifier for the video you want to add a caption to.
+                  language = "en" # str | A valid BCP 47 language representation.
+                  file = open('/path/to/file', 'rb') # file_type | The video text track (VTT) you want to upload.
 
-                # example passing only required values which don't have defaults set
-                try:
-                    # Upload a caption
-                    api_response = api_instance.upload(video_id, language, file)
-                    pprint(api_response)
-                except apivideo.ApiException as e:
-                    print("Exception when calling CaptionsApi->upload: %s\n" % e)
-        - language: java
-          code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.CaptionsApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    CaptionsApi apiInstance = client.captions();\n    \n    String videoId = \"vi4k0jvEUuaTdRAEjQ4Prklg\"; // The unique identifier for the video you want captions for.\n    String language = \"en\"; // A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation\n\n    try {\n      Caption result = apiInstance.get(videoId, language);\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling CaptionsApi#get\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
-        - language: csharp
-          code: |
-            //install via Nuget
-            //Install-Package ApiVideo
-            using System.Diagnostics;
-            using ApiVideo.Client;
+                  # example passing only required values which don't have defaults set
+                  try:
+                      # Upload a caption
+                      api_response = api_instance.upload(video_id, language, file)
+                      pprint(api_response)
+                  except apivideo.ApiException as e:
+                      print("Exception when calling CaptionsApi->upload: %s\n" % e)
+          - language: java
+            code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.CaptionsApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    CaptionsApi apiInstance = client.captions();\n    \n    String videoId = \"vi4k0jvEUuaTdRAEjQ4Prklg\"; // The unique identifier for the video you want captions for.\n    String language = \"en\"; // A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation\n\n    try {\n      Caption result = apiInstance.get(videoId, language);\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling CaptionsApi#get\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
+          - language: csharp
+            code: |
+              //install via Nuget
+              //Install-Package ApiVideo
+              using System.Diagnostics;
+              using ApiVideo.Client;
 
-            namespace Example
-            {
-                public class uploadExample
-                {
-                    public static void Main()
-                    {
-                        var basePath = ApiVideoClient.Client.Environment.SANDBOX;
-                        var apiKey = "YOUR_API_KEY";
+              namespace Example
+              {
+                  public class uploadExample
+                  {
+                      public static void Main()
+                      {
+                          var basePath = ApiVideoClient.Client.Environment.SANDBOX;
+                          var apiKey = "YOUR_API_KEY";
 
-                        var apiInstance = new ApiVideoClient(apiKey,basePath);
+                          var apiInstance = new ApiVideoClient(apiKey,basePath);
 
-                        var videoId = vi4k0jvEUuaTdRAEjQ4Prklg;  // string | The unique identifier for the video you want to add a caption to.
-                        var language = en;  // string | A valid BCP 47 language representation.
-                        var file = BINARY_DATA_HERE;  // System.IO.Stream | The video text track (VTT) you want to upload.
-                        var apiCaptionsInstance = apiInstance.Captions();
-                        try
-                        {
-                            // Upload a caption
-                            Caption result = apiCaptionsInstance.upload(videoId, language, file);
-                            Debug.WriteLine(result);
-                        }
-                        catch (ApiException  e)
-                        {
-                            Debug.Print("Exception when calling CaptionsApi.upload: " + e.Message );
-                            Debug.Print("Status Code: "+ e.ErrorCode);
-                            Debug.Print(e.StackTrace);
-                        }
-                    }
-                }
-            }
+                          var videoId = vi4k0jvEUuaTdRAEjQ4Prklg;  // string | The unique identifier for the video you want to add a caption to.
+                          var language = en;  // string | A valid BCP 47 language representation.
+                          var file = BINARY_DATA_HERE;  // System.IO.Stream | The video text track (VTT) you want to upload.
+                          var apiCaptionsInstance = apiInstance.Captions();
+                          try
+                          {
+                              // Upload a caption
+                              Caption result = apiCaptionsInstance.upload(videoId, language, file);
+                              Debug.WriteLine(result);
+                          }
+                          catch (ApiException  e)
+                          {
+                              Debug.Print("Exception when calling CaptionsApi.upload: " + e.Message );
+                              Debug.Print("Status Code: "+ e.ErrorCode);
+                              Debug.Print(e.StackTrace);
+                          }
+                      }
+                  }
+              }
     delete:
       tags:
-      - Captions
+        - Captions
       summary: Delete a caption
       description: Delete a caption in a specific language by providing the video ID for the video you want to delete the caption from and the language the caption is in.
       operationId: DELETE_videos-videoId-captions-language
       parameters:
-      - name: videoId
-        in: path
-        description: The unique identifier for the video you want to delete a caption from.
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-        example: vi4k0jvEUuaTdRAEjQ4Prklgc
-      - name: language
-        in: path
-        description: A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-        example: en
+        - name: videoId
+          in: path
+          description: The unique identifier for the video you want to delete a caption from.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: vi4k0jvEUuaTdRAEjQ4Prklgc
+        - name: language
+          in: path
+          description: A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: en
       responses:
         "204":
           description: No Content
@@ -3054,116 +3087,117 @@ paths:
               schema:
                 $ref: '#/components/schemas/not-found'
       security:
-      - bearerAuth: []
+        - bearerAuth: []
       x-client-action: delete
       x-readme:
         code-samples:
-        - language: go
-          code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    videoId := \"vi4k0jvEUuaTdRAEjQ4Prklgc\" // string | The unique identifier for the video you want to delete a caption from.\n    language := \"en\" // string | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.\n\n    \n    err := client.Captions.Delete(videoId, language)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `Captions.Delete``: %v\\n\", err)\n    }\n}\n"
-        - language: node
-          code: |
-            //install the module with npm or yarn
-            //npm install @api.video/nodejs-client --save
-            //yarn add @api.video/nodejs-client
-            (async () => {
-                try {
-                    const client = new ApiVideoClient({ apiKey: "YOUR_API_TOKEN" });
+          - language: go
+            code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    videoId := \"vi4k0jvEUuaTdRAEjQ4Prklgc\" // string | The unique identifier for the video you want to delete a caption from.\n    language := \"en\" // string | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.\n\n    \n    err := client.Captions.Delete(videoId, language)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `Captions.Delete``: %v\\n\", err)\n    }\n}\n"
+          - language: node
+            code: |
+              //install the module with npm or yarn
+              //npm install @api.video/nodejs-client --save
+              //yarn add @api.video/nodejs-client
+              (async () => {
+                  try {
+                      const client = new ApiVideoClient({ apiKey: "YOUR_API_TOKEN" });
 
-                    const videoId = 'vi4k0jvEUuaTdRAEjQ4Prklgc'; // The unique identifier for the video you want to delete a caption from.
-                    const language = 'en'; // A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.
+                      const videoId = 'vi4k0jvEUuaTdRAEjQ4Prklgc'; // The unique identifier for the video you want to delete a caption from.
+                      const language = 'en'; // A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.
 
-                    // void
-                    const result = await client.captions.delete(videoId, language);
-                    console.log(result);
-                } catch (e) {
-                    console.error(e);
-                }
-            })();
-        - language: python
-          code: |
-            #install the api.video API client library
-            #pip install api.video
-            import apivideo
-            from apivideo.api import captions_api
-            from apivideo.model.not_found import NotFound
-            from pprint import pprint
+                      // void
+                      const result = await client.captions.delete(videoId, language);
+                      console.log(result);
+                  } catch (e) {
+                      console.error(e);
+                  }
+              })();
+          - language: python
+            code: |
+              #install the api.video API client library
+              #pip install api.video
+              import apivideo
+              from apivideo.api import captions_api
+              from apivideo.model.not_found import NotFound
+              from pprint import pprint
 
-            # Enter a context with an instance of the API client
-            with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
-                # Create an instance of the API class
-                api_instance = captions_api.CaptionsApi(api_client)
-                video_id = "vi4k0jvEUuaTdRAEjQ4Prklgc" # str | The unique identifier for the video you want to delete a caption from.
-                language = "en" # str | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.
+              # Enter a context with an instance of the API client
+              with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
+                  # Create an instance of the API class
+                  api_instance = captions_api.CaptionsApi(api_client)
+                  video_id = "vi4k0jvEUuaTdRAEjQ4Prklgc" # str | The unique identifier for the video you want to delete a caption from.
+                  language = "en" # str | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.
 
-                # example passing only required values which don't have defaults set
-                try:
-                    # Delete a caption
-                    api_instance.delete(video_id, language)
-                except apivideo.ApiException as e:
-                    print("Exception when calling CaptionsApi->delete: %s\n" % e)
-        - language: java
-          code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.CaptionsApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    CaptionsApi apiInstance = client.captions();\n    \n    String videoId = \"vi4k0jvEUuaTdRAEjQ4Prklgc\"; // The unique identifier for the video you want to delete a caption from.\n    String language = \"en\"; // A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.\n\n    try {\n      apiInstance.delete(videoId, language);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling CaptionsApi#delete\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
-        - language: csharp
-          code: |
-            //install via Nuget
-            //Install-Package ApiVideo
-            using System.Diagnostics;
-            using ApiVideo.Client;
+                  # example passing only required values which don't have defaults set
+                  try:
+                      # Delete a caption
+                      api_instance.delete(video_id, language)
+                  except apivideo.ApiException as e:
+                      print("Exception when calling CaptionsApi->delete: %s\n" % e)
+          - language: java
+            code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.CaptionsApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    CaptionsApi apiInstance = client.captions();\n    \n    String videoId = \"vi4k0jvEUuaTdRAEjQ4Prklgc\"; // The unique identifier for the video you want to delete a caption from.\n    String language = \"en\"; // A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.\n\n    try {\n      apiInstance.delete(videoId, language);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling CaptionsApi#delete\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
+          - language: csharp
+            code: |
+              //install via Nuget
+              //Install-Package ApiVideo
+              using System.Diagnostics;
+              using ApiVideo.Client;
 
-            namespace Example
-            {
-                public class deleteExample
-                {
-                    public static void Main()
-                    {
-                        var basePath = ApiVideoClient.Client.Environment.SANDBOX;
-                        var apiKey = "YOUR_API_KEY";
+              namespace Example
+              {
+                  public class deleteExample
+                  {
+                      public static void Main()
+                      {
+                          var basePath = ApiVideoClient.Client.Environment.SANDBOX;
+                          var apiKey = "YOUR_API_KEY";
 
-                        var apiInstance = new ApiVideoClient(apiKey,basePath);
+                          var apiInstance = new ApiVideoClient(apiKey,basePath);
 
-                        var videoId = vi4k0jvEUuaTdRAEjQ4Prklgc;  // string | The unique identifier for the video you want to delete a caption from.
-                        var language = en;  // string | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.
-                        var apiCaptionsInstance = apiInstance.Captions();
-                        try
-                        {
-                            // Delete a caption
-                            apiCaptionsInstance.delete(videoId, language);
-                        }
-                        catch (ApiException  e)
-                        {
-                            Debug.Print("Exception when calling CaptionsApi.delete: " + e.Message );
-                            Debug.Print("Status Code: "+ e.ErrorCode);
-                            Debug.Print(e.StackTrace);
-                        }
-                    }
-                }
-            }
+                          var videoId = vi4k0jvEUuaTdRAEjQ4Prklgc;  // string | The unique identifier for the video you want to delete a caption from.
+                          var language = en;  // string | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.
+                          var apiCaptionsInstance = apiInstance.Captions();
+                          try
+                          {
+                              // Delete a caption
+                              apiCaptionsInstance.delete(videoId, language);
+                          }
+                          catch (ApiException  e)
+                          {
+                              Debug.Print("Exception when calling CaptionsApi.delete: " + e.Message );
+                              Debug.Print("Status Code: "+ e.ErrorCode);
+                              Debug.Print(e.StackTrace);
+                          }
+                      }
+                  }
+              }
     patch:
       tags:
-      - Captions
+        - Captions
       summary: Update caption
       description: 'To have the captions on automatically, use this PATCH to set default: true.'
       operationId: PATCH_videos-videoId-captions-language
       parameters:
-      - name: videoId
-        in: path
-        description: 'The unique identifier for the video you want to have automatic captions for. '
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-        example: vi4k0jvEUuaTdRAEjQ4Prklg
-      - name: language
-        in: path
-        description: A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-        example: en
+        - name: videoId
+          in: path
+          description: 'The unique identifier for the video you want to have automatic captions for.'
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: vi4k0jvEUuaTdRAEjQ4Prklg
+        - name: language
+          in: path
+          description: A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: en
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -3174,7 +3208,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/subtitle'
+                $ref: '#/components/schemas/caption'
               examples:
                 response:
                   value:
@@ -3196,7 +3230,7 @@ paths:
                     name: string (required)
                     status: integer (required)
                     problems:
-                    - null
+                      - null
         "404":
           description: Not Found
           content:
@@ -3211,57 +3245,39 @@ paths:
                     name: irure mollit aute
                     status: 85925135
       security:
-      - bearerAuth: []
+        - bearerAuth: []
       x-client-action: update
       x-readme:
         code-samples:
-        - language: go
-          code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    videoId := \"vi4k0jvEUuaTdRAEjQ4Prklg\" // string | The unique identifier for the video you want to have automatic captions for.\n    language := \"en\" // string | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.\n    captionsUpdatePayload := *apivideosdk.NewCaptionsUpdatePayload() // CaptionsUpdatePayload | \n\n    \n    res, err := client.Captions.Update(videoId, language, captionsUpdatePayload)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `Captions.Update``: %v\\n\", err)\n    }\n    // response from `Update`: Caption\n    fmt.Fprintf(os.Stdout, \"Response from `Captions.Update`: %v\\n\", res)\n}\n"
-        - language: node
-          code: "//install the module with npm or yarn\n//npm install @api.video/nodejs-client --save\n//yarn add @api.video/nodejs-client\n(async () => {\n    try {\n        const client = new ApiVideoClient({ apiKey: \"YOUR_API_TOKEN\" });\n\n        const videoId = 'vi4k0jvEUuaTdRAEjQ4Prklg'; // The unique identifier for the video you want to have automatic captions for.\n        const language = 'en'; // A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.\n        const captionsUpdatePayload = {\n      _default: true,\n    }; \n\n        // Caption\n        const result = await client.captions.update(videoId, language, captionsUpdatePayload);\n        console.log(result);\n    } catch (e) {\n        console.error(e);\n    }\n})();\n"
-        - language: python
-          code: "#install the api.video API client library\n#pip install api.video\nimport apivideo\nfrom apivideo.api import captions_api\nfrom apivideo.model.bad_request import BadRequest\nfrom apivideo.model.captions_update_payload import CaptionsUpdatePayload\nfrom apivideo.model.not_found import NotFound\nfrom apivideo.model.caption import Caption\nfrom pprint import pprint\n\n# Enter a context with an instance of the API client\nwith apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:\n    # Create an instance of the API class\n    api_instance = captions_api.CaptionsApi(api_client)\n    video_id = \"vi4k0jvEUuaTdRAEjQ4Prklg\" # str | The unique identifier for the video you want to have automatic captions for.\n    language = \"en\" # str | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.\n    captions_update_payload = CaptionsUpdatePayload(\n        default=True,\n    ) # CaptionsUpdatePayload | \n\n    # example passing only required values which don't have defaults set\n    try:\n        # Update caption\n        api_response = api_instance.update(video_id, language, captions_update_payload)\n        pprint(api_response)\n    except apivideo.ApiException as e:\n        print(\"Exception when calling CaptionsApi->update: %s\\n\" % e)\n"
-        - language: java
-          code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.CaptionsApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    CaptionsApi apiInstance = client.captions();\n    \n    String videoId = \"vi4k0jvEUuaTdRAEjQ4Prklg\"; // The unique identifier for the video you want to have automatic captions for.\n    String language = \"en\"; // A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.\n    CaptionsUpdatePayload captionsUpdatePayload = new CaptionsUpdatePayload(); // \n    captionsUpdatePayload.setDefault(); // \n\n\n    try {\n      Caption result = apiInstance.update(videoId, language, captionsUpdatePayload);\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling CaptionsApi#update\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
-        - language: csharp
-          code: "//install via Nuget\n//Install-Package ApiVideo\nusing System.Diagnostics;\nusing ApiVideo.Client;\n\nnamespace Example\n{\n    public class updateExample\n    {\n        public static void Main()\n        {\n            var basePath = ApiVideoClient.Client.Environment.SANDBOX;\n            var apiKey = \"YOUR_API_KEY\";\n\n            var apiInstance = new ApiVideoClient(apiKey,basePath);\n\n            var videoId = vi4k0jvEUuaTdRAEjQ4Prklg;  // string | The unique identifier for the video you want to have automatic captions for.\n            var language = en;  // string | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.\n            var captionsUpdatePayload = new CaptionsUpdatePayload(); // CaptionsUpdatePayload | \n            var apiCaptionsInstance = apiInstance.Captions();\n            try\n            {\n                // Update caption\n                Caption result = apiCaptionsInstance.update(videoId, language, captionsUpdatePayload);\n                Debug.WriteLine(result);\n            }\n            catch (ApiException  e)\n            {\n                Debug.Print(\"Exception when calling CaptionsApi.update: \" + e.Message );\n                Debug.Print(\"Status Code: \"+ e.ErrorCode);\n                Debug.Print(e.StackTrace);\n            }\n        }\n    }\n}\n"
+          - language: go
+            code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    videoId := \"vi4k0jvEUuaTdRAEjQ4Prklg\" // string | The unique identifier for the video you want to have automatic captions for.\n    language := \"en\" // string | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.\n    captionsUpdatePayload := *apivideosdk.NewCaptionsUpdatePayload() // CaptionsUpdatePayload | \n\n    \n    res, err := client.Captions.Update(videoId, language, captionsUpdatePayload)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `Captions.Update``: %v\\n\", err)\n    }\n    // response from `Update`: Caption\n    fmt.Fprintf(os.Stdout, \"Response from `Captions.Update`: %v\\n\", res)\n}\n"
+          - language: node
+            code: "//install the module with npm or yarn\n//npm install @api.video/nodejs-client --save\n//yarn add @api.video/nodejs-client\n(async () => {\n    try {\n        const client = new ApiVideoClient({ apiKey: \"YOUR_API_TOKEN\" });\n\n        const videoId = 'vi4k0jvEUuaTdRAEjQ4Prklg'; // The unique identifier for the video you want to have automatic captions for.\n        const language = 'en'; // A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.\n        const captionsUpdatePayload = {\n      _default: true,\n    }; \n\n        // Caption\n        const result = await client.captions.update(videoId, language, captionsUpdatePayload);\n        console.log(result);\n    } catch (e) {\n        console.error(e);\n    }\n})();\n"
+          - language: python
+            code: "#install the api.video API client library\n#pip install api.video\nimport apivideo\nfrom apivideo.api import captions_api\nfrom apivideo.model.bad_request import BadRequest\nfrom apivideo.model.captions_update_payload import CaptionsUpdatePayload\nfrom apivideo.model.not_found import NotFound\nfrom apivideo.model.caption import Caption\nfrom pprint import pprint\n\n# Enter a context with an instance of the API client\nwith apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:\n    # Create an instance of the API class\n    api_instance = captions_api.CaptionsApi(api_client)\n    video_id = \"vi4k0jvEUuaTdRAEjQ4Prklg\" # str | The unique identifier for the video you want to have automatic captions for.\n    language = \"en\" # str | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.\n    captions_update_payload = CaptionsUpdatePayload(\n        default=True,\n    ) # CaptionsUpdatePayload | \n\n    # example passing only required values which don't have defaults set\n    try:\n        # Update caption\n        api_response = api_instance.update(video_id, language, captions_update_payload)\n        pprint(api_response)\n    except apivideo.ApiException as e:\n        print(\"Exception when calling CaptionsApi->update: %s\\n\" % e)\n"
+          - language: java
+            code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.CaptionsApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    CaptionsApi apiInstance = client.captions();\n    \n    String videoId = \"vi4k0jvEUuaTdRAEjQ4Prklg\"; // The unique identifier for the video you want to have automatic captions for.\n    String language = \"en\"; // A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.\n    CaptionsUpdatePayload captionsUpdatePayload = new CaptionsUpdatePayload(); // \n    captionsUpdatePayload.setDefault(); // \n\n\n    try {\n      Caption result = apiInstance.update(videoId, language, captionsUpdatePayload);\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling CaptionsApi#update\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
+          - language: csharp
+            code: "//install via Nuget\n//Install-Package ApiVideo\nusing System.Diagnostics;\nusing ApiVideo.Client;\n\nnamespace Example\n{\n    public class updateExample\n    {\n        public static void Main()\n        {\n            var basePath = ApiVideoClient.Client.Environment.SANDBOX;\n            var apiKey = \"YOUR_API_KEY\";\n\n            var apiInstance = new ApiVideoClient(apiKey,basePath);\n\n            var videoId = vi4k0jvEUuaTdRAEjQ4Prklg;  // string | The unique identifier for the video you want to have automatic captions for.\n            var language = en;  // string | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.\n            var captionsUpdatePayload = new CaptionsUpdatePayload(); // CaptionsUpdatePayload | \n            var apiCaptionsInstance = apiInstance.Captions();\n            try\n            {\n                // Update caption\n                Caption result = apiCaptionsInstance.update(videoId, language, captionsUpdatePayload);\n                Debug.WriteLine(result);\n            }\n            catch (ApiException  e)\n            {\n                Debug.Print(\"Exception when calling CaptionsApi.update: \" + e.Message );\n                Debug.Print(\"Status Code: \"+ e.ErrorCode);\n                Debug.Print(e.StackTrace);\n            }\n        }\n    }\n}\n"
   /videos/{videoId}/captions:
     get:
       tags:
-      - Captions
+        - Captions
       summary: List video captions
       description: Retrieve a list of available captions for the videoId you provide.
       operationId: GET_videos-videoId-captions
       parameters:
-      - name: videoId
-        in: path
-        description: The unique identifier for the video you want to retrieve a list of captions for.
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-        example: vi4k0jvEUuaTdRAEjQ4Prklg
-      - name: currentPage
-        in: query
-        description: 'Choose the number of search results to return per page. Minimum value: 1'
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          default: 1
-        example: 2
-      - name: pageSize
-        in: query
-        description: Results per page. Allowed values 1-100, default is 25.
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          default: 25
-        example: 30
+        - name: videoId
+          in: path
+          description: The unique identifier for the video you want to retrieve a list of captions for.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: vi4k0jvEUuaTdRAEjQ4Prklg
+        - $ref: '#/components/parameters/current-page'
+        - $ref: '#/components/parameters/page-size'
       responses:
         "200":
           description: Success
@@ -3273,14 +3289,14 @@ paths:
                 response:
                   value:
                     data:
-                    - uri: /videos/vi3N6cDinStg3oBbN79GklWS/captions/en
-                      src: https://cdn.api.video/vod/vi3N6cDinStg3oBbN79GklWS/captions/en.vtt
-                      srclang: en
-                      default: false
-                    - uri: /videos/vi3N6cDinStg3oBbN79GklWS/captions/fr
-                      src: https://cdn.api.video/vod/vi3N6cDinStg3oBbN79GklWS/captions/fr.vtt
-                      srclang: fr
-                      default: false
+                      - uri: /videos/vi3N6cDinStg3oBbN79GklWS/captions/en
+                        src: https://cdn.api.video/vod/vi3N6cDinStg3oBbN79GklWS/captions/en.vtt
+                        srclang: en
+                        default: false
+                      - uri: /videos/vi3N6cDinStg3oBbN79GklWS/captions/fr
+                        src: https://cdn.api.video/vod/vi3N6cDinStg3oBbN79GklWS/captions/fr.vtt
+                        srclang: fr
+                        default: false
                     pagination:
                       currentPage: 1
                       currentPageItems: 2
@@ -3288,12 +3304,12 @@ paths:
                       pagesTotal: 1
                       itemsTotal: 2
                       links:
-                      - rel: self
-                        uri: /videos/vi3N6cDinStg3oBbN79GklWS/captions?currentPage=1&pageSize=25
-                      - rel: first
-                        uri: /videos/vi3N6cDinStg3oBbN79GklWS/captions?currentPage=1&pageSize=25
-                      - rel: last
-                        uri: /videos/vi3N6cDinStg3oBbN79GklWS/captions?currentPage=1&pageSize=25
+                        - rel: self
+                          uri: /videos/vi3N6cDinStg3oBbN79GklWS/captions?currentPage=1&pageSize=25
+                        - rel: first
+                          uri: /videos/vi3N6cDinStg3oBbN79GklWS/captions?currentPage=1&pageSize=25
+                        - rel: last
+                          uri: /videos/vi3N6cDinStg3oBbN79GklWS/captions?currentPage=1&pageSize=25
         "404":
           description: Not Found
           content:
@@ -3301,121 +3317,121 @@ paths:
               schema:
                 $ref: '#/components/schemas/not-found'
       security:
-      - bearerAuth: []
+        - bearerAuth: []
       x-client-action: list
       x-group-parameters: true
       x-client-paginated: true
       x-readme:
         code-samples:
-        - language: go
-          code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    videoId := \"vi4k0jvEUuaTdRAEjQ4Prklg\" // string | The unique identifier for the video you want captions for.\n    language := \"en\" // string | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation\n\n    \n    res, err := client.Captions.Get(videoId, language)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `Captions.Get``: %v\\n\", err)\n    }\n    // response from `Get`: Caption\n    fmt.Fprintf(os.Stdout, \"Response from `Captions.Get`: %v\\n\", res)\n}\n"
-        - language: node
-          code: |
-            //install the module with npm or yarn
-            //npm install @api.video/nodejs-client --save
-            //yarn add @api.video/nodejs-client
-            (async () => {
-                try {
-                    const client = new ApiVideoClient({ apiKey: "YOUR_API_TOKEN" });
+          - language: go
+            code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    videoId := \"vi4k0jvEUuaTdRAEjQ4Prklg\" // string | The unique identifier for the video you want captions for.\n    language := \"en\" // string | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation\n\n    \n    res, err := client.Captions.Get(videoId, language)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `Captions.Get``: %v\\n\", err)\n    }\n    // response from `Get`: Caption\n    fmt.Fprintf(os.Stdout, \"Response from `Captions.Get`: %v\\n\", res)\n}\n"
+          - language: node
+            code: |
+              //install the module with npm or yarn
+              //npm install @api.video/nodejs-client --save
+              //yarn add @api.video/nodejs-client
+              (async () => {
+                  try {
+                      const client = new ApiVideoClient({ apiKey: "YOUR_API_TOKEN" });
 
-                    const videoId = 'vi4k0jvEUuaTdRAEjQ4Prklg'; // The unique identifier for the video you want captions for.
-                    const language = 'en'; // A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation
+                      const videoId = 'vi4k0jvEUuaTdRAEjQ4Prklg'; // The unique identifier for the video you want captions for.
+                      const language = 'en'; // A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation
 
-                    // Caption
-                    const result = await client.captions.get(videoId, language);
-                    console.log(result);
-                } catch (e) {
-                    console.error(e);
-                }
-            })();
-        - language: python
-          code: |
-            #install the api.video API client library
-            #pip install api.video
-            import apivideo
-            from apivideo.api import captions_api
-            from apivideo.model.not_found import NotFound
-            from apivideo.model.caption import Caption
-            from pprint import pprint
+                      // Caption
+                      const result = await client.captions.get(videoId, language);
+                      console.log(result);
+                  } catch (e) {
+                      console.error(e);
+                  }
+              })();
+          - language: python
+            code: |
+              #install the api.video API client library
+              #pip install api.video
+              import apivideo
+              from apivideo.api import captions_api
+              from apivideo.model.not_found import NotFound
+              from apivideo.model.caption import Caption
+              from pprint import pprint
 
-            # Enter a context with an instance of the API client
-            with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
-                # Create an instance of the API class
-                api_instance = captions_api.CaptionsApi(api_client)
-                video_id = "vi4k0jvEUuaTdRAEjQ4Prklg" # str | The unique identifier for the video you want captions for.
-                language = "en" # str | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation
+              # Enter a context with an instance of the API client
+              with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
+                  # Create an instance of the API class
+                  api_instance = captions_api.CaptionsApi(api_client)
+                  video_id = "vi4k0jvEUuaTdRAEjQ4Prklg" # str | The unique identifier for the video you want captions for.
+                  language = "en" # str | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation
 
-                # example passing only required values which don't have defaults set
-                try:
-                    # Show a caption
-                    api_response = api_instance.get(video_id, language)
-                    pprint(api_response)
-                except apivideo.ApiException as e:
-                    print("Exception when calling CaptionsApi->get: %s\n" % e)
-        - language: java
-          code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.CaptionsApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    CaptionsApi apiInstance = client.captions();\n    \n    String videoId = \"vi4k0jvEUuaTdRAEjQ4Prklg\"; // The unique identifier for the video you want captions for.\n    String language = \"en\"; // A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation\n\n    try {\n      Caption result = apiInstance.get(videoId, language);\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling CaptionsApi#get\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
-        - language: csharp
-          code: |
-            //install via Nuget
-            //Install-Package ApiVideo
-            using System.Diagnostics;
-            using ApiVideo.Client;
+                  # example passing only required values which don't have defaults set
+                  try:
+                      # Show a caption
+                      api_response = api_instance.get(video_id, language)
+                      pprint(api_response)
+                  except apivideo.ApiException as e:
+                      print("Exception when calling CaptionsApi->get: %s\n" % e)
+          - language: java
+            code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.CaptionsApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    CaptionsApi apiInstance = client.captions();\n    \n    String videoId = \"vi4k0jvEUuaTdRAEjQ4Prklg\"; // The unique identifier for the video you want captions for.\n    String language = \"en\"; // A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation\n\n    try {\n      Caption result = apiInstance.get(videoId, language);\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling CaptionsApi#get\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
+          - language: csharp
+            code: |
+              //install via Nuget
+              //Install-Package ApiVideo
+              using System.Diagnostics;
+              using ApiVideo.Client;
 
-            namespace Example
-            {
-                public class getExample
-                {
-                    public static void Main()
-                    {
-                        var basePath = ApiVideoClient.Client.Environment.SANDBOX;
-                        var apiKey = "YOUR_API_KEY";
+              namespace Example
+              {
+                  public class getExample
+                  {
+                      public static void Main()
+                      {
+                          var basePath = ApiVideoClient.Client.Environment.SANDBOX;
+                          var apiKey = "YOUR_API_KEY";
 
-                        var apiInstance = new ApiVideoClient(apiKey,basePath);
+                          var apiInstance = new ApiVideoClient(apiKey,basePath);
 
-                        var videoId = vi4k0jvEUuaTdRAEjQ4Prklg;  // string | The unique identifier for the video you want captions for.
-                        var language = en;  // string | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation
-                        var apiCaptionsInstance = apiInstance.Captions();
-                        try
-                        {
-                            // Show a caption
-                            Caption result = apiCaptionsInstance.get(videoId, language);
-                            Debug.WriteLine(result);
-                        }
-                        catch (ApiException  e)
-                        {
-                            Debug.Print("Exception when calling CaptionsApi.get: " + e.Message );
-                            Debug.Print("Status Code: "+ e.ErrorCode);
-                            Debug.Print(e.StackTrace);
-                        }
-                    }
-                }
-            }
+                          var videoId = vi4k0jvEUuaTdRAEjQ4Prklg;  // string | The unique identifier for the video you want captions for.
+                          var language = en;  // string | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation
+                          var apiCaptionsInstance = apiInstance.Captions();
+                          try
+                          {
+                              // Show a caption
+                              Caption result = apiCaptionsInstance.get(videoId, language);
+                              Debug.WriteLine(result);
+                          }
+                          catch (ApiException  e)
+                          {
+                              Debug.Print("Exception when calling CaptionsApi.get: " + e.Message );
+                              Debug.Print("Status Code: "+ e.ErrorCode);
+                              Debug.Print(e.StackTrace);
+                          }
+                      }
+                  }
+              }
   /videos/{videoId}/chapters/{language}:
     get:
       tags:
-      - Chapters
+        - Chapters
       summary: Show a chapter
       description: Chapters help your viewers find the sections of the video they are most interested in viewing. Tutorials that use the [chapters endpoint](https://api.video/blog/endpoints/chapters).
       operationId: GET_videos-videoId-chapters-language
       parameters:
-      - name: videoId
-        in: path
-        description: The unique identifier for the video you want to show a chapter for.
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-        example: vi4k0jvEUuaTdRAEjQ4Jfrgz
-      - name: language
-        in: path
-        description: A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-        example: en
+        - name: videoId
+          in: path
+          description: The unique identifier for the video you want to show a chapter for.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: vi4k0jvEUuaTdRAEjQ4Jfrgz
+        - name: language
+          in: path
+          description: A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: en
       responses:
         "200":
           description: Success
@@ -3436,119 +3452,120 @@ paths:
               schema:
                 $ref: '#/components/schemas/not-found'
       security:
-      - bearerAuth: []
+        - bearerAuth: []
       x-client-action: get
       x-readme:
         code-samples:
-        - language: go
-          code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    videoId := \"vi4k0jvEUuaTdRAEjQ4Jfrgz\" // string | The unique identifier for the video you want to show a chapter for.\n    language := \"en\" // string | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.\n\n    \n    res, err := client.Chapters.Get(videoId, language)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `Chapters.Get``: %v\\n\", err)\n    }\n    // response from `Get`: Chapter\n    fmt.Fprintf(os.Stdout, \"Response from `Chapters.Get`: %v\\n\", res)\n}\n"
-        - language: node
-          code: |
-            //install the module with npm or yarn
-            //npm install @api.video/nodejs-client --save
-            //yarn add @api.video/nodejs-client
-            (async () => {
-                try {
-                    const client = new ApiVideoClient({ apiKey: "YOUR_API_TOKEN" });
+          - language: go
+            code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    videoId := \"vi4k0jvEUuaTdRAEjQ4Jfrgz\" // string | The unique identifier for the video you want to show a chapter for.\n    language := \"en\" // string | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.\n\n    \n    res, err := client.Chapters.Get(videoId, language)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `Chapters.Get``: %v\\n\", err)\n    }\n    // response from `Get`: Chapter\n    fmt.Fprintf(os.Stdout, \"Response from `Chapters.Get`: %v\\n\", res)\n}\n"
+          - language: node
+            code: |
+              //install the module with npm or yarn
+              //npm install @api.video/nodejs-client --save
+              //yarn add @api.video/nodejs-client
+              (async () => {
+                  try {
+                      const client = new ApiVideoClient({ apiKey: "YOUR_API_TOKEN" });
 
-                    const videoId = 'vi4k0jvEUuaTdRAEjQ4Jfrgz'; // The unique identifier for the video you want to show a chapter for.
-                    const language = 'en'; // A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.
+                      const videoId = 'vi4k0jvEUuaTdRAEjQ4Jfrgz'; // The unique identifier for the video you want to show a chapter for.
+                      const language = 'en'; // A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.
 
-                    // Chapter
-                    const result = await client.chapters.get(videoId, language);
-                    console.log(result);
-                } catch (e) {
-                    console.error(e);
-                }
-            })();
-        - language: python
-          code: |
-            #install the api.video API client library
-            #pip install api.video
-            import apivideo
-            from apivideo.api import chapters_api
-            from apivideo.model.not_found import NotFound
-            from apivideo.model.chapter import Chapter
-            from pprint import pprint
+                      // Chapter
+                      const result = await client.chapters.get(videoId, language);
+                      console.log(result);
+                  } catch (e) {
+                      console.error(e);
+                  }
+              })();
+          - language: python
+            code: |
+              #install the api.video API client library
+              #pip install api.video
+              import apivideo
+              from apivideo.api import chapters_api
+              from apivideo.model.not_found import NotFound
+              from apivideo.model.chapter import Chapter
+              from pprint import pprint
 
-            # Enter a context with an instance of the API client
-            with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
-                # Create an instance of the API class
-                api_instance = chapters_api.ChaptersApi(api_client)
-                video_id = "vi4k0jvEUuaTdRAEjQ4Jfrgz" # str | The unique identifier for the video you want to show a chapter for.
-                language = "en" # str | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.
+              # Enter a context with an instance of the API client
+              with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
+                  # Create an instance of the API class
+                  api_instance = chapters_api.ChaptersApi(api_client)
+                  video_id = "vi4k0jvEUuaTdRAEjQ4Jfrgz" # str | The unique identifier for the video you want to show a chapter for.
+                  language = "en" # str | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.
 
-                # example passing only required values which don't have defaults set
-                try:
-                    # Show a chapter
-                    api_response = api_instance.get(video_id, language)
-                    pprint(api_response)
-                except apivideo.ApiException as e:
-                    print("Exception when calling ChaptersApi->get: %s\n" % e)
-        - language: java
-          code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.ChaptersApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    ChaptersApi apiInstance = client.chapters();\n    \n    String videoId = \"vi4k0jvEUuaTdRAEjQ4Jfrgz\"; // The unique identifier for the video you want to show a chapter for.\n    String language = \"en\"; // A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.\n\n    try {\n      Chapter result = apiInstance.get(videoId, language);\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling ChaptersApi#get\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
-        - language: csharp
-          code: |
-            //install via Nuget
-            //Install-Package ApiVideo
-            using System.Diagnostics;
-            using ApiVideo.Client;
+                  # example passing only required values which don't have defaults set
+                  try:
+                      # Show a chapter
+                      api_response = api_instance.get(video_id, language)
+                      pprint(api_response)
+                  except apivideo.ApiException as e:
+                      print("Exception when calling ChaptersApi->get: %s\n" % e)
+          - language: java
+            code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.ChaptersApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    ChaptersApi apiInstance = client.chapters();\n    \n    String videoId = \"vi4k0jvEUuaTdRAEjQ4Jfrgz\"; // The unique identifier for the video you want to show a chapter for.\n    String language = \"en\"; // A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.\n\n    try {\n      Chapter result = apiInstance.get(videoId, language);\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling ChaptersApi#get\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
+          - language: csharp
+            code: |
+              //install via Nuget
+              //Install-Package ApiVideo
+              using System.Diagnostics;
+              using ApiVideo.Client;
 
-            namespace Example
-            {
-                public class getExample
-                {
-                    public static void Main()
-                    {
-                        var basePath = ApiVideoClient.Client.Environment.SANDBOX;
-                        var apiKey = "YOUR_API_KEY";
+              namespace Example
+              {
+                  public class getExample
+                  {
+                      public static void Main()
+                      {
+                          var basePath = ApiVideoClient.Client.Environment.SANDBOX;
+                          var apiKey = "YOUR_API_KEY";
 
-                        var apiInstance = new ApiVideoClient(apiKey,basePath);
+                          var apiInstance = new ApiVideoClient(apiKey,basePath);
 
-                        var videoId = vi4k0jvEUuaTdRAEjQ4Jfrgz;  // string | The unique identifier for the video you want to show a chapter for.
-                        var language = en;  // string | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.
-                        var apiChaptersInstance = apiInstance.Chapters();
-                        try
-                        {
-                            // Show a chapter
-                            Chapter result = apiChaptersInstance.get(videoId, language);
-                            Debug.WriteLine(result);
-                        }
-                        catch (ApiException  e)
-                        {
-                            Debug.Print("Exception when calling ChaptersApi.get: " + e.Message );
-                            Debug.Print("Status Code: "+ e.ErrorCode);
-                            Debug.Print(e.StackTrace);
-                        }
-                    }
-                }
-            }
+                          var videoId = vi4k0jvEUuaTdRAEjQ4Jfrgz;  // string | The unique identifier for the video you want to show a chapter for.
+                          var language = en;  // string | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.
+                          var apiChaptersInstance = apiInstance.Chapters();
+                          try
+                          {
+                              // Show a chapter
+                              Chapter result = apiChaptersInstance.get(videoId, language);
+                              Debug.WriteLine(result);
+                          }
+                          catch (ApiException  e)
+                          {
+                              Debug.Print("Exception when calling ChaptersApi.get: " + e.Message );
+                              Debug.Print("Status Code: "+ e.ErrorCode);
+                              Debug.Print(e.StackTrace);
+                          }
+                      }
+                  }
+              }
     post:
       tags:
-      - Chapters
+        - Chapters
       summary: Upload a chapter
       description: Chapters help break the video into sections. Read our [tutorial](https://api.video/blog/tutorials/adding-chapters-to-your-videos) for more details.
       operationId: POST_videos-videoId-chapters-language
       parameters:
-      - name: videoId
-        in: path
-        description: The unique identifier for the video you want to upload a chapter for.
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-        example: vi4k0jvEUuaTdRAEjQ4Jfrgz
-      - name: language
-        in: path
-        description: A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-        example: en
+        - name: videoId
+          in: path
+          description: The unique identifier for the video you want to upload a chapter for.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: vi4k0jvEUuaTdRAEjQ4Jfrgz
+        - name: language
+          in: path
+          description: A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: en
       requestBody:
+        required: true
         content:
           multipart/form-data:
             schema:
@@ -3579,121 +3596,121 @@ paths:
               schema:
                 $ref: '#/components/schemas/not-found'
       security:
-      - bearerAuth: []
+        - bearerAuth: []
       x-client-action: upload
       x-readme:
         code-samples:
-        - language: go
-          code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    videoId := \"vi4k0jvEUuaTdRAEjQ4Jfrgz\" // string | The unique identifier for the video you want to upload a chapter for.\n    language := \"en\" // string | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.\n    file := os.NewFile(1234, \"some_file\") // *os.File | The VTT file describing the chapters you want to upload.\n\n    \n    res, err := client.Chapters.UploadFile(videoId, language, file)\n\n    // you can also use a Reader instead of a File:\n    // client.Chapters.Upload(videoId, language, fileName, fileReader)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `Chapters.Upload``: %v\\n\", err)\n    }\n    // response from `Upload`: Chapter\n    fmt.Fprintf(os.Stdout, \"Response from `Chapters.Upload`: %v\\n\", res)\n}\n"
-        - language: node
-          code: |
-            //install the module with npm or yarn
-            //npm install @api.video/nodejs-client --save
-            //yarn add @api.video/nodejs-client
-            (async () => {
-                try {
-                    const client = new ApiVideoClient({ apiKey: "YOUR_API_TOKEN" });
+          - language: go
+            code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    videoId := \"vi4k0jvEUuaTdRAEjQ4Jfrgz\" // string | The unique identifier for the video you want to upload a chapter for.\n    language := \"en\" // string | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.\n    file := os.NewFile(1234, \"some_file\") // *os.File | The VTT file describing the chapters you want to upload.\n\n    \n    res, err := client.Chapters.UploadFile(videoId, language, file)\n\n    // you can also use a Reader instead of a File:\n    // client.Chapters.Upload(videoId, language, fileName, fileReader)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `Chapters.Upload``: %v\\n\", err)\n    }\n    // response from `Upload`: Chapter\n    fmt.Fprintf(os.Stdout, \"Response from `Chapters.Upload`: %v\\n\", res)\n}\n"
+          - language: node
+            code: |
+              //install the module with npm or yarn
+              //npm install @api.video/nodejs-client --save
+              //yarn add @api.video/nodejs-client
+              (async () => {
+                  try {
+                      const client = new ApiVideoClient({ apiKey: "YOUR_API_TOKEN" });
 
-                    const videoId = 'vi4k0jvEUuaTdRAEjQ4Jfrgz'; // The unique identifier for the video you want to upload a chapter for.
-                    const language = 'en'; // A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.
-                    const file = 'BINARY_DATA_HERE'; // The VTT file describing the chapters you want to upload.
+                      const videoId = 'vi4k0jvEUuaTdRAEjQ4Jfrgz'; // The unique identifier for the video you want to upload a chapter for.
+                      const language = 'en'; // A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.
+                      const file = 'BINARY_DATA_HERE'; // The VTT file describing the chapters you want to upload.
 
-                    // Chapter
-                    const result = await client.chapters.upload(videoId, language, file);
-                    console.log(result);
-                } catch (e) {
-                    console.error(e);
-                }
-            })();
-        - language: python
-          code: |
-            #install the api.video API client library
-            #pip install api.video
-            import apivideo
-            from apivideo.api import chapters_api
-            from apivideo.model.bad_request import BadRequest
-            from apivideo.model.not_found import NotFound
-            from apivideo.model.chapter import Chapter
-            from pprint import pprint
+                      // Chapter
+                      const result = await client.chapters.upload(videoId, language, file);
+                      console.log(result);
+                  } catch (e) {
+                      console.error(e);
+                  }
+              })();
+          - language: python
+            code: |
+              #install the api.video API client library
+              #pip install api.video
+              import apivideo
+              from apivideo.api import chapters_api
+              from apivideo.model.bad_request import BadRequest
+              from apivideo.model.not_found import NotFound
+              from apivideo.model.chapter import Chapter
+              from pprint import pprint
 
-            # Enter a context with an instance of the API client
-            with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
-                # Create an instance of the API class
-                api_instance = chapters_api.ChaptersApi(api_client)
-                video_id = "vi4k0jvEUuaTdRAEjQ4Jfrgz" # str | The unique identifier for the video you want to upload a chapter for.
-                language = "en" # str | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.
-                file = open('/path/to/file', 'rb') # file_type | The VTT file describing the chapters you want to upload.
+              # Enter a context with an instance of the API client
+              with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
+                  # Create an instance of the API class
+                  api_instance = chapters_api.ChaptersApi(api_client)
+                  video_id = "vi4k0jvEUuaTdRAEjQ4Jfrgz" # str | The unique identifier for the video you want to upload a chapter for.
+                  language = "en" # str | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.
+                  file = open('/path/to/file', 'rb') # file_type | The VTT file describing the chapters you want to upload.
 
-                # example passing only required values which don't have defaults set
-                try:
-                    # Upload a chapter
-                    api_response = api_instance.upload(video_id, language, file)
-                    pprint(api_response)
-                except apivideo.ApiException as e:
-                    print("Exception when calling ChaptersApi->upload: %s\n" % e)
-        - language: java
-          code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.ChaptersApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    ChaptersApi apiInstance = client.chapters();\n    \n    String videoId = \"vi4k0jvEUuaTdRAEjQ4Jfrgz\"; // The unique identifier for the video you want to upload a chapter for.\n    String language = \"en\"; // A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.\n    File file = new File(\"/path/to/file\"); // The VTT file describing the chapters you want to upload.\n\n    try {\n      Chapter result = apiInstance.upload(videoId, language, file);\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling ChaptersApi#upload\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
-        - language: csharp
-          code: |
-            //install via Nuget
-            //Install-Package ApiVideo
-            using System.Diagnostics;
-            using ApiVideo.Client;
+                  # example passing only required values which don't have defaults set
+                  try:
+                      # Upload a chapter
+                      api_response = api_instance.upload(video_id, language, file)
+                      pprint(api_response)
+                  except apivideo.ApiException as e:
+                      print("Exception when calling ChaptersApi->upload: %s\n" % e)
+          - language: java
+            code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.ChaptersApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    ChaptersApi apiInstance = client.chapters();\n    \n    String videoId = \"vi4k0jvEUuaTdRAEjQ4Jfrgz\"; // The unique identifier for the video you want to upload a chapter for.\n    String language = \"en\"; // A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.\n    File file = new File(\"/path/to/file\"); // The VTT file describing the chapters you want to upload.\n\n    try {\n      Chapter result = apiInstance.upload(videoId, language, file);\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling ChaptersApi#upload\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
+          - language: csharp
+            code: |
+              //install via Nuget
+              //Install-Package ApiVideo
+              using System.Diagnostics;
+              using ApiVideo.Client;
 
-            namespace Example
-            {
-                public class uploadExample
-                {
-                    public static void Main()
-                    {
-                        var basePath = ApiVideoClient.Client.Environment.SANDBOX;
-                        var apiKey = "YOUR_API_KEY";
+              namespace Example
+              {
+                  public class uploadExample
+                  {
+                      public static void Main()
+                      {
+                          var basePath = ApiVideoClient.Client.Environment.SANDBOX;
+                          var apiKey = "YOUR_API_KEY";
 
-                        var apiInstance = new ApiVideoClient(apiKey,basePath);
+                          var apiInstance = new ApiVideoClient(apiKey,basePath);
 
-                        var videoId = vi4k0jvEUuaTdRAEjQ4Jfrgz;  // string | The unique identifier for the video you want to upload a chapter for.
-                        var language = en;  // string | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.
-                        var file = BINARY_DATA_HERE;  // System.IO.Stream | The VTT file describing the chapters you want to upload.
-                        var apiChaptersInstance = apiInstance.Chapters();
-                        try
-                        {
-                            // Upload a chapter
-                            Chapter result = apiChaptersInstance.upload(videoId, language, file);
-                            Debug.WriteLine(result);
-                        }
-                        catch (ApiException  e)
-                        {
-                            Debug.Print("Exception when calling ChaptersApi.upload: " + e.Message );
-                            Debug.Print("Status Code: "+ e.ErrorCode);
-                            Debug.Print(e.StackTrace);
-                        }
-                    }
-                }
-            }
+                          var videoId = vi4k0jvEUuaTdRAEjQ4Jfrgz;  // string | The unique identifier for the video you want to upload a chapter for.
+                          var language = en;  // string | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.
+                          var file = BINARY_DATA_HERE;  // System.IO.Stream | The VTT file describing the chapters you want to upload.
+                          var apiChaptersInstance = apiInstance.Chapters();
+                          try
+                          {
+                              // Upload a chapter
+                              Chapter result = apiChaptersInstance.upload(videoId, language, file);
+                              Debug.WriteLine(result);
+                          }
+                          catch (ApiException  e)
+                          {
+                              Debug.Print("Exception when calling ChaptersApi.upload: " + e.Message );
+                              Debug.Print("Status Code: "+ e.ErrorCode);
+                              Debug.Print(e.StackTrace);
+                          }
+                      }
+                  }
+              }
     delete:
       tags:
-      - Chapters
+        - Chapters
       summary: Delete a chapter
       operationId: DELETE_videos-videoId-chapters-language
       parameters:
-      - name: videoId
-        in: path
-        description: 'The unique identifier for the video you want to delete a chapter from. '
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-        example: vi4k0jvEUuaTdRAEjQ4Jfrgz
-      - name: language
-        in: path
-        description: A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-        example: en
+        - name: videoId
+          in: path
+          description: 'The unique identifier for the video you want to delete a chapter from.'
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: vi4k0jvEUuaTdRAEjQ4Jfrgz
+        - name: language
+          in: path
+          description: A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: en
       responses:
         "204":
           description: No Content
@@ -3704,127 +3721,109 @@ paths:
               schema:
                 $ref: '#/components/schemas/not-found'
       security:
-      - bearerAuth: []
+        - bearerAuth: []
       x-client-action: delete
       x-readme:
         code-samples:
-        - language: go
-          code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    videoId := \"vi4k0jvEUuaTdRAEjQ4Jfrgz\" // string | The unique identifier for the video you want to delete a chapter from.\n    language := \"en\" // string | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.\n\n    \n    err := client.Chapters.Delete(videoId, language)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `Chapters.Delete``: %v\\n\", err)\n    }\n}\n"
-        - language: node
-          code: |
-            //install the module with npm or yarn
-            //npm install @api.video/nodejs-client --save
-            //yarn add @api.video/nodejs-client
-            (async () => {
-                try {
-                    const client = new ApiVideoClient({ apiKey: "YOUR_API_TOKEN" });
+          - language: go
+            code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    videoId := \"vi4k0jvEUuaTdRAEjQ4Jfrgz\" // string | The unique identifier for the video you want to delete a chapter from.\n    language := \"en\" // string | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.\n\n    \n    err := client.Chapters.Delete(videoId, language)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `Chapters.Delete``: %v\\n\", err)\n    }\n}\n"
+          - language: node
+            code: |
+              //install the module with npm or yarn
+              //npm install @api.video/nodejs-client --save
+              //yarn add @api.video/nodejs-client
+              (async () => {
+                  try {
+                      const client = new ApiVideoClient({ apiKey: "YOUR_API_TOKEN" });
 
-                    const videoId = 'vi4k0jvEUuaTdRAEjQ4Jfrgz'; // The unique identifier for the video you want to delete a chapter from.
-                    const language = 'en'; // A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.
+                      const videoId = 'vi4k0jvEUuaTdRAEjQ4Jfrgz'; // The unique identifier for the video you want to delete a chapter from.
+                      const language = 'en'; // A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.
 
-                    // void
-                    const result = await client.chapters.delete(videoId, language);
-                    console.log(result);
-                } catch (e) {
-                    console.error(e);
-                }
-            })();
-        - language: python
-          code: |
-            #install the api.video API client library
-            #pip install api.video
-            import apivideo
-            from apivideo.api import chapters_api
-            from apivideo.model.not_found import NotFound
-            from pprint import pprint
+                      // void
+                      const result = await client.chapters.delete(videoId, language);
+                      console.log(result);
+                  } catch (e) {
+                      console.error(e);
+                  }
+              })();
+          - language: python
+            code: |
+              #install the api.video API client library
+              #pip install api.video
+              import apivideo
+              from apivideo.api import chapters_api
+              from apivideo.model.not_found import NotFound
+              from pprint import pprint
 
-            # Enter a context with an instance of the API client
-            with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
-                # Create an instance of the API class
-                api_instance = chapters_api.ChaptersApi(api_client)
-                video_id = "vi4k0jvEUuaTdRAEjQ4Jfrgz" # str | The unique identifier for the video you want to delete a chapter from.
-                language = "en" # str | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.
+              # Enter a context with an instance of the API client
+              with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
+                  # Create an instance of the API class
+                  api_instance = chapters_api.ChaptersApi(api_client)
+                  video_id = "vi4k0jvEUuaTdRAEjQ4Jfrgz" # str | The unique identifier for the video you want to delete a chapter from.
+                  language = "en" # str | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.
 
-                # example passing only required values which don't have defaults set
-                try:
-                    # Delete a chapter
-                    api_instance.delete(video_id, language)
-                except apivideo.ApiException as e:
-                    print("Exception when calling ChaptersApi->delete: %s\n" % e)
-        - language: java
-          code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.ChaptersApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    ChaptersApi apiInstance = client.chapters();\n    \n    String videoId = \"vi4k0jvEUuaTdRAEjQ4Jfrgz\"; // The unique identifier for the video you want to delete a chapter from.\n    String language = \"en\"; // A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.\n\n    try {\n      apiInstance.delete(videoId, language);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling ChaptersApi#delete\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
-        - language: csharp
-          code: |
-            //install via Nuget
-            //Install-Package ApiVideo
-            using System.Diagnostics;
-            using ApiVideo.Client;
+                  # example passing only required values which don't have defaults set
+                  try:
+                      # Delete a chapter
+                      api_instance.delete(video_id, language)
+                  except apivideo.ApiException as e:
+                      print("Exception when calling ChaptersApi->delete: %s\n" % e)
+          - language: java
+            code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.ChaptersApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    ChaptersApi apiInstance = client.chapters();\n    \n    String videoId = \"vi4k0jvEUuaTdRAEjQ4Jfrgz\"; // The unique identifier for the video you want to delete a chapter from.\n    String language = \"en\"; // A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.\n\n    try {\n      apiInstance.delete(videoId, language);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling ChaptersApi#delete\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
+          - language: csharp
+            code: |
+              //install via Nuget
+              //Install-Package ApiVideo
+              using System.Diagnostics;
+              using ApiVideo.Client;
 
-            namespace Example
-            {
-                public class deleteExample
-                {
-                    public static void Main()
-                    {
-                        var basePath = ApiVideoClient.Client.Environment.SANDBOX;
-                        var apiKey = "YOUR_API_KEY";
+              namespace Example
+              {
+                  public class deleteExample
+                  {
+                      public static void Main()
+                      {
+                          var basePath = ApiVideoClient.Client.Environment.SANDBOX;
+                          var apiKey = "YOUR_API_KEY";
 
-                        var apiInstance = new ApiVideoClient(apiKey,basePath);
+                          var apiInstance = new ApiVideoClient(apiKey,basePath);
 
-                        var videoId = vi4k0jvEUuaTdRAEjQ4Jfrgz;  // string | The unique identifier for the video you want to delete a chapter from.
-                        var language = en;  // string | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.
-                        var apiChaptersInstance = apiInstance.Chapters();
-                        try
-                        {
-                            // Delete a chapter
-                            apiChaptersInstance.delete(videoId, language);
-                        }
-                        catch (ApiException  e)
-                        {
-                            Debug.Print("Exception when calling ChaptersApi.delete: " + e.Message );
-                            Debug.Print("Status Code: "+ e.ErrorCode);
-                            Debug.Print(e.StackTrace);
-                        }
-                    }
-                }
-            }
+                          var videoId = vi4k0jvEUuaTdRAEjQ4Jfrgz;  // string | The unique identifier for the video you want to delete a chapter from.
+                          var language = en;  // string | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.
+                          var apiChaptersInstance = apiInstance.Chapters();
+                          try
+                          {
+                              // Delete a chapter
+                              apiChaptersInstance.delete(videoId, language);
+                          }
+                          catch (ApiException  e)
+                          {
+                              Debug.Print("Exception when calling ChaptersApi.delete: " + e.Message );
+                              Debug.Print("Status Code: "+ e.ErrorCode);
+                              Debug.Print(e.StackTrace);
+                          }
+                      }
+                  }
+              }
   /videos/{videoId}/chapters:
     get:
       tags:
-      - Chapters
+        - Chapters
       summary: List video chapters
       description: Retrieve a list of all chapters for a specified video.
       operationId: GET_videos-videoId-chapters
       parameters:
-      - name: videoId
-        in: path
-        description: The unique identifier for the video you want to retrieve a list of chapters for.
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-        example: vi4k0jvEUuaTdRAEjQ4Jfrgz
-      - name: currentPage
-        in: query
-        description: 'Choose the number of search results to return per page. Minimum value: 1'
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          default: 1
-        example: 2
-      - name: pageSize
-        in: query
-        description: Results per page. Allowed values 1-100, default is 25.
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          default: 25
-        example: 30
+        - name: videoId
+          in: path
+          description: The unique identifier for the video you want to retrieve a list of chapters for.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: vi4k0jvEUuaTdRAEjQ4Jfrgz
+        - $ref: '#/components/parameters/current-page'
+        - $ref: '#/components/parameters/page-size'
       responses:
         "200":
           description: Success
@@ -3836,12 +3835,12 @@ paths:
                 response:
                   value:
                     data:
-                    - uri: /videos/vi3N6cDinStg3oBbN79GklWS/chapters/fr
-                      src: https://cdn.api.video/vod/vi3N6cDinStg3oBbN79GklWS/chapters/fr.vtt
-                      language: fr
-                    - uri: /videos/vi3N6cDinStg3oBbN79GklWS/chapters/en
-                      src: https://cdn.api.video/vod/vi3N6cDinStg3oBbN79GklWS/chapters/en.vtt
-                      language: en
+                      - uri: /videos/vi3N6cDinStg3oBbN79GklWS/chapters/fr
+                        src: https://cdn.api.video/vod/vi3N6cDinStg3oBbN79GklWS/chapters/fr.vtt
+                        language: fr
+                      - uri: /videos/vi3N6cDinStg3oBbN79GklWS/chapters/en
+                        src: https://cdn.api.video/vod/vi3N6cDinStg3oBbN79GklWS/chapters/en.vtt
+                        language: en
                     pagination:
                       currentPage: 1
                       currentPageItems: 2
@@ -3849,12 +3848,12 @@ paths:
                       pagesTotal: 1
                       itemsTotal: 2
                       links:
-                      - rel: self
-                        uri: /videos/vi3N6cDinStg3oBbN79GklWS/chapters?currentPage=1&pageSize=25
-                      - rel: first
-                        uri: /videos/vi3N6cDinStg3oBbN79GklWS/chapters?currentPage=1&pageSize=25
-                      - rel: last
-                        uri: /videos/vi3N6cDinStg3oBbN79GklWS/chapters?currentPage=1&pageSize=25
+                        - rel: self
+                          uri: /videos/vi3N6cDinStg3oBbN79GklWS/chapters?currentPage=1&pageSize=25
+                        - rel: first
+                          uri: /videos/vi3N6cDinStg3oBbN79GklWS/chapters?currentPage=1&pageSize=25
+                        - rel: last
+                          uri: /videos/vi3N6cDinStg3oBbN79GklWS/chapters?currentPage=1&pageSize=25
         "404":
           description: Not Found
           content:
@@ -3862,206 +3861,178 @@ paths:
               schema:
                 $ref: '#/components/schemas/not-found'
       security:
-      - bearerAuth: []
+        - bearerAuth: []
       x-client-action: list
       x-group-parameters: true
       x-client-paginated: true
       x-readme:
         code-samples:
-        - language: go
-          code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    videoId := \"vi4k0jvEUuaTdRAEjQ4Jfrgz\" // string | The unique identifier for the video you want to show a chapter for.\n    language := \"en\" // string | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.\n\n    \n    res, err := client.Chapters.Get(videoId, language)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `Chapters.Get``: %v\\n\", err)\n    }\n    // response from `Get`: Chapter\n    fmt.Fprintf(os.Stdout, \"Response from `Chapters.Get`: %v\\n\", res)\n}\n"
-        - language: node
-          code: |
-            //install the module with npm or yarn
-            //npm install @api.video/nodejs-client --save
-            //yarn add @api.video/nodejs-client
-            (async () => {
-                try {
-                    const client = new ApiVideoClient({ apiKey: "YOUR_API_TOKEN" });
+          - language: go
+            code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    videoId := \"vi4k0jvEUuaTdRAEjQ4Jfrgz\" // string | The unique identifier for the video you want to show a chapter for.\n    language := \"en\" // string | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.\n\n    \n    res, err := client.Chapters.Get(videoId, language)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `Chapters.Get``: %v\\n\", err)\n    }\n    // response from `Get`: Chapter\n    fmt.Fprintf(os.Stdout, \"Response from `Chapters.Get`: %v\\n\", res)\n}\n"
+          - language: node
+            code: |
+              //install the module with npm or yarn
+              //npm install @api.video/nodejs-client --save
+              //yarn add @api.video/nodejs-client
+              (async () => {
+                  try {
+                      const client = new ApiVideoClient({ apiKey: "YOUR_API_TOKEN" });
 
-                    const videoId = 'vi4k0jvEUuaTdRAEjQ4Jfrgz'; // The unique identifier for the video you want to show a chapter for.
-                    const language = 'en'; // A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.
+                      const videoId = 'vi4k0jvEUuaTdRAEjQ4Jfrgz'; // The unique identifier for the video you want to show a chapter for.
+                      const language = 'en'; // A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.
 
-                    // Chapter
-                    const result = await client.chapters.get(videoId, language);
-                    console.log(result);
-                } catch (e) {
-                    console.error(e);
-                }
-            })();
-        - language: python
-          code: |
-            #install the api.video API client library
-            #pip install api.video
-            import apivideo
-            from apivideo.api import chapters_api
-            from apivideo.model.not_found import NotFound
-            from apivideo.model.chapter import Chapter
-            from pprint import pprint
+                      // Chapter
+                      const result = await client.chapters.get(videoId, language);
+                      console.log(result);
+                  } catch (e) {
+                      console.error(e);
+                  }
+              })();
+          - language: python
+            code: |
+              #install the api.video API client library
+              #pip install api.video
+              import apivideo
+              from apivideo.api import chapters_api
+              from apivideo.model.not_found import NotFound
+              from apivideo.model.chapter import Chapter
+              from pprint import pprint
 
-            # Enter a context with an instance of the API client
-            with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
-                # Create an instance of the API class
-                api_instance = chapters_api.ChaptersApi(api_client)
-                video_id = "vi4k0jvEUuaTdRAEjQ4Jfrgz" # str | The unique identifier for the video you want to show a chapter for.
-                language = "en" # str | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.
+              # Enter a context with an instance of the API client
+              with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
+                  # Create an instance of the API class
+                  api_instance = chapters_api.ChaptersApi(api_client)
+                  video_id = "vi4k0jvEUuaTdRAEjQ4Jfrgz" # str | The unique identifier for the video you want to show a chapter for.
+                  language = "en" # str | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.
 
-                # example passing only required values which don't have defaults set
-                try:
-                    # Show a chapter
-                    api_response = api_instance.get(video_id, language)
-                    pprint(api_response)
-                except apivideo.ApiException as e:
-                    print("Exception when calling ChaptersApi->get: %s\n" % e)
-        - language: java
-          code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.ChaptersApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    ChaptersApi apiInstance = client.chapters();\n    \n    String videoId = \"vi4k0jvEUuaTdRAEjQ4Jfrgz\"; // The unique identifier for the video you want to show a chapter for.\n    String language = \"en\"; // A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.\n\n    try {\n      Chapter result = apiInstance.get(videoId, language);\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling ChaptersApi#get\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
-        - language: csharp
-          code: |
-            //install via Nuget
-            //Install-Package ApiVideo
-            using System.Diagnostics;
-            using ApiVideo.Client;
+                  # example passing only required values which don't have defaults set
+                  try:
+                      # Show a chapter
+                      api_response = api_instance.get(video_id, language)
+                      pprint(api_response)
+                  except apivideo.ApiException as e:
+                      print("Exception when calling ChaptersApi->get: %s\n" % e)
+          - language: java
+            code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.ChaptersApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    ChaptersApi apiInstance = client.chapters();\n    \n    String videoId = \"vi4k0jvEUuaTdRAEjQ4Jfrgz\"; // The unique identifier for the video you want to show a chapter for.\n    String language = \"en\"; // A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.\n\n    try {\n      Chapter result = apiInstance.get(videoId, language);\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling ChaptersApi#get\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
+          - language: csharp
+            code: |
+              //install via Nuget
+              //Install-Package ApiVideo
+              using System.Diagnostics;
+              using ApiVideo.Client;
 
-            namespace Example
-            {
-                public class getExample
-                {
-                    public static void Main()
-                    {
-                        var basePath = ApiVideoClient.Client.Environment.SANDBOX;
-                        var apiKey = "YOUR_API_KEY";
+              namespace Example
+              {
+                  public class getExample
+                  {
+                      public static void Main()
+                      {
+                          var basePath = ApiVideoClient.Client.Environment.SANDBOX;
+                          var apiKey = "YOUR_API_KEY";
 
-                        var apiInstance = new ApiVideoClient(apiKey,basePath);
+                          var apiInstance = new ApiVideoClient(apiKey,basePath);
 
-                        var videoId = vi4k0jvEUuaTdRAEjQ4Jfrgz;  // string | The unique identifier for the video you want to show a chapter for.
-                        var language = en;  // string | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.
-                        var apiChaptersInstance = apiInstance.Chapters();
-                        try
-                        {
-                            // Show a chapter
-                            Chapter result = apiChaptersInstance.get(videoId, language);
-                            Debug.WriteLine(result);
-                        }
-                        catch (ApiException  e)
-                        {
-                            Debug.Print("Exception when calling ChaptersApi.get: " + e.Message );
-                            Debug.Print("Status Code: "+ e.ErrorCode);
-                            Debug.Print(e.StackTrace);
-                        }
-                    }
-                }
-            }
+                          var videoId = vi4k0jvEUuaTdRAEjQ4Jfrgz;  // string | The unique identifier for the video you want to show a chapter for.
+                          var language = en;  // string | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.
+                          var apiChaptersInstance = apiInstance.Chapters();
+                          try
+                          {
+                              // Show a chapter
+                              Chapter result = apiChaptersInstance.get(videoId, language);
+                              Debug.WriteLine(result);
+                          }
+                          catch (ApiException  e)
+                          {
+                              Debug.Print("Exception when calling ChaptersApi.get: " + e.Message );
+                              Debug.Print("Status Code: "+ e.ErrorCode);
+                              Debug.Print(e.StackTrace);
+                          }
+                      }
+                  }
+              }
   /players:
     get:
       tags:
-      - Players
+        - Player Themes
       summary: List all players
       description: |-
         Retrieve a list of all the players you created, as well as details about each one.
         Tutorials that use the [player endpoint](https://api.video/blog/endpoints/player).
       operationId: GET_players
       parameters:
-      - name: sortBy
-        in: query
-        description: createdAt is the time the player was created. updatedAt is the time the player was last updated. The time is presented in ISO-8601 format.
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-          enum:
-          - createdAt
-          - updatedAt
-        example: createdAt
-      - name: sortOrder
-        in: query
-        description: 'Allowed: asc, desc. Ascending for date and time means that earlier values precede later ones. Descending means that later values preced earlier ones.'
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-          enum:
-          - asc
-          - desc
-        example: asc
-      - name: currentPage
-        in: query
-        description: 'Choose the number of search results to return per page. Minimum value: 1'
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          default: 1
-        example: 2
-      - name: pageSize
-        in: query
-        description: Results per page. Allowed values 1-100, default is 25.
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          default: 25
-        example: 30
+        - name: sortBy
+          in: query
+          description: createdAt is the time the player was created. updatedAt is the time the player was last updated. The time is presented in ISO-8601 format.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+            enum:
+              - createdAt
+              - updatedAt
+          example: createdAt
+        - name: sortOrder
+          in: query
+          description: 'Allowed: asc, desc. Ascending for date and time means that earlier values precede later ones. Descending means that later values preced earlier ones.'
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+            enum:
+              - asc
+              - desc
+          example: asc
+        - $ref: '#/components/parameters/current-page'
+        - $ref: '#/components/parameters/page-size'
       responses:
         "200":
           description: Success
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/players-list-response'
+                $ref: '#/components/schemas/player-themes-list-response'
               examples:
                 response:
                   value:
                     data:
-                    - playerId: pl4fgtjy4tjyKDK545DRdfg
-                      createdAt: 2020-01-13T10:09:17+00:00
-                      updatedAt: 2020-01-13T10:09:17+00:00
-                      shapeMargin: 10
-                      shapeRadius: 3
-                      shapeAspect: flat
-                      shapeBackgroundTop: rgba(50, 50, 50, .7)
-                      shapeBackgroundBottom: rgba(50, 50, 50, .8)
-                      text: rgba(255, 255, 255, .95)
-                      link: rgba(255, 0, 0, .95)
-                      linkHover: rgba(255, 255, 255, .75)
-                      linkActive: rgba(255, 0, 0, .75)
-                      trackPlayed: rgba(255, 255, 255, .95)
-                      trackUnplayed: rgba(255, 255, 255, .1)
-                      trackBackground: rgba(0, 0, 0, 0)
-                      backgroundTop: rgba(72, 4, 45, 1)
-                      backgroundBottom: rgba(94, 95, 89, 1)
-                      backgroundText: rgba(255, 255, 255, .95)
-                      enableApi: false
-                      enableControls: false
-                      forceAutoplay: false
-                      hideTitle: false
-                      forceLoop: false
-                    - playerId: pl54fgtjy4tjyKDK45DRdfg
-                      createdAt: 2020-01-13T10:09:17+00:00
-                      updatedAt: 2020-01-13T10:09:17+00:00
-                      shapeMargin: 10
-                      shapeRadius: 3
-                      shapeAspect: flat
-                      shapeBackgroundTop: rgba(50, 50, 50, .7)
-                      shapeBackgroundBottom: rgba(50, 50, 50, .8)
-                      text: rgba(255, 255, 255, .95)
-                      link: rgba(255, 0, 0, .95)
-                      linkHover: rgba(255, 255, 255, .75)
-                      linkActive: rgba(255, 0, 0, .75)
-                      trackPlayed: rgba(255, 255, 255, .95)
-                      trackUnplayed: rgba(255, 255, 255, .1)
-                      trackBackground: rgba(0, 0, 0, 0)
-                      backgroundTop: rgba(72, 4, 45, 1)
-                      backgroundBottom: rgba(94, 95, 89, 1)
-                      backgroundText: rgba(255, 255, 255, .95)
-                      enableApi: true
-                      enableControls: true
-                      forceAutoplay: true
-                      hideTitle: false
-                      forceLoop: false
+                      - playerId: pl4fgtjy4tjyKDK545DRdfg
+                        createdAt: '2020-01-13T10:09:17+00:00'
+                        updatedAt: '2020-01-13T10:09:17+00:00'
+                        text: 'rgba(255, 255, 255, .95)'
+                        link: 'rgba(255, 0, 0, .95)'
+                        linkHover: 'rgba(255, 255, 255, .75)'
+                        linkActive: 'rgba(255, 0, 0, .75)'
+                        trackPlayed: 'rgba(255, 255, 255, .95)'
+                        trackUnplayed: 'rgba(255, 255, 255, .1)'
+                        trackBackground: 'rgba(0, 0, 0, 0)'
+                        backgroundTop: 'rgba(72, 4, 45, 1)'
+                        backgroundBottom: 'rgba(94, 95, 89, 1)'
+                        backgroundText: 'rgba(255, 255, 255, .95)'
+                        enableApi: false
+                        enableControls: false
+                        forceAutoplay: false
+                        hideTitle: false
+                        forceLoop: false
+                      - playerId: pl54fgtjy4tjyKDK45DRdfg
+                        createdAt: '2020-01-13T10:09:17+00:00'
+                        updatedAt: '2020-01-13T10:09:17+00:00'
+                        text: 'rgba(255, 255, 255, .95)'
+                        link: 'rgba(255, 0, 0, .95)'
+                        linkHover: 'rgba(255, 255, 255, .75)'
+                        linkActive: 'rgba(255, 0, 0, .75)'
+                        trackPlayed: 'rgba(255, 255, 255, .95)'
+                        trackUnplayed: 'rgba(255, 255, 255, .1)'
+                        trackBackground: 'rgba(0, 0, 0, 0)'
+                        backgroundTop: 'rgba(72, 4, 45, 1)'
+                        backgroundBottom: 'rgba(94, 95, 89, 1)'
+                        backgroundText: 'rgba(255, 255, 255, .95)'
+                        enableApi: true
+                        enableControls: true
+                        forceAutoplay: true
+                        hideTitle: false
+                        forceLoop: false
                     pagination:
                       currentPage: 1
                       pageSize: 25
@@ -4069,12 +4040,12 @@ paths:
                       itemsTotal: 4
                       currentPageItems: 4
                       links:
-                      - rel: self
-                        uri: https://ws.api.video/players?currentPage=1
-                      - rel: first
-                        uri: https://ws.api.video/players?currentPage=1
-                      - rel: last
-                        uri: https://ws.api.video/players?currentPage=1
+                        - rel: self
+                          uri: 'https://ws.api.video/players?currentPage=1'
+                        - rel: first
+                          uri: 'https://ws.api.video/players?currentPage=1'
+                        - rel: last
+                          uri: 'https://ws.api.video/players?currentPage=1'
         "400":
           description: Bad Request
           content:
@@ -4090,79 +4061,80 @@ paths:
                     range:
                       min: 1
                     problems:
-                    - title: This parameter is out of the allowed range of values.
-                      name: page
-                      range:
-                        min: 1
-                    - title: This parameter is out of the allowed range of values.
-                      name: pageSize
-                      range:
-                        min: 10
-                        max: 100
+                      - title: This parameter is out of the allowed range of values.
+                        name: page
+                        range:
+                          min: 1
+                      - title: This parameter is out of the allowed range of values.
+                        name: pageSize
+                        range:
+                          min: 10
+                          max: 100
       security:
-      - bearerAuth: []
+        - bearerAuth: []
       x-client-action: list
       x-group-parameters: true
       x-client-paginated: true
+      x-optional-object: true
       x-readme:
         code-samples:
-        - language: go
-          code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n    req := apivideosdk.PlayerThemesApiListRequest{}\n    \n    req.SortBy(\"createdAt\") // string | createdAt is the time the player was created. updatedAt is the time the player was last updated. The time is presented in ISO-8601 format.\n    req.SortOrder(\"asc\") // string | Allowed: asc, desc. Ascending for date and time means that earlier values precede later ones. Descending means that later values preced earlier ones.\n    req.CurrentPage(int32(2)) // int32 | Choose the number of search results to return per page. Minimum value: 1 (default to 1)\n    req.PageSize(int32(30)) // int32 | Results per page. Allowed values 1-100, default is 25. (default to 25)\n\n    res, err := client.PlayerThemes.List(req)\n    \n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `PlayerThemes.List``: %v\\n\", err)\n    }\n    // response from `List`: PlayerThemesListResponse\n    fmt.Fprintf(os.Stdout, \"Response from `PlayerThemes.List`: %v\\n\", res)\n}\n"
-        - language: node
-          code: |
-            //install the module with npm or yarn
-            //npm install @api.video/nodejs-client --save
-            //yarn add @api.video/nodejs-client
-            (async () => {
-                try {
-                    const client = new ApiVideoClient({ apiKey: "YOUR_API_TOKEN" });
+          - language: go
+            code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n    req := apivideosdk.PlayerThemesApiListRequest{}\n    \n    req.SortBy(\"createdAt\") // string | createdAt is the time the player was created. updatedAt is the time the player was last updated. The time is presented in ISO-8601 format.\n    req.SortOrder(\"asc\") // string | Allowed: asc, desc. Ascending for date and time means that earlier values precede later ones. Descending means that later values preced earlier ones.\n    req.CurrentPage(int32(2)) // int32 | Choose the number of search results to return per page. Minimum value: 1 (default to 1)\n    req.PageSize(int32(30)) // int32 | Results per page. Allowed values 1-100, default is 25. (default to 25)\n\n    res, err := client.PlayerThemes.List(req)\n    \n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `PlayerThemes.List``: %v\\n\", err)\n    }\n    // response from `List`: PlayerThemesListResponse\n    fmt.Fprintf(os.Stdout, \"Response from `PlayerThemes.List`: %v\\n\", res)\n}\n"
+          - language: node
+            code: |
+              //install the module with npm or yarn
+              //npm install @api.video/nodejs-client --save
+              //yarn add @api.video/nodejs-client
+              (async () => {
+                  try {
+                      const client = new ApiVideoClient({ apiKey: "YOUR_API_TOKEN" });
 
-                    const sortBy = 'createdAt'; // createdAt is the time the player was created. updatedAt is the time the player was last updated. The time is presented in ISO-8601 format.
-                    const sortOrder = 'asc'; // Allowed: asc, desc. Ascending for date and time means that earlier values precede later ones. Descending means that later values preced earlier ones.
-                    const currentPage = '2'; // Choose the number of search results to return per page. Minimum value: 1
-                    const pageSize = '30'; // Results per page. Allowed values 1-100, default is 25.
+                      const sortBy = 'createdAt'; // createdAt is the time the player was created. updatedAt is the time the player was last updated. The time is presented in ISO-8601 format.
+                      const sortOrder = 'asc'; // Allowed: asc, desc. Ascending for date and time means that earlier values precede later ones. Descending means that later values preced earlier ones.
+                      const currentPage = '2'; // Choose the number of search results to return per page. Minimum value: 1
+                      const pageSize = '30'; // Results per page. Allowed values 1-100, default is 25.
 
-                    // PlayerThemesListResponse
-                    const result = await client.playerThemes.list({ sortBy, sortOrder, currentPage, pageSize })
-                    console.log(result);
-                } catch (e) {
-                    console.error(e);
-                }
-            })();
-        - language: python
-          code: |
-            #install the api.video API client library
-            #pip install api.video
-            import apivideo
-            from apivideo.api import player_themes_api
-            from apivideo.model.bad_request import BadRequest
-            from apivideo.model.player_themes_list_response import PlayerThemesListResponse
-            from pprint import pprint
+                      // PlayerThemesListResponse
+                      const result = await client.playerThemes.list({ sortBy, sortOrder, currentPage, pageSize })
+                      console.log(result);
+                  } catch (e) {
+                      console.error(e);
+                  }
+              })();
+          - language: python
+            code: |
+              #install the api.video API client library
+              #pip install api.video
+              import apivideo
+              from apivideo.api import player_themes_api
+              from apivideo.model.bad_request import BadRequest
+              from apivideo.model.player_themes_list_response import PlayerThemesListResponse
+              from pprint import pprint
 
-            # Enter a context with an instance of the API client
-            with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
-                # Create an instance of the API class
-                api_instance = player_themes_api.PlayerThemesApi(api_client)
-                sort_by = "createdAt" # str | createdAt is the time the player was created. updatedAt is the time the player was last updated. The time is presented in ISO-8601 format. (optional)
-                sort_order = "asc" # str | Allowed: asc, desc. Ascending for date and time means that earlier values precede later ones. Descending means that later values preced earlier ones. (optional)
-                current_page = 2 # int | Choose the number of search results to return per page. Minimum value: 1 (optional) if omitted the server will use the default value of 1
-                page_size = 30 # int | Results per page. Allowed values 1-100, default is 25. (optional) if omitted the server will use the default value of 25
+              # Enter a context with an instance of the API client
+              with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
+                  # Create an instance of the API class
+                  api_instance = player_themes_api.PlayerThemesApi(api_client)
+                  sort_by = "createdAt" # str | createdAt is the time the player was created. updatedAt is the time the player was last updated. The time is presented in ISO-8601 format. (optional)
+                  sort_order = "asc" # str | Allowed: asc, desc. Ascending for date and time means that earlier values precede later ones. Descending means that later values preced earlier ones. (optional)
+                  current_page = 2 # int | Choose the number of search results to return per page. Minimum value: 1 (optional) if omitted the server will use the default value of 1
+                  page_size = 30 # int | Results per page. Allowed values 1-100, default is 25. (optional) if omitted the server will use the default value of 25
 
-                # example passing only required values which don't have defaults set
-                # and optional values
-                try:
-                    # List all players
-                    api_response = api_instance.list(sort_by=sort_by, sort_order=sort_order, current_page=current_page, page_size=page_size)
-                    pprint(api_response)
-                except apivideo.ApiException as e:
-                    print("Exception when calling PlayerThemesApi->list: %s\n" % e)
-        - language: java
-          code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.PlayerThemesApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    PlayerThemesApi apiInstance = client.playerThemes();\n    \n    String sortBy = \"createdAt\"; // createdAt is the time the player was created. updatedAt is the time the player was last updated. The time is presented in ISO-8601 format.\n    String sortOrder = \"asc\"; // Allowed: asc, desc. Ascending for date and time means that earlier values precede later ones. Descending means that later values preced earlier ones.\n    Integer currentPage = 1; // Choose the number of search results to return per page. Minimum value: 1\n    Integer pageSize = 25; // Results per page. Allowed values 1-100, default is 25.\n\n    try {\n      Page<PlayerTheme> result = apiInstance.list()\n            .sortBy(sortBy)\n            .sortOrder(sortOrder)\n            .currentPage(currentPage)\n            .pageSize(pageSize)\n            .execute();\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling PlayerThemesApi#list\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
-        - language: csharp
-          code: "//install via Nuget\n//Install-Package ApiVideo\nusing System.Diagnostics;\nusing ApiVideo.Client;\n\nnamespace Example\n{\n    public class listExample\n    {\n        public static void Main()\n        {\n            var basePath = ApiVideoClient.Client.Environment.SANDBOX;\n            var apiKey = \"YOUR_API_KEY\";\n\n            var apiInstance = new ApiVideoClient(apiKey,basePath);\n\n            var sortBy = createdAt;  // string | createdAt is the time the player was created. updatedAt is the time the player was last updated. The time is presented in ISO-8601 format. (optional) \n            var sortOrder = asc;  // string | Allowed: asc, desc. Ascending for date and time means that earlier values precede later ones. Descending means that later values preced earlier ones. (optional) \n            var currentPage = 2;  // int? | Choose the number of search results to return per page. Minimum value: 1 (optional)  (default to 1)\n            var pageSize = 30;  // int? | Results per page. Allowed values 1-100, default is 25. (optional)  (default to 25)\n            var apiPlayerThemesInstance = apiInstance.PlayerThemes();\n            try\n            {\n                // List all players\n                PlayerThemesListResponse result = apiPlayerThemesInstance.list(sortBy, sortOrder, currentPage, pageSize);\n                Debug.WriteLine(result);\n            }\n            catch (ApiException  e)\n            {\n                Debug.Print(\"Exception when calling PlayerThemesApi.list: \" + e.Message );\n                Debug.Print(\"Status Code: \"+ e.ErrorCode);\n                Debug.Print(e.StackTrace);\n            }\n        }\n    }\n}\n"
+                  # example passing only required values which don't have defaults set
+                  # and optional values
+                  try:
+                      # List all players
+                      api_response = api_instance.list(sort_by=sort_by, sort_order=sort_order, current_page=current_page, page_size=page_size)
+                      pprint(api_response)
+                  except apivideo.ApiException as e:
+                      print("Exception when calling PlayerThemesApi->list: %s\n" % e)
+          - language: java
+            code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.PlayerThemesApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    PlayerThemesApi apiInstance = client.playerThemes();\n    \n    String sortBy = \"createdAt\"; // createdAt is the time the player was created. updatedAt is the time the player was last updated. The time is presented in ISO-8601 format.\n    String sortOrder = \"asc\"; // Allowed: asc, desc. Ascending for date and time means that earlier values precede later ones. Descending means that later values preced earlier ones.\n    Integer currentPage = 1; // Choose the number of search results to return per page. Minimum value: 1\n    Integer pageSize = 25; // Results per page. Allowed values 1-100, default is 25.\n\n    try {\n      Page<PlayerTheme> result = apiInstance.list()\n            .sortBy(sortBy)\n            .sortOrder(sortOrder)\n            .currentPage(currentPage)\n            .pageSize(pageSize)\n            .execute();\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling PlayerThemesApi#list\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
+          - language: csharp
+            code: "//install via Nuget\n//Install-Package ApiVideo\nusing System.Diagnostics;\nusing ApiVideo.Client;\n\nnamespace Example\n{\n    public class listExample\n    {\n        public static void Main()\n        {\n            var basePath = ApiVideoClient.Client.Environment.SANDBOX;\n            var apiKey = \"YOUR_API_KEY\";\n\n            var apiInstance = new ApiVideoClient(apiKey,basePath);\n\n            var sortBy = createdAt;  // string | createdAt is the time the player was created. updatedAt is the time the player was last updated. The time is presented in ISO-8601 format. (optional) \n            var sortOrder = asc;  // string | Allowed: asc, desc. Ascending for date and time means that earlier values precede later ones. Descending means that later values preced earlier ones. (optional) \n            var currentPage = 2;  // int? | Choose the number of search results to return per page. Minimum value: 1 (optional)  (default to 1)\n            var pageSize = 30;  // int? | Results per page. Allowed values 1-100, default is 25. (optional)  (default to 25)\n            var apiPlayerThemesInstance = apiInstance.PlayerThemes();\n            try\n            {\n                // List all players\n                PlayerThemesListResponse result = apiPlayerThemesInstance.list(sortBy, sortOrder, currentPage, pageSize);\n                Debug.WriteLine(result);\n            }\n            catch (ApiException  e)\n            {\n                Debug.Print(\"Exception when calling PlayerThemesApi.list: \" + e.Message );\n                Debug.Print(\"Status Code: \"+ e.ErrorCode);\n                Debug.Print(e.StackTrace);\n            }\n        }\n    }\n}\n"
     post:
       tags:
-      - Players
+        - Player Themes
       summary: Create a player
       description: Create a player for your video, and customise it.
       operationId: POST_players
@@ -4170,7 +4142,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/playerCreationPayload'
+              $ref: '#/components/schemas/player-theme-creation-payload'
         required: true
       responses:
         "201":
@@ -4178,91 +4150,83 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/player'
+                $ref: '#/components/schemas/player-theme'
               examples:
                 response:
                   value:
                     playerId: pl45d5vFFGrfdsdsd156dGhh
-                    createdAt: 2020-01-13T10:09:17+00:00
-                    updatedAt: 2020-01-13T10:09:17+00:00
-                    shapeRadius: 3
-                    shapeAspect: flat
-                    shapeBackgroundTop: rgba(50, 50, 50, .7)
-                    shapeBackgroundBottom: rgba(50, 50, 50, .8)
-                    text: rgba(255, 255, 255, .95)
-                    link: rgba(255, 0, 0, .95)
-                    linkHover: rgba(255, 255, 255, .75)
-                    linkActive: rgba(255, 0, 0, .75)
-                    trackPlayed: rgba(255, 255, 255, .95)
-                    trackUnplayed: rgba(255, 255, 255, .1)
-                    trackBackground: rgba(0, 0, 0, 0)
-                    backgroundTop: rgba(72, 4, 45, 1)
-                    backgroundBottom: rgba(94, 95, 89, 1)
-                    backgroundText: rgba(255, 255, 255, .95)
+                    createdAt: '2020-01-13T10:09:17+00:00'
+                    updatedAt: '2020-01-13T10:09:17+00:00'
+                    text: 'rgba(255, 255, 255, .95)'
+                    link: 'rgba(255, 0, 0, .95)'
+                    linkHover: 'rgba(255, 255, 255, .75)'
+                    linkActive: 'rgba(255, 0, 0, .75)'
+                    trackPlayed: 'rgba(255, 255, 255, .95)'
+                    trackUnplayed: 'rgba(255, 255, 255, .1)'
+                    trackBackground: 'rgba(0, 0, 0, 0)'
+                    backgroundTop: 'rgba(72, 4, 45, 1)'
+                    backgroundBottom: 'rgba(94, 95, 89, 1)'
+                    backgroundText: 'rgba(255, 255, 255, .95)'
                     enableApi: false
                     enableControls: false
                     forceAutoplay: false
                     hideTitle: false
                     forceLoop: false
       security:
-      - bearerAuth: []
+        - bearerAuth: []
       x-client-action: create
       x-readme:
         code-samples:
-        - language: go
-          code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    playerThemeCreationPayload := *apivideosdk.NewPlayerThemeCreationPayload() // PlayerThemeCreationPayload | \n\n    \n    res, err := client.PlayerThemes.Create(playerThemeCreationPayload)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `PlayerThemes.Create``: %v\\n\", err)\n    }\n    // response from `Create`: PlayerTheme\n    fmt.Fprintf(os.Stdout, \"Response from `PlayerThemes.Create`: %v\\n\", res)\n}\n"
-        - language: node
-          code: "//install the module with npm or yarn\n//npm install @api.video/nodejs-client --save\n//yarn add @api.video/nodejs-client\n(async () => {\n    try {\n        const client = new ApiVideoClient({ apiKey: \"YOUR_API_TOKEN\" });\n\n        const playerThemeCreationPayload = {\n      text: \"text_example\", // RGBA color for timer text. Default: rgba(255, 255, 255, 1)\n      link: \"link_example\", // RGBA color for all controls. Default: rgba(255, 255, 255, 1)\n      linkHover: \"linkHover_example\", // RGBA color for all controls when hovered. Default: rgba(255, 255, 255, 1)\n      trackPlayed: \"trackPlayed_example\", // RGBA color playback bar: played content. Default: rgba(88, 131, 255, .95)\n      trackUnplayed: \"trackUnplayed_example\", // RGBA color playback bar: downloaded but unplayed (buffered) content. Default: rgba(255, 255, 255, .35)\n      trackBackground: \"trackBackground_example\", // RGBA color playback bar: background. Default: rgba(255, 255, 255, .2)\n      backgroundTop: \"backgroundTop_example\", // RGBA color: top 50% of background. Default: rgba(0, 0, 0, .7)\n      backgroundBottom: \"backgroundBottom_example\", // RGBA color: bottom 50% of background. Default: rgba(0, 0, 0, .7)\n      backgroundText: \"backgroundText_example\", // RGBA color for title text. Default: rgba(255, 255, 255, 1)\n      enableApi: true, // enable/disable player SDK access. Default: true\n      enableControls: true, // enable/disable player controls. Default: true\n      forceAutoplay: true, // enable/disable player autoplay. Default: false\n      hideTitle: true, // enable/disable title. Default: false\n      forceLoop: true, // enable/disable looping. Default: false\n    }; \n\n        // PlayerTheme\n        const result = await client.playerThemes.create(playerThemeCreationPayload);\n        console.log(result);\n    } catch (e) {\n        console.error(e);\n    }\n})();\n"
-        - language: python
-          code: "#install the api.video API client library\n#pip install api.video\nimport apivideo\nfrom apivideo.api import player_themes_api\nfrom apivideo.model.player_theme_creation_payload import PlayerThemeCreationPayload\nfrom apivideo.model.player_theme import PlayerTheme\nfrom pprint import pprint\n\n# Enter a context with an instance of the API client\nwith apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:\n    # Create an instance of the API class\n    api_instance = player_themes_api.PlayerThemesApi(api_client)\n    player_theme_creation_payload = PlayerThemeCreationPayload(\n        text=\"text_example\",\n        link=\"link_example\",\n        link_hover=\"link_hover_example\",\n        track_played=\"track_played_example\",\n        track_unplayed=\"track_unplayed_example\",\n        track_background=\"track_background_example\",\n        background_top=\"background_top_example\",\n        background_bottom=\"background_bottom_example\",\n        background_text=\"background_text_example\",\n        enable_api=True,\n        enable_controls=True,\n        force_autoplay=False,\n        hide_title=False,\n        force_loop=False,\n    ) # PlayerThemeCreationPayload | \n\n    # example passing only required values which don't have defaults set\n    try:\n        # Create a player\n        api_response = api_instance.create(player_theme_creation_payload)\n        pprint(api_response)\n    except apivideo.ApiException as e:\n        print(\"Exception when calling PlayerThemesApi->create: %s\\n\" % e)\n"
-        - language: java
-          code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.PlayerThemesApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    PlayerThemesApi apiInstance = client.playerThemes();\n    \n    PlayerThemeCreationPayload playerThemeCreationPayload = new PlayerThemeCreationPayload(); // \n    playerThemeCreationPayload.setText(\"\"null\"\"); // RGBA color for timer text. Default: rgba(255, 255, 255, 1)\n    playerThemeCreationPayload.setLink(\"\"null\"\"); // RGBA color for all controls. Default: rgba(255, 255, 255, 1)\n    playerThemeCreationPayload.setLinkHover(\"\"null\"\"); // RGBA color for all controls when hovered. Default: rgba(255, 255, 255, 1)\n    playerThemeCreationPayload.setTrackPlayed(\"\"null\"\"); // RGBA color playback bar: played content. Default: rgba(88, 131, 255, .95)\n    playerThemeCreationPayload.setTrackUnplayed(\"\"null\"\"); // RGBA color playback bar: downloaded but unplayed (buffered) content. Default: rgba(255, 255, 255, .35)\n    playerThemeCreationPayload.setTrackBackground(\"\"null\"\"); // RGBA color playback bar: background. Default: rgba(255, 255, 255, .2)\n    playerThemeCreationPayload.setBackgroundTop(\"\"null\"\"); // RGBA color: top 50% of background. Default: rgba(0, 0, 0, .7)\n    playerThemeCreationPayload.setBackgroundBottom(\"\"null\"\"); // RGBA color: bottom 50% of background. Default: rgba(0, 0, 0, .7)\n    playerThemeCreationPayload.setBackgroundText(\"\"null\"\"); // RGBA color for title text. Default: rgba(255, 255, 255, 1)\n    playerThemeCreationPayload.setEnableApi(); // enable/disable player SDK access. Default: true\n    playerThemeCreationPayload.setEnableControls(); // enable/disable player controls. Default: true\n    playerThemeCreationPayload.setForceAutoplay(); // enable/disable player autoplay. Default: false\n    playerThemeCreationPayload.setHideTitle(); // enable/disable title. Default: false\n    playerThemeCreationPayload.setForceLoop(); // enable/disable looping. Default: false\n\n\n    try {\n      PlayerTheme result = apiInstance.create(playerThemeCreationPayload);\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling PlayerThemesApi#create\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
-        - language: csharp
-          code: "//install via Nuget\n//Install-Package ApiVideo\nusing System.Diagnostics;\nusing ApiVideo.Client;\n\nnamespace Example\n{\n    public class createExample\n    {\n        public static void Main()\n        {\n            var basePath = ApiVideoClient.Client.Environment.SANDBOX;\n            var apiKey = \"YOUR_API_KEY\";\n\n            var apiInstance = new ApiVideoClient(apiKey,basePath);\n\n            var playerThemeCreationPayload = new PlayerThemeCreationPayload(); // PlayerThemeCreationPayload | \n            var apiPlayerThemesInstance = apiInstance.PlayerThemes();\n            try\n            {\n                // Create a player\n                PlayerTheme result = apiPlayerThemesInstance.create(playerThemeCreationPayload);\n                Debug.WriteLine(result);\n            }\n            catch (ApiException  e)\n            {\n                Debug.Print(\"Exception when calling PlayerThemesApi.create: \" + e.Message );\n                Debug.Print(\"Status Code: \"+ e.ErrorCode);\n                Debug.Print(e.StackTrace);\n            }\n        }\n    }\n}\n"
+          - language: go
+            code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    playerThemeCreationPayload := *apivideosdk.NewPlayerThemeCreationPayload() // PlayerThemeCreationPayload | \n\n    \n    res, err := client.PlayerThemes.Create(playerThemeCreationPayload)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `PlayerThemes.Create``: %v\\n\", err)\n    }\n    // response from `Create`: PlayerTheme\n    fmt.Fprintf(os.Stdout, \"Response from `PlayerThemes.Create`: %v\\n\", res)\n}\n"
+          - language: node
+            code: "//install the module with npm or yarn\n//npm install @api.video/nodejs-client --save\n//yarn add @api.video/nodejs-client\n(async () => {\n    try {\n        const client = new ApiVideoClient({ apiKey: \"YOUR_API_TOKEN\" });\n\n        const playerThemeCreationPayload = {\n      text: \"text_example\", // RGBA color for timer text. Default: rgba(255, 255, 255, 1)\n      link: \"link_example\", // RGBA color for all controls. Default: rgba(255, 255, 255, 1)\n      linkHover: \"linkHover_example\", // RGBA color for all controls when hovered. Default: rgba(255, 255, 255, 1)\n      trackPlayed: \"trackPlayed_example\", // RGBA color playback bar: played content. Default: rgba(88, 131, 255, .95)\n      trackUnplayed: \"trackUnplayed_example\", // RGBA color playback bar: downloaded but unplayed (buffered) content. Default: rgba(255, 255, 255, .35)\n      trackBackground: \"trackBackground_example\", // RGBA color playback bar: background. Default: rgba(255, 255, 255, .2)\n      backgroundTop: \"backgroundTop_example\", // RGBA color: top 50% of background. Default: rgba(0, 0, 0, .7)\n      backgroundBottom: \"backgroundBottom_example\", // RGBA color: bottom 50% of background. Default: rgba(0, 0, 0, .7)\n      backgroundText: \"backgroundText_example\", // RGBA color for title text. Default: rgba(255, 255, 255, 1)\n      enableApi: true, // enable/disable player SDK access. Default: true\n      enableControls: true, // enable/disable player controls. Default: true\n      forceAutoplay: true, // enable/disable player autoplay. Default: false\n      hideTitle: true, // enable/disable title. Default: false\n      forceLoop: true, // enable/disable looping. Default: false\n    }; \n\n        // PlayerTheme\n        const result = await client.playerThemes.create(playerThemeCreationPayload);\n        console.log(result);\n    } catch (e) {\n        console.error(e);\n    }\n})();\n"
+          - language: python
+            code: "#install the api.video API client library\n#pip install api.video\nimport apivideo\nfrom apivideo.api import player_themes_api\nfrom apivideo.model.player_theme_creation_payload import PlayerThemeCreationPayload\nfrom apivideo.model.player_theme import PlayerTheme\nfrom pprint import pprint\n\n# Enter a context with an instance of the API client\nwith apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:\n    # Create an instance of the API class\n    api_instance = player_themes_api.PlayerThemesApi(api_client)\n    player_theme_creation_payload = PlayerThemeCreationPayload(\n        text=\"text_example\",\n        link=\"link_example\",\n        link_hover=\"link_hover_example\",\n        track_played=\"track_played_example\",\n        track_unplayed=\"track_unplayed_example\",\n        track_background=\"track_background_example\",\n        background_top=\"background_top_example\",\n        background_bottom=\"background_bottom_example\",\n        background_text=\"background_text_example\",\n        enable_api=True,\n        enable_controls=True,\n        force_autoplay=False,\n        hide_title=False,\n        force_loop=False,\n    ) # PlayerThemeCreationPayload | \n\n    # example passing only required values which don't have defaults set\n    try:\n        # Create a player\n        api_response = api_instance.create(player_theme_creation_payload)\n        pprint(api_response)\n    except apivideo.ApiException as e:\n        print(\"Exception when calling PlayerThemesApi->create: %s\\n\" % e)\n"
+          - language: java
+            code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.PlayerThemesApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    PlayerThemesApi apiInstance = client.playerThemes();\n    \n    PlayerThemeCreationPayload playerThemeCreationPayload = new PlayerThemeCreationPayload(); // \n    playerThemeCreationPayload.setText(\"\"null\"\"); // RGBA color for timer text. Default: rgba(255, 255, 255, 1)\n    playerThemeCreationPayload.setLink(\"\"null\"\"); // RGBA color for all controls. Default: rgba(255, 255, 255, 1)\n    playerThemeCreationPayload.setLinkHover(\"\"null\"\"); // RGBA color for all controls when hovered. Default: rgba(255, 255, 255, 1)\n    playerThemeCreationPayload.setTrackPlayed(\"\"null\"\"); // RGBA color playback bar: played content. Default: rgba(88, 131, 255, .95)\n    playerThemeCreationPayload.setTrackUnplayed(\"\"null\"\"); // RGBA color playback bar: downloaded but unplayed (buffered) content. Default: rgba(255, 255, 255, .35)\n    playerThemeCreationPayload.setTrackBackground(\"\"null\"\"); // RGBA color playback bar: background. Default: rgba(255, 255, 255, .2)\n    playerThemeCreationPayload.setBackgroundTop(\"\"null\"\"); // RGBA color: top 50% of background. Default: rgba(0, 0, 0, .7)\n    playerThemeCreationPayload.setBackgroundBottom(\"\"null\"\"); // RGBA color: bottom 50% of background. Default: rgba(0, 0, 0, .7)\n    playerThemeCreationPayload.setBackgroundText(\"\"null\"\"); // RGBA color for title text. Default: rgba(255, 255, 255, 1)\n    playerThemeCreationPayload.setEnableApi(); // enable/disable player SDK access. Default: true\n    playerThemeCreationPayload.setEnableControls(); // enable/disable player controls. Default: true\n    playerThemeCreationPayload.setForceAutoplay(); // enable/disable player autoplay. Default: false\n    playerThemeCreationPayload.setHideTitle(); // enable/disable title. Default: false\n    playerThemeCreationPayload.setForceLoop(); // enable/disable looping. Default: false\n\n\n    try {\n      PlayerTheme result = apiInstance.create(playerThemeCreationPayload);\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling PlayerThemesApi#create\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
+          - language: csharp
+            code: "//install via Nuget\n//Install-Package ApiVideo\nusing System.Diagnostics;\nusing ApiVideo.Client;\n\nnamespace Example\n{\n    public class createExample\n    {\n        public static void Main()\n        {\n            var basePath = ApiVideoClient.Client.Environment.SANDBOX;\n            var apiKey = \"YOUR_API_KEY\";\n\n            var apiInstance = new ApiVideoClient(apiKey,basePath);\n\n            var playerThemeCreationPayload = new PlayerThemeCreationPayload(); // PlayerThemeCreationPayload | \n            var apiPlayerThemesInstance = apiInstance.PlayerThemes();\n            try\n            {\n                // Create a player\n                PlayerTheme result = apiPlayerThemesInstance.create(playerThemeCreationPayload);\n                Debug.WriteLine(result);\n            }\n            catch (ApiException  e)\n            {\n                Debug.Print(\"Exception when calling PlayerThemesApi.create: \" + e.Message );\n                Debug.Print(\"Status Code: \"+ e.ErrorCode);\n                Debug.Print(e.StackTrace);\n            }\n        }\n    }\n}\n"
   /players/{playerId}:
     get:
       tags:
-      - Players
+        - Player Themes
       summary: Show a player
       description: Use a player ID to retrieve details about the player and display it for viewers.
       operationId: GET_players-playerId
       parameters:
-      - name: playerId
-        in: path
-        description: 'The unique identifier for the player you want to retrieve. '
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-        example: pl45d5vFFGrfdsdsd156dGhh
+        - name: playerId
+          in: path
+          description: 'The unique identifier for the player you want to retrieve. '
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: pl45d5vFFGrfdsdsd156dGhh
       responses:
         "200":
           description: Success
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/player'
+                $ref: '#/components/schemas/player-theme'
               examples:
                 response:
                   value:
                     playerId: pl45d5vFFGrfdsdsd156dGhh
-                    createdAt: 2020-01-13T10:09:17+00:00
-                    updatedAt: 2020-01-13T11:12:14+00:00
-                    shapeRadius: 3
-                    shapeAspect: flat
-                    shapeBackgroundTop: rgba(50, 50, 50, .7)
-                    shapeBackgroundBottom: rgba(50, 50, 50, .8)
-                    text: rgba(255, 255, 255, .95)
-                    link: rgba(255, 0, 0, .95)
-                    linkHover: rgba(255, 255, 255, .75)
-                    linkActive: rgba(255, 0, 0, .75)
-                    trackPlayed: rgba(255, 255, 255, .95)
-                    trackUnplayed: rgba(255, 255, 255, .1)
-                    trackBackground: rgba(0, 0, 0, 0)
-                    backgroundTop: rgba(72, 4, 45, 1)
-                    backgroundBottom: rgba(94, 95, 89, 1)
-                    backgroundText: rgba(255, 255, 255, .95)
+                    createdAt: '2020-01-13T10:09:17+00:00'
+                    updatedAt: '2020-01-13T11:12:14+00:00'
+                    text: 'rgba(255, 255, 255, .95)'
+                    link: 'rgba(255, 0, 0, .95)'
+                    linkHover: 'rgba(255, 255, 255, .75)'
+                    linkActive: 'rgba(255, 0, 0, .75)'
+                    trackPlayed: 'rgba(255, 255, 255, .95)'
+                    trackUnplayed: 'rgba(255, 255, 255, .1)'
+                    trackBackground: 'rgba(0, 0, 0, 0)'
+                    backgroundTop: 'rgba(72, 4, 45, 1)'
+                    backgroundBottom: 'rgba(94, 95, 89, 1)'
+                    backgroundText: 'rgba(255, 255, 255, .95)'
                     enableApi: false
                     enableControls: false
                     forceAutoplay: false
@@ -4282,36 +4246,36 @@ paths:
                     name: playerId
                     status: 404
       security:
-      - bearerAuth: []
+        - bearerAuth: []
       x-client-action: get
       x-readme:
         code-samples:
-        - language: go
-          code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    playerId := \"pl45d5vFFGrfdsdsd156dGhh\" // string | The unique identifier for the player you want to retrieve. \n\n    \n    res, err := client.PlayerThemes.Get(playerId)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `PlayerThemes.Get``: %v\\n\", err)\n    }\n    // response from `Get`: PlayerTheme\n    fmt.Fprintf(os.Stdout, \"Response from `PlayerThemes.Get`: %v\\n\", res)\n}\n"
-        - language: node
-          code: "//install the module with npm or yarn\n//npm install @api.video/nodejs-client --save\n//yarn add @api.video/nodejs-client\n(async () => {\n    try {\n        const client = new ApiVideoClient({ apiKey: \"YOUR_API_TOKEN\" });\n\n        const playerId = 'pl45d5vFFGrfdsdsd156dGhh'; // The unique identifier for the player you want to retrieve. \n\n        // PlayerTheme\n        const result = await client.playerThemes.get(playerId);\n        console.log(result);\n    } catch (e) {\n        console.error(e);\n    }\n})();\n"
-        - language: python
-          code: "#install the api.video API client library\n#pip install api.video\nimport apivideo\nfrom apivideo.api import player_themes_api\nfrom apivideo.model.not_found import NotFound\nfrom apivideo.model.player_theme import PlayerTheme\nfrom pprint import pprint\n\n# Enter a context with an instance of the API client\nwith apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:\n    # Create an instance of the API class\n    api_instance = player_themes_api.PlayerThemesApi(api_client)\n    player_id = \"pl45d5vFFGrfdsdsd156dGhh\" # str | The unique identifier for the player you want to retrieve. \n\n    # example passing only required values which don't have defaults set\n    try:\n        # Show a player\n        api_response = api_instance.get(player_id)\n        pprint(api_response)\n    except apivideo.ApiException as e:\n        print(\"Exception when calling PlayerThemesApi->get: %s\\n\" % e)\n"
-        - language: java
-          code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.PlayerThemesApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    PlayerThemesApi apiInstance = client.playerThemes();\n    \n    String playerId = \"pl45d5vFFGrfdsdsd156dGhh\"; // The unique identifier for the player you want to retrieve. \n\n    try {\n      PlayerTheme result = apiInstance.get(playerId);\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling PlayerThemesApi#get\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
-        - language: csharp
-          code: "//install via Nuget\n//Install-Package ApiVideo\nusing System.Diagnostics;\nusing ApiVideo.Client;\n\nnamespace Example\n{\n    public class getExample\n    {\n        public static void Main()\n        {\n            var basePath = ApiVideoClient.Client.Environment.SANDBOX;\n            var apiKey = \"YOUR_API_KEY\";\n\n            var apiInstance = new ApiVideoClient(apiKey,basePath);\n\n            var playerId = pl45d5vFFGrfdsdsd156dGhh;  // string | The unique identifier for the player you want to retrieve. \n            var apiPlayerThemesInstance = apiInstance.PlayerThemes();\n            try\n            {\n                // Show a player\n                PlayerTheme result = apiPlayerThemesInstance.get(playerId);\n                Debug.WriteLine(result);\n            }\n            catch (ApiException  e)\n            {\n                Debug.Print(\"Exception when calling PlayerThemesApi.get: \" + e.Message );\n                Debug.Print(\"Status Code: \"+ e.ErrorCode);\n                Debug.Print(e.StackTrace);\n            }\n        }\n    }\n}\n"
+          - language: go
+            code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    playerId := \"pl45d5vFFGrfdsdsd156dGhh\" // string | The unique identifier for the player you want to retrieve. \n\n    \n    res, err := client.PlayerThemes.Get(playerId)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `PlayerThemes.Get``: %v\\n\", err)\n    }\n    // response from `Get`: PlayerTheme\n    fmt.Fprintf(os.Stdout, \"Response from `PlayerThemes.Get`: %v\\n\", res)\n}\n"
+          - language: node
+            code: "//install the module with npm or yarn\n//npm install @api.video/nodejs-client --save\n//yarn add @api.video/nodejs-client\n(async () => {\n    try {\n        const client = new ApiVideoClient({ apiKey: \"YOUR_API_TOKEN\" });\n\n        const playerId = 'pl45d5vFFGrfdsdsd156dGhh'; // The unique identifier for the player you want to retrieve. \n\n        // PlayerTheme\n        const result = await client.playerThemes.get(playerId);\n        console.log(result);\n    } catch (e) {\n        console.error(e);\n    }\n})();\n"
+          - language: python
+            code: "#install the api.video API client library\n#pip install api.video\nimport apivideo\nfrom apivideo.api import player_themes_api\nfrom apivideo.model.not_found import NotFound\nfrom apivideo.model.player_theme import PlayerTheme\nfrom pprint import pprint\n\n# Enter a context with an instance of the API client\nwith apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:\n    # Create an instance of the API class\n    api_instance = player_themes_api.PlayerThemesApi(api_client)\n    player_id = \"pl45d5vFFGrfdsdsd156dGhh\" # str | The unique identifier for the player you want to retrieve. \n\n    # example passing only required values which don't have defaults set\n    try:\n        # Show a player\n        api_response = api_instance.get(player_id)\n        pprint(api_response)\n    except apivideo.ApiException as e:\n        print(\"Exception when calling PlayerThemesApi->get: %s\\n\" % e)\n"
+          - language: java
+            code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.PlayerThemesApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    PlayerThemesApi apiInstance = client.playerThemes();\n    \n    String playerId = \"pl45d5vFFGrfdsdsd156dGhh\"; // The unique identifier for the player you want to retrieve. \n\n    try {\n      PlayerTheme result = apiInstance.get(playerId);\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling PlayerThemesApi#get\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
+          - language: csharp
+            code: "//install via Nuget\n//Install-Package ApiVideo\nusing System.Diagnostics;\nusing ApiVideo.Client;\n\nnamespace Example\n{\n    public class getExample\n    {\n        public static void Main()\n        {\n            var basePath = ApiVideoClient.Client.Environment.SANDBOX;\n            var apiKey = \"YOUR_API_KEY\";\n\n            var apiInstance = new ApiVideoClient(apiKey,basePath);\n\n            var playerId = pl45d5vFFGrfdsdsd156dGhh;  // string | The unique identifier for the player you want to retrieve. \n            var apiPlayerThemesInstance = apiInstance.PlayerThemes();\n            try\n            {\n                // Show a player\n                PlayerTheme result = apiPlayerThemesInstance.get(playerId);\n                Debug.WriteLine(result);\n            }\n            catch (ApiException  e)\n            {\n                Debug.Print(\"Exception when calling PlayerThemesApi.get: \" + e.Message );\n                Debug.Print(\"Status Code: \"+ e.ErrorCode);\n                Debug.Print(e.StackTrace);\n            }\n        }\n    }\n}\n"
     delete:
       tags:
-      - Players
+        - Player Themes
       summary: Delete a player
       description: Delete a player if you no longer need it. You can delete any player that you have the player ID for.
       operationId: DELETE_players-playerId
       parameters:
-      - name: playerId
-        in: path
-        description: The unique identifier for the player you want to delete.
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-        example: pl45d5vFFGrfdsdsd156dGhh
+        - name: playerId
+          in: path
+          description: The unique identifier for the player you want to delete.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: pl45d5vFFGrfdsdsd156dGhh
       responses:
         "204":
           description: No Content
@@ -4329,108 +4293,108 @@ paths:
                     name: playerId
                     status: 404
       security:
-      - bearerAuth: []
+        - bearerAuth: []
       x-client-action: delete
       x-readme:
         code-samples:
-        - language: go
-          code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    playerId := \"pl45d5vFFGrfdsdsd156dGhh\" // string | The unique identifier for the player you want to delete.\n\n    \n    err := client.PlayerThemes.Delete(playerId)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `PlayerThemes.Delete``: %v\\n\", err)\n    }\n}\n"
-        - language: node
-          code: |
-            //install the module with npm or yarn
-            //npm install @api.video/nodejs-client --save
-            //yarn add @api.video/nodejs-client
-            (async () => {
-                try {
-                    const client = new ApiVideoClient({ apiKey: "YOUR_API_TOKEN" });
+          - language: go
+            code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    playerId := \"pl45d5vFFGrfdsdsd156dGhh\" // string | The unique identifier for the player you want to delete.\n\n    \n    err := client.PlayerThemes.Delete(playerId)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `PlayerThemes.Delete``: %v\\n\", err)\n    }\n}\n"
+          - language: node
+            code: |
+              //install the module with npm or yarn
+              //npm install @api.video/nodejs-client --save
+              //yarn add @api.video/nodejs-client
+              (async () => {
+                  try {
+                      const client = new ApiVideoClient({ apiKey: "YOUR_API_TOKEN" });
 
-                    const playerId = 'pl45d5vFFGrfdsdsd156dGhh'; // The unique identifier for the player you want to delete.
+                      const playerId = 'pl45d5vFFGrfdsdsd156dGhh'; // The unique identifier for the player you want to delete.
 
-                    // void
-                    const result = await client.playerThemes.delete(playerId);
-                    console.log(result);
-                } catch (e) {
-                    console.error(e);
-                }
-            })();
-        - language: python
-          code: |
-            #install the api.video API client library
-            #pip install api.video
-            import apivideo
-            from apivideo.api import player_themes_api
-            from apivideo.model.not_found import NotFound
-            from pprint import pprint
+                      // void
+                      const result = await client.playerThemes.delete(playerId);
+                      console.log(result);
+                  } catch (e) {
+                      console.error(e);
+                  }
+              })();
+          - language: python
+            code: |
+              #install the api.video API client library
+              #pip install api.video
+              import apivideo
+              from apivideo.api import player_themes_api
+              from apivideo.model.not_found import NotFound
+              from pprint import pprint
 
-            # Enter a context with an instance of the API client
-            with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
-                # Create an instance of the API class
-                api_instance = player_themes_api.PlayerThemesApi(api_client)
-                player_id = "pl45d5vFFGrfdsdsd156dGhh" # str | The unique identifier for the player you want to delete.
+              # Enter a context with an instance of the API client
+              with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
+                  # Create an instance of the API class
+                  api_instance = player_themes_api.PlayerThemesApi(api_client)
+                  player_id = "pl45d5vFFGrfdsdsd156dGhh" # str | The unique identifier for the player you want to delete.
 
-                # example passing only required values which don't have defaults set
-                try:
-                    # Delete a player
-                    api_instance.delete(player_id)
-                except apivideo.ApiException as e:
-                    print("Exception when calling PlayerThemesApi->delete: %s\n" % e)
-        - language: java
-          code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.PlayerThemesApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    PlayerThemesApi apiInstance = client.playerThemes();\n    \n    String playerId = \"pl45d5vFFGrfdsdsd156dGhh\"; // The unique identifier for the player you want to delete.\n\n    try {\n      apiInstance.delete(playerId);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling PlayerThemesApi#delete\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
-        - language: csharp
-          code: |
-            //install via Nuget
-            //Install-Package ApiVideo
-            using System.Diagnostics;
-            using ApiVideo.Client;
+                  # example passing only required values which don't have defaults set
+                  try:
+                      # Delete a player
+                      api_instance.delete(player_id)
+                  except apivideo.ApiException as e:
+                      print("Exception when calling PlayerThemesApi->delete: %s\n" % e)
+          - language: java
+            code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.PlayerThemesApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    PlayerThemesApi apiInstance = client.playerThemes();\n    \n    String playerId = \"pl45d5vFFGrfdsdsd156dGhh\"; // The unique identifier for the player you want to delete.\n\n    try {\n      apiInstance.delete(playerId);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling PlayerThemesApi#delete\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
+          - language: csharp
+            code: |
+              //install via Nuget
+              //Install-Package ApiVideo
+              using System.Diagnostics;
+              using ApiVideo.Client;
 
-            namespace Example
-            {
-                public class deleteExample
-                {
-                    public static void Main()
-                    {
-                        var basePath = ApiVideoClient.Client.Environment.SANDBOX;
-                        var apiKey = "YOUR_API_KEY";
+              namespace Example
+              {
+                  public class deleteExample
+                  {
+                      public static void Main()
+                      {
+                          var basePath = ApiVideoClient.Client.Environment.SANDBOX;
+                          var apiKey = "YOUR_API_KEY";
 
-                        var apiInstance = new ApiVideoClient(apiKey,basePath);
+                          var apiInstance = new ApiVideoClient(apiKey,basePath);
 
-                        var playerId = pl45d5vFFGrfdsdsd156dGhh;  // string | The unique identifier for the player you want to delete.
-                        var apiPlayerThemesInstance = apiInstance.PlayerThemes();
-                        try
-                        {
-                            // Delete a player
-                            apiPlayerThemesInstance.delete(playerId);
-                        }
-                        catch (ApiException  e)
-                        {
-                            Debug.Print("Exception when calling PlayerThemesApi.delete: " + e.Message );
-                            Debug.Print("Status Code: "+ e.ErrorCode);
-                            Debug.Print(e.StackTrace);
-                        }
-                    }
-                }
-            }
+                          var playerId = pl45d5vFFGrfdsdsd156dGhh;  // string | The unique identifier for the player you want to delete.
+                          var apiPlayerThemesInstance = apiInstance.PlayerThemes();
+                          try
+                          {
+                              // Delete a player
+                              apiPlayerThemesInstance.delete(playerId);
+                          }
+                          catch (ApiException  e)
+                          {
+                              Debug.Print("Exception when calling PlayerThemesApi.delete: " + e.Message );
+                              Debug.Print("Status Code: "+ e.ErrorCode);
+                              Debug.Print(e.StackTrace);
+                          }
+                      }
+                  }
+              }
     patch:
       tags:
-      - Players
+        - Player Themes
       summary: Update a player
       description: 'Use a player ID to update specific details for a player. NOTE: It may take up to 10 min before the new player configuration is available from our CDN.'
       operationId: PATCH_players-playerId
       parameters:
-      - name: playerId
-        in: path
-        description: The unique identifier for the player.
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-        example: pl45d5vFFGrfdsdsd156dGhh
+        - name: playerId
+          in: path
+          description: The unique identifier for the player.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: pl45d5vFFGrfdsdsd156dGhh
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/playerUpdatePayload'
+              $ref: '#/components/schemas/player-theme-update-payload'
         required: true
       responses:
         "200":
@@ -4438,27 +4402,23 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/player'
+                $ref: '#/components/schemas/player-theme'
               examples:
                 response:
                   value:
                     playerId: pl45d5vFFGrfdsdsd156dGhh
-                    createdAt: 2020-01-13T10:09:17+00:00
-                    updatedAt: 2020-01-13T11:12:14+00:00
-                    shapeRadius: 3
-                    shapeAspect: flat
-                    shapeBackgroundTop: rgba(50, 50, 50, .7)
-                    shapeBackgroundBottom: rgba(50, 50, 50, .8)
-                    text: rgba(255, 255, 255, .95)
-                    link: rgba(255, 0, 0, .95)
-                    linkHover: rgba(255, 255, 255, .75)
-                    linkActive: rgba(255, 0, 0, .75)
-                    trackPlayed: rgba(255, 255, 255, .95)
-                    trackUnplayed: rgba(255, 255, 255, .1)
-                    trackBackground: rgba(0, 0, 0, 0)
-                    backgroundTop: rgba(72, 4, 45, 1)
-                    backgroundBottom: rgba(94, 95, 89, 1)
-                    backgroundText: rgba(255, 255, 255, .95)
+                    createdAt: '2020-01-13T10:09:17+00:00'
+                    updatedAt: '2020-01-13T11:12:14+00:00'
+                    text: 'rgba(255, 255, 255, .95)'
+                    link: 'rgba(255, 0, 0, .95)'
+                    linkHover: 'rgba(255, 255, 255, .75)'
+                    linkActive: 'rgba(255, 0, 0, .75)'
+                    trackPlayed: 'rgba(255, 255, 255, .95)'
+                    trackUnplayed: 'rgba(255, 255, 255, .1)'
+                    trackBackground: 'rgba(0, 0, 0, 0)'
+                    backgroundTop: 'rgba(72, 4, 45, 1)'
+                    backgroundBottom: 'rgba(94, 95, 89, 1)'
+                    backgroundText: 'rgba(255, 255, 255, .95)'
                     enableApi: false
                     enableControls: false
                     forceAutoplay: false
@@ -4478,49 +4438,50 @@ paths:
                     name: playerId
                     status: 404
       security:
-      - bearerAuth: []
+        - bearerAuth: []
       x-client-action: update
       x-readme:
         code-samples:
-        - language: go
-          code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    playerId := \"pl45d5vFFGrfdsdsd156dGhh\" // string | The unique identifier for the player.\n    playerThemeUpdatePayload := *apivideosdk.NewPlayerThemeUpdatePayload() // PlayerThemeUpdatePayload | \n\n    \n    res, err := client.PlayerThemes.Update(playerId, playerThemeUpdatePayload)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `PlayerThemes.Update``: %v\\n\", err)\n    }\n    // response from `Update`: PlayerTheme\n    fmt.Fprintf(os.Stdout, \"Response from `PlayerThemes.Update`: %v\\n\", res)\n}\n"
-        - language: node
-          code: "//install the module with npm or yarn\n//npm install @api.video/nodejs-client --save\n//yarn add @api.video/nodejs-client\n(async () => {\n    try {\n        const client = new ApiVideoClient({ apiKey: \"YOUR_API_TOKEN\" });\n\n        const playerId = 'pl45d5vFFGrfdsdsd156dGhh'; // The unique identifier for the player.\n        const playerThemeUpdatePayload = {\n      text: \"text_example\", // RGBA color for timer text. Default: rgba(255, 255, 255, 1)\n      link: \"link_example\", // RGBA color for all controls. Default: rgba(255, 255, 255, 1)\n      linkHover: \"linkHover_example\", // RGBA color for all controls when hovered. Default: rgba(255, 255, 255, 1)\n      trackPlayed: \"trackPlayed_example\", // RGBA color playback bar: played content. Default: rgba(88, 131, 255, .95)\n      trackUnplayed: \"trackUnplayed_example\", // RGBA color playback bar: downloaded but unplayed (buffered) content. Default: rgba(255, 255, 255, .35)\n      trackBackground: \"trackBackground_example\", // RGBA color playback bar: background. Default: rgba(255, 255, 255, .2)\n      backgroundTop: \"backgroundTop_example\", // RGBA color: top 50% of background. Default: rgba(0, 0, 0, .7)\n      backgroundBottom: \"backgroundBottom_example\", // RGBA color: bottom 50% of background. Default: rgba(0, 0, 0, .7)\n      backgroundText: \"backgroundText_example\", // RGBA color for title text. Default: rgba(255, 255, 255, 1)\n      enableApi: true, // enable/disable player SDK access. Default: true\n      enableControls: true, // enable/disable player controls. Default: true\n      forceAutoplay: true, // enable/disable player autoplay. Default: false\n      hideTitle: true, // enable/disable title. Default: false\n      forceLoop: true, // enable/disable looping. Default: false\n    }; \n\n        // PlayerTheme\n        const result = await client.playerThemes.update(playerId, playerThemeUpdatePayload);\n        console.log(result);\n    } catch (e) {\n        console.error(e);\n    }\n})();\n"
-        - language: python
-          code: "#install the api.video API client library\n#pip install api.video\nimport apivideo\nfrom apivideo.api import player_themes_api\nfrom apivideo.model.not_found import NotFound\nfrom apivideo.model.player_theme import PlayerTheme\nfrom apivideo.model.player_theme_update_payload import PlayerThemeUpdatePayload\nfrom pprint import pprint\n\n# Enter a context with an instance of the API client\nwith apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:\n    # Create an instance of the API class\n    api_instance = player_themes_api.PlayerThemesApi(api_client)\n    player_id = \"pl45d5vFFGrfdsdsd156dGhh\" # str | The unique identifier for the player.\n    player_theme_update_payload = PlayerThemeUpdatePayload(\n        text=\"text_example\",\n        link=\"link_example\",\n        link_hover=\"link_hover_example\",\n        track_played=\"track_played_example\",\n        track_unplayed=\"track_unplayed_example\",\n        track_background=\"track_background_example\",\n        background_top=\"background_top_example\",\n        background_bottom=\"background_bottom_example\",\n        background_text=\"background_text_example\",\n        enable_api=True,\n        enable_controls=True,\n        force_autoplay=True,\n        hide_title=True,\n        force_loop=True,\n    ) # PlayerThemeUpdatePayload | \n\n    # example passing only required values which don't have defaults set\n    try:\n        # Update a player\n        api_response = api_instance.update(player_id, player_theme_update_payload)\n        pprint(api_response)\n    except apivideo.ApiException as e:\n        print(\"Exception when calling PlayerThemesApi->update: %s\\n\" % e)\n"
-        - language: java
-          code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.PlayerThemesApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    PlayerThemesApi apiInstance = client.playerThemes();\n    \n    String playerId = \"pl45d5vFFGrfdsdsd156dGhh\"; // The unique identifier for the player.\n    PlayerThemeUpdatePayload playerThemeUpdatePayload = new PlayerThemeUpdatePayload(); // \n    playerThemeUpdatePayload.setText(\"\"null\"\"); // RGBA color for timer text. Default: rgba(255, 255, 255, 1)\n    playerThemeUpdatePayload.setLink(\"\"null\"\"); // RGBA color for all controls. Default: rgba(255, 255, 255, 1)\n    playerThemeUpdatePayload.setLinkHover(\"\"null\"\"); // RGBA color for all controls when hovered. Default: rgba(255, 255, 255, 1)\n    playerThemeUpdatePayload.setTrackPlayed(\"\"null\"\"); // RGBA color playback bar: played content. Default: rgba(88, 131, 255, .95)\n    playerThemeUpdatePayload.setTrackUnplayed(\"\"null\"\"); // RGBA color playback bar: downloaded but unplayed (buffered) content. Default: rgba(255, 255, 255, .35)\n    playerThemeUpdatePayload.setTrackBackground(\"\"null\"\"); // RGBA color playback bar: background. Default: rgba(255, 255, 255, .2)\n    playerThemeUpdatePayload.setBackgroundTop(\"\"null\"\"); // RGBA color: top 50% of background. Default: rgba(0, 0, 0, .7)\n    playerThemeUpdatePayload.setBackgroundBottom(\"\"null\"\"); // RGBA color: bottom 50% of background. Default: rgba(0, 0, 0, .7)\n    playerThemeUpdatePayload.setBackgroundText(\"\"null\"\"); // RGBA color for title text. Default: rgba(255, 255, 255, 1)\n    playerThemeUpdatePayload.setEnableApi(); // enable/disable player SDK access. Default: true\n    playerThemeUpdatePayload.setEnableControls(); // enable/disable player controls. Default: true\n    playerThemeUpdatePayload.setForceAutoplay(); // enable/disable player autoplay. Default: false\n    playerThemeUpdatePayload.setHideTitle(); // enable/disable title. Default: false\n    playerThemeUpdatePayload.setForceLoop(); // enable/disable looping. Default: false\n\n\n    try {\n      PlayerTheme result = apiInstance.update(playerId, playerThemeUpdatePayload);\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling PlayerThemesApi#update\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
-        - language: csharp
-          code: "//install via Nuget\n//Install-Package ApiVideo\nusing System.Diagnostics;\nusing ApiVideo.Client;\n\nnamespace Example\n{\n    public class updateExample\n    {\n        public static void Main()\n        {\n            var basePath = ApiVideoClient.Client.Environment.SANDBOX;\n            var apiKey = \"YOUR_API_KEY\";\n\n            var apiInstance = new ApiVideoClient(apiKey,basePath);\n\n            var playerId = pl45d5vFFGrfdsdsd156dGhh;  // string | The unique identifier for the player.\n            var playerThemeUpdatePayload = new PlayerThemeUpdatePayload(); // PlayerThemeUpdatePayload | \n            var apiPlayerThemesInstance = apiInstance.PlayerThemes();\n            try\n            {\n                // Update a player\n                PlayerTheme result = apiPlayerThemesInstance.update(playerId, playerThemeUpdatePayload);\n                Debug.WriteLine(result);\n            }\n            catch (ApiException  e)\n            {\n                Debug.Print(\"Exception when calling PlayerThemesApi.update: \" + e.Message );\n                Debug.Print(\"Status Code: \"+ e.ErrorCode);\n                Debug.Print(e.StackTrace);\n            }\n        }\n    }\n}\n"
+          - language: go
+            code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    playerId := \"pl45d5vFFGrfdsdsd156dGhh\" // string | The unique identifier for the player.\n    playerThemeUpdatePayload := *apivideosdk.NewPlayerThemeUpdatePayload() // PlayerThemeUpdatePayload | \n\n    \n    res, err := client.PlayerThemes.Update(playerId, playerThemeUpdatePayload)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `PlayerThemes.Update``: %v\\n\", err)\n    }\n    // response from `Update`: PlayerTheme\n    fmt.Fprintf(os.Stdout, \"Response from `PlayerThemes.Update`: %v\\n\", res)\n}\n"
+          - language: node
+            code: "//install the module with npm or yarn\n//npm install @api.video/nodejs-client --save\n//yarn add @api.video/nodejs-client\n(async () => {\n    try {\n        const client = new ApiVideoClient({ apiKey: \"YOUR_API_TOKEN\" });\n\n        const playerId = 'pl45d5vFFGrfdsdsd156dGhh'; // The unique identifier for the player.\n        const playerThemeUpdatePayload = {\n      text: \"text_example\", // RGBA color for timer text. Default: rgba(255, 255, 255, 1)\n      link: \"link_example\", // RGBA color for all controls. Default: rgba(255, 255, 255, 1)\n      linkHover: \"linkHover_example\", // RGBA color for all controls when hovered. Default: rgba(255, 255, 255, 1)\n      trackPlayed: \"trackPlayed_example\", // RGBA color playback bar: played content. Default: rgba(88, 131, 255, .95)\n      trackUnplayed: \"trackUnplayed_example\", // RGBA color playback bar: downloaded but unplayed (buffered) content. Default: rgba(255, 255, 255, .35)\n      trackBackground: \"trackBackground_example\", // RGBA color playback bar: background. Default: rgba(255, 255, 255, .2)\n      backgroundTop: \"backgroundTop_example\", // RGBA color: top 50% of background. Default: rgba(0, 0, 0, .7)\n      backgroundBottom: \"backgroundBottom_example\", // RGBA color: bottom 50% of background. Default: rgba(0, 0, 0, .7)\n      backgroundText: \"backgroundText_example\", // RGBA color for title text. Default: rgba(255, 255, 255, 1)\n      enableApi: true, // enable/disable player SDK access. Default: true\n      enableControls: true, // enable/disable player controls. Default: true\n      forceAutoplay: true, // enable/disable player autoplay. Default: false\n      hideTitle: true, // enable/disable title. Default: false\n      forceLoop: true, // enable/disable looping. Default: false\n    }; \n\n        // PlayerTheme\n        const result = await client.playerThemes.update(playerId, playerThemeUpdatePayload);\n        console.log(result);\n    } catch (e) {\n        console.error(e);\n    }\n})();\n"
+          - language: python
+            code: "#install the api.video API client library\n#pip install api.video\nimport apivideo\nfrom apivideo.api import player_themes_api\nfrom apivideo.model.not_found import NotFound\nfrom apivideo.model.player_theme import PlayerTheme\nfrom apivideo.model.player_theme_update_payload import PlayerThemeUpdatePayload\nfrom pprint import pprint\n\n# Enter a context with an instance of the API client\nwith apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:\n    # Create an instance of the API class\n    api_instance = player_themes_api.PlayerThemesApi(api_client)\n    player_id = \"pl45d5vFFGrfdsdsd156dGhh\" # str | The unique identifier for the player.\n    player_theme_update_payload = PlayerThemeUpdatePayload(\n        text=\"text_example\",\n        link=\"link_example\",\n        link_hover=\"link_hover_example\",\n        track_played=\"track_played_example\",\n        track_unplayed=\"track_unplayed_example\",\n        track_background=\"track_background_example\",\n        background_top=\"background_top_example\",\n        background_bottom=\"background_bottom_example\",\n        background_text=\"background_text_example\",\n        enable_api=True,\n        enable_controls=True,\n        force_autoplay=True,\n        hide_title=True,\n        force_loop=True,\n    ) # PlayerThemeUpdatePayload | \n\n    # example passing only required values which don't have defaults set\n    try:\n        # Update a player\n        api_response = api_instance.update(player_id, player_theme_update_payload)\n        pprint(api_response)\n    except apivideo.ApiException as e:\n        print(\"Exception when calling PlayerThemesApi->update: %s\\n\" % e)\n"
+          - language: java
+            code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.PlayerThemesApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    PlayerThemesApi apiInstance = client.playerThemes();\n    \n    String playerId = \"pl45d5vFFGrfdsdsd156dGhh\"; // The unique identifier for the player.\n    PlayerThemeUpdatePayload playerThemeUpdatePayload = new PlayerThemeUpdatePayload(); // \n    playerThemeUpdatePayload.setText(\"\"null\"\"); // RGBA color for timer text. Default: rgba(255, 255, 255, 1)\n    playerThemeUpdatePayload.setLink(\"\"null\"\"); // RGBA color for all controls. Default: rgba(255, 255, 255, 1)\n    playerThemeUpdatePayload.setLinkHover(\"\"null\"\"); // RGBA color for all controls when hovered. Default: rgba(255, 255, 255, 1)\n    playerThemeUpdatePayload.setTrackPlayed(\"\"null\"\"); // RGBA color playback bar: played content. Default: rgba(88, 131, 255, .95)\n    playerThemeUpdatePayload.setTrackUnplayed(\"\"null\"\"); // RGBA color playback bar: downloaded but unplayed (buffered) content. Default: rgba(255, 255, 255, .35)\n    playerThemeUpdatePayload.setTrackBackground(\"\"null\"\"); // RGBA color playback bar: background. Default: rgba(255, 255, 255, .2)\n    playerThemeUpdatePayload.setBackgroundTop(\"\"null\"\"); // RGBA color: top 50% of background. Default: rgba(0, 0, 0, .7)\n    playerThemeUpdatePayload.setBackgroundBottom(\"\"null\"\"); // RGBA color: bottom 50% of background. Default: rgba(0, 0, 0, .7)\n    playerThemeUpdatePayload.setBackgroundText(\"\"null\"\"); // RGBA color for title text. Default: rgba(255, 255, 255, 1)\n    playerThemeUpdatePayload.setEnableApi(); // enable/disable player SDK access. Default: true\n    playerThemeUpdatePayload.setEnableControls(); // enable/disable player controls. Default: true\n    playerThemeUpdatePayload.setForceAutoplay(); // enable/disable player autoplay. Default: false\n    playerThemeUpdatePayload.setHideTitle(); // enable/disable title. Default: false\n    playerThemeUpdatePayload.setForceLoop(); // enable/disable looping. Default: false\n\n\n    try {\n      PlayerTheme result = apiInstance.update(playerId, playerThemeUpdatePayload);\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling PlayerThemesApi#update\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
+          - language: csharp
+            code: "//install via Nuget\n//Install-Package ApiVideo\nusing System.Diagnostics;\nusing ApiVideo.Client;\n\nnamespace Example\n{\n    public class updateExample\n    {\n        public static void Main()\n        {\n            var basePath = ApiVideoClient.Client.Environment.SANDBOX;\n            var apiKey = \"YOUR_API_KEY\";\n\n            var apiInstance = new ApiVideoClient(apiKey,basePath);\n\n            var playerId = pl45d5vFFGrfdsdsd156dGhh;  // string | The unique identifier for the player.\n            var playerThemeUpdatePayload = new PlayerThemeUpdatePayload(); // PlayerThemeUpdatePayload | \n            var apiPlayerThemesInstance = apiInstance.PlayerThemes();\n            try\n            {\n                // Update a player\n                PlayerTheme result = apiPlayerThemesInstance.update(playerId, playerThemeUpdatePayload);\n                Debug.WriteLine(result);\n            }\n            catch (ApiException  e)\n            {\n                Debug.Print(\"Exception when calling PlayerThemesApi.update: \" + e.Message );\n                Debug.Print(\"Status Code: \"+ e.ErrorCode);\n                Debug.Print(e.StackTrace);\n            }\n        }\n    }\n}\n"
   /players/{playerId}/logo:
     post:
       tags:
-      - Players
+        - Player Themes
       summary: Upload a logo
       description: The uploaded image maximum size should be 200x100 and its weight should be 200KB.  It will be scaled down to 30px height and converted to PNG to be displayed in the player.
       operationId: POST_players-playerId-logo
       parameters:
-      - name: playerId
-        in: path
-        description: The unique identifier for the player.
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-        example: pl14Db6oMJRH6SRVoOwORacK
+        - name: playerId
+          in: path
+          description: The unique identifier for the player.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: pl14Db6oMJRH6SRVoOwORacK
       requestBody:
+        required: true
         content:
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/players-upload-logo-payload'
+              $ref: '#/components/schemas/player-theme-upload-logo-payload'
       responses:
         "201":
           description: Created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/player'
+                $ref: '#/components/schemas/player-theme'
         "400":
           description: Bad Request
           content:
@@ -4548,93 +4509,89 @@ paths:
                     name: playerId
                     status: 404
       security:
-      - bearerAuth: []
+        - bearerAuth: []
       x-client-action: uploadLogo
       x-readme:
         code-samples:
-        - language: go
-          code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    playerId := \"pl14Db6oMJRH6SRVoOwORacK\" // string | The unique identifier for the player.\n    file := os.NewFile(1234, \"some_file\") // *os.File | The name of the file you want to use for your logo.\n    link := \"link_example\" // string | A public link that you want to advertise in your player. For example, you could add a link to your company. When a viewer clicks on your logo, they will be taken to this address.\n\n    \n    res, err := client.PlayerThemes.UploadLogoFile(playerId, file)\n\n    // you can also use a Reader instead of a File:\n    // client.PlayerThemes.UploadLogo(playerId, fileName, fileReader)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `PlayerThemes.UploadLogo``: %v\\n\", err)\n    }\n    // response from `UploadLogo`: PlayerTheme\n    fmt.Fprintf(os.Stdout, \"Response from `PlayerThemes.UploadLogo`: %v\\n\", res)\n}\n"
-        - language: node
-          code: |
-            //install the module with npm or yarn
-            //npm install @api.video/nodejs-client --save
-            //yarn add @api.video/nodejs-client
-            (async () => {
-                try {
-                    const client = new ApiVideoClient({ apiKey: "YOUR_API_TOKEN" });
+          - language: go
+            code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    playerId := \"pl14Db6oMJRH6SRVoOwORacK\" // string | The unique identifier for the player.\n    file := os.NewFile(1234, \"some_file\") // *os.File | The name of the file you want to use for your logo.\n    link := \"link_example\" // string | A public link that you want to advertise in your player. For example, you could add a link to your company. When a viewer clicks on your logo, they will be taken to this address.\n\n    \n    res, err := client.PlayerThemes.UploadLogoFile(playerId, file)\n\n    // you can also use a Reader instead of a File:\n    // client.PlayerThemes.UploadLogo(playerId, fileName, fileReader)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `PlayerThemes.UploadLogo``: %v\\n\", err)\n    }\n    // response from `UploadLogo`: PlayerTheme\n    fmt.Fprintf(os.Stdout, \"Response from `PlayerThemes.UploadLogo`: %v\\n\", res)\n}\n"
+          - language: node
+            code: |
+              //install the module with npm or yarn
+              //npm install @api.video/nodejs-client --save
+              //yarn add @api.video/nodejs-client
+              (async () => {
+                  try {
+                      const client = new ApiVideoClient({ apiKey: "YOUR_API_TOKEN" });
 
-                    const playerId = 'pl14Db6oMJRH6SRVoOwORacK'; // The unique identifier for the player.
-                    const file = 'BINARY_DATA_HERE'; // The name of the file you want to use for your logo.
-                    const link = 'link_example'; // A public link that you want to advertise in your player. For example, you could add a link to your company. When a viewer clicks on your logo, they will be taken to this address.
+                      const playerId = 'pl14Db6oMJRH6SRVoOwORacK'; // The unique identifier for the player.
+                      const file = 'BINARY_DATA_HERE'; // The name of the file you want to use for your logo.
+                      const link = 'link_example'; // A public link that you want to advertise in your player. For example, you could add a link to your company. When a viewer clicks on your logo, they will be taken to this address.
 
-                    // PlayerTheme
-                    const result = await client.playerThemes.uploadLogo(playerId, file, link);
-                    console.log(result);
-                } catch (e) {
-                    console.error(e);
-                }
-            })();
-        - language: python
-          code: |
-            #install the api.video API client library
-            #pip install api.video
-            import apivideo
-            from apivideo.api import player_themes_api
-            from apivideo.model.bad_request import BadRequest
-            from apivideo.model.not_found import NotFound
-            from apivideo.model.player_theme import PlayerTheme
-            from pprint import pprint
+                      // PlayerTheme
+                      const result = await client.playerThemes.uploadLogo(playerId, file, link);
+                      console.log(result);
+                  } catch (e) {
+                      console.error(e);
+                  }
+              })();
+          - language: python
+            code: |
+              #install the api.video API client library
+              #pip install api.video
+              import apivideo
+              from apivideo.api import player_themes_api
+              from apivideo.model.bad_request import BadRequest
+              from apivideo.model.not_found import NotFound
+              from apivideo.model.player_theme import PlayerTheme
+              from pprint import pprint
 
-            # Enter a context with an instance of the API client
-            with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
-                # Create an instance of the API class
-                api_instance = player_themes_api.PlayerThemesApi(api_client)
-                player_id = "pl14Db6oMJRH6SRVoOwORacK" # str | The unique identifier for the player.
-                file = open('/path/to/file', 'rb') # file_type | The name of the file you want to use for your logo.
-                link = "https://my-company.com" # str | A public link that you want to advertise in your player. For example, you could add a link to your company. When a viewer clicks on your logo, they will be taken to this address. (optional)
+              # Enter a context with an instance of the API client
+              with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
+                  # Create an instance of the API class
+                  api_instance = player_themes_api.PlayerThemesApi(api_client)
+                  player_id = "pl14Db6oMJRH6SRVoOwORacK" # str | The unique identifier for the player.
+                  file = open('/path/to/file', 'rb') # file_type | The name of the file you want to use for your logo.
+                  link = "https://my-company.com" # str | A public link that you want to advertise in your player. For example, you could add a link to your company. When a viewer clicks on your logo, they will be taken to this address. (optional)
 
-                # example passing only required values which don't have defaults set
-                try:
-                    # Upload a logo
-                    api_response = api_instance.upload_logo(player_id, file)
-                    pprint(api_response)
-                except apivideo.ApiException as e:
-                    print("Exception when calling PlayerThemesApi->upload_logo: %s\n" % e)
+                  # example passing only required values which don't have defaults set
+                  try:
+                      # Upload a logo
+                      api_response = api_instance.upload_logo(player_id, file)
+                      pprint(api_response)
+                  except apivideo.ApiException as e:
+                      print("Exception when calling PlayerThemesApi->upload_logo: %s\n" % e)
 
-                # example passing only required values which don't have defaults set
-                # and optional values
-                try:
-                    # Upload a logo
-                    api_response = api_instance.upload_logo(player_id, file, link=link)
-                    pprint(api_response)
-                except apivideo.ApiException as e:
-                    print("Exception when calling PlayerThemesApi->upload_logo: %s\n" % e)
-        - language: java
-          code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.PlayerThemesApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    PlayerThemesApi apiInstance = client.playerThemes();\n    \n    String playerId = \"pl14Db6oMJRH6SRVoOwORacK\"; // The unique identifier for the player.\n    File file = new File(\"/path/to/file\"); // The name of the file you want to use for your logo.\n    String link = \"link_example\"; // A public link that you want to advertise in your player. For example, you could add a link to your company. When a viewer clicks on your logo, they will be taken to this address.\n\n    try {\n      PlayerTheme result = apiInstance.uploadLogo(playerId, file, link);\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling PlayerThemesApi#uploadLogo\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
-        - language: csharp
-          code: "//install via Nuget\n//Install-Package ApiVideo\nusing System.Diagnostics;\nusing ApiVideo.Client;\n\nnamespace Example\n{\n    public class uploadLogoExample\n    {\n        public static void Main()\n        {\n            var basePath = ApiVideoClient.Client.Environment.SANDBOX;\n            var apiKey = \"YOUR_API_KEY\";\n\n            var apiInstance = new ApiVideoClient(apiKey,basePath);\n\n            var playerId = pl14Db6oMJRH6SRVoOwORacK;  // string | The unique identifier for the player.\n            var file = BINARY_DATA_HERE;  // System.IO.Stream | The name of the file you want to use for your logo.\n            var link = link_example;  // string | A public link that you want to advertise in your player. For example, you could add a link to your company. When a viewer clicks on your logo, they will be taken to this address. (optional) \n            var apiPlayerThemesInstance = apiInstance.PlayerThemes();\n            try\n            {\n                // Upload a logo\n                PlayerTheme result = apiPlayerThemesInstance.uploadLogo(playerId, file, link);\n                Debug.WriteLine(result);\n            }\n            catch (ApiException  e)\n            {\n                Debug.Print(\"Exception when calling PlayerThemesApi.uploadLogo: \" + e.Message );\n                Debug.Print(\"Status Code: \"+ e.ErrorCode);\n                Debug.Print(e.StackTrace);\n            }\n        }\n    }\n}\n"
+                  # example passing only required values which don't have defaults set
+                  # and optional values
+                  try:
+                      # Upload a logo
+                      api_response = api_instance.upload_logo(player_id, file, link=link)
+                      pprint(api_response)
+                  except apivideo.ApiException as e:
+                      print("Exception when calling PlayerThemesApi->upload_logo: %s\n" % e)
+          - language: java
+            code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.PlayerThemesApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    PlayerThemesApi apiInstance = client.playerThemes();\n    \n    String playerId = \"pl14Db6oMJRH6SRVoOwORacK\"; // The unique identifier for the player.\n    File file = new File(\"/path/to/file\"); // The name of the file you want to use for your logo.\n    String link = \"link_example\"; // A public link that you want to advertise in your player. For example, you could add a link to your company. When a viewer clicks on your logo, they will be taken to this address.\n\n    try {\n      PlayerTheme result = apiInstance.uploadLogo(playerId, file, link);\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling PlayerThemesApi#uploadLogo\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
+          - language: csharp
+            code: "//install via Nuget\n//Install-Package ApiVideo\nusing System.Diagnostics;\nusing ApiVideo.Client;\n\nnamespace Example\n{\n    public class uploadLogoExample\n    {\n        public static void Main()\n        {\n            var basePath = ApiVideoClient.Client.Environment.SANDBOX;\n            var apiKey = \"YOUR_API_KEY\";\n\n            var apiInstance = new ApiVideoClient(apiKey,basePath);\n\n            var playerId = pl14Db6oMJRH6SRVoOwORacK;  // string | The unique identifier for the player.\n            var file = BINARY_DATA_HERE;  // System.IO.Stream | The name of the file you want to use for your logo.\n            var link = link_example;  // string | A public link that you want to advertise in your player. For example, you could add a link to your company. When a viewer clicks on your logo, they will be taken to this address. (optional) \n            var apiPlayerThemesInstance = apiInstance.PlayerThemes();\n            try\n            {\n                // Upload a logo\n                PlayerTheme result = apiPlayerThemesInstance.uploadLogo(playerId, file, link);\n                Debug.WriteLine(result);\n            }\n            catch (ApiException  e)\n            {\n                Debug.Print(\"Exception when calling PlayerThemesApi.uploadLogo: \" + e.Message );\n                Debug.Print(\"Status Code: \"+ e.ErrorCode);\n                Debug.Print(e.StackTrace);\n            }\n        }\n    }\n}\n"
     delete:
       tags:
-      - Players
+        - Player Themes
       summary: Delete logo
       operationId: DELETE_players-playerId-logo
       parameters:
-      - name: playerId
-        in: path
-        description: The unique identifier for the player.
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-        example: pl14Db6oMJRH6SRVoOwORacK
+        - name: playerId
+          in: path
+          description: The unique identifier for the player.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: pl14Db6oMJRH6SRVoOwORacK
       responses:
         "204":
           description: No Content
-          content:
-            application/json:
-              schema:
-                type: object
         "404":
           description: Not Found
           content:
@@ -4649,144 +4606,127 @@ paths:
                     name: playerId
                     status: 404
       security:
-      - bearerAuth: []
+        - bearerAuth: []
       x-client-action: deleteLogo
       x-readme:
         code-samples:
-        - language: go
-          code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    playerId := \"pl14Db6oMJRH6SRVoOwORacK\" // string | The unique identifier for the player.\n\n    \n    err := client.PlayerThemes.DeleteLogo(playerId)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `PlayerThemes.DeleteLogo``: %v\\n\", err)\n    }\n}\n"
-        - language: node
-          code: |
-            //install the module with npm or yarn
-            //npm install @api.video/nodejs-client --save
-            //yarn add @api.video/nodejs-client
-            (async () => {
-                try {
-                    const client = new ApiVideoClient({ apiKey: "YOUR_API_TOKEN" });
+          - language: go
+            code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    playerId := \"pl14Db6oMJRH6SRVoOwORacK\" // string | The unique identifier for the player.\n\n    \n    err := client.PlayerThemes.DeleteLogo(playerId)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `PlayerThemes.DeleteLogo``: %v\\n\", err)\n    }\n}\n"
+          - language: node
+            code: |
+              //install the module with npm or yarn
+              //npm install @api.video/nodejs-client --save
+              //yarn add @api.video/nodejs-client
+              (async () => {
+                  try {
+                      const client = new ApiVideoClient({ apiKey: "YOUR_API_TOKEN" });
 
-                    const playerId = 'pl14Db6oMJRH6SRVoOwORacK'; // The unique identifier for the player.
+                      const playerId = 'pl14Db6oMJRH6SRVoOwORacK'; // The unique identifier for the player.
 
-                    // void
-                    const result = await client.playerThemes.deleteLogo(playerId);
-                    console.log(result);
-                } catch (e) {
-                    console.error(e);
-                }
-            })();
-        - language: python
-          code: |
-            #install the api.video API client library
-            #pip install api.video
-            import apivideo
-            from apivideo.api import player_themes_api
-            from apivideo.model.not_found import NotFound
-            from pprint import pprint
+                      // void
+                      const result = await client.playerThemes.deleteLogo(playerId);
+                      console.log(result);
+                  } catch (e) {
+                      console.error(e);
+                  }
+              })();
+          - language: python
+            code: |
+              #install the api.video API client library
+              #pip install api.video
+              import apivideo
+              from apivideo.api import player_themes_api
+              from apivideo.model.not_found import NotFound
+              from pprint import pprint
 
-            # Enter a context with an instance of the API client
-            with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
-                # Create an instance of the API class
-                api_instance = player_themes_api.PlayerThemesApi(api_client)
-                player_id = "pl14Db6oMJRH6SRVoOwORacK" # str | The unique identifier for the player.
+              # Enter a context with an instance of the API client
+              with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
+                  # Create an instance of the API class
+                  api_instance = player_themes_api.PlayerThemesApi(api_client)
+                  player_id = "pl14Db6oMJRH6SRVoOwORacK" # str | The unique identifier for the player.
 
-                # example passing only required values which don't have defaults set
-                try:
-                    # Delete logo
-                    api_instance.delete_logo(player_id)
-                except apivideo.ApiException as e:
-                    print("Exception when calling PlayerThemesApi->delete_logo: %s\n" % e)
-        - language: java
-          code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.PlayerThemesApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    PlayerThemesApi apiInstance = client.playerThemes();\n    \n    String playerId = \"pl14Db6oMJRH6SRVoOwORacK\"; // The unique identifier for the player.\n\n    try {\n      apiInstance.deleteLogo(playerId);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling PlayerThemesApi#deleteLogo\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
-        - language: csharp
-          code: |
-            //install via Nuget
-            //Install-Package ApiVideo
-            using System.Diagnostics;
-            using ApiVideo.Client;
+                  # example passing only required values which don't have defaults set
+                  try:
+                      # Delete logo
+                      api_instance.delete_logo(player_id)
+                  except apivideo.ApiException as e:
+                      print("Exception when calling PlayerThemesApi->delete_logo: %s\n" % e)
+          - language: java
+            code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.PlayerThemesApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    PlayerThemesApi apiInstance = client.playerThemes();\n    \n    String playerId = \"pl14Db6oMJRH6SRVoOwORacK\"; // The unique identifier for the player.\n\n    try {\n      apiInstance.deleteLogo(playerId);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling PlayerThemesApi#deleteLogo\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
+          - language: csharp
+            code: |
+              //install via Nuget
+              //Install-Package ApiVideo
+              using System.Diagnostics;
+              using ApiVideo.Client;
 
-            namespace Example
-            {
-                public class deleteLogoExample
-                {
-                    public static void Main()
-                    {
-                        var basePath = ApiVideoClient.Client.Environment.SANDBOX;
-                        var apiKey = "YOUR_API_KEY";
+              namespace Example
+              {
+                  public class deleteLogoExample
+                  {
+                      public static void Main()
+                      {
+                          var basePath = ApiVideoClient.Client.Environment.SANDBOX;
+                          var apiKey = "YOUR_API_KEY";
 
-                        var apiInstance = new ApiVideoClient(apiKey,basePath);
+                          var apiInstance = new ApiVideoClient(apiKey,basePath);
 
-                        var playerId = pl14Db6oMJRH6SRVoOwORacK;  // string | The unique identifier for the player.
-                        var apiPlayerThemesInstance = apiInstance.PlayerThemes();
-                        try
-                        {
-                            // Delete logo
-                            apiPlayerThemesInstance.deleteLogo(playerId);
-                        }
-                        catch (ApiException  e)
-                        {
-                            Debug.Print("Exception when calling PlayerThemesApi.deleteLogo: " + e.Message );
-                            Debug.Print("Status Code: "+ e.ErrorCode);
-                            Debug.Print(e.StackTrace);
-                        }
-                    }
-                }
-            }
+                          var playerId = pl14Db6oMJRH6SRVoOwORacK;  // string | The unique identifier for the player.
+                          var apiPlayerThemesInstance = apiInstance.PlayerThemes();
+                          try
+                          {
+                              // Delete logo
+                              apiPlayerThemesInstance.deleteLogo(playerId);
+                          }
+                          catch (ApiException  e)
+                          {
+                              Debug.Print("Exception when calling PlayerThemesApi.deleteLogo: " + e.Message );
+                              Debug.Print("Status Code: "+ e.ErrorCode);
+                              Debug.Print(e.StackTrace);
+                          }
+                      }
+                  }
+              }
   /analytics/videos/{videoId}:
     get:
       tags:
-      - Analytics
+        - Raw statistics
       summary: List video player sessions
       description: Retrieve all available user sessions for a specific video. Tutorials that use the [analytics endpoint](https://api.video/blog/endpoints/analytics).
       operationId: GET_analytics-videos-videoId
       parameters:
-      - name: videoId
-        in: path
-        description: The unique identifier for the video you want to retrieve session information for.
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-        example: vi4k0jvEUuaTdRAEjQ4Prklg
-      - name: period
-        in: query
-        description: "Period must have one of the following formats: \n- For a day : 2018-01-01,\n- For a week: 2018-W01, \n- For a month: 2018-01\n- For a year: 2018\nFor a range period: \n-  Date range: 2018-01-01/2018-01-15\n"
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-          format: period
-      - name: metadata
-        in: query
-        description: Metadata and [Dynamic Metadata](https://api.video/blog/endpoints/dynamic-metadata) filter. Send an array of key value pairs you want to filter sessios with.
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: array
-          items:
+        - name: videoId
+          in: path
+          description: The unique identifier for the video you want to retrieve session information for.
+          required: true
+          style: simple
+          explode: false
+          schema:
             type: string
-        example: '[{"key": "Author", "value": "John Doe"}, {"key": "Format", "value": "Tutorial"}]'
-      - name: currentPage
-        in: query
-        description: 'Choose the number of search results to return per page. Minimum value: 1'
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          default: 1
-        example: 2
-      - name: pageSize
-        in: query
-        description: Results per page. Allowed values 1-100, default is 25.
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          default: 25
-        example: 30
+          example: vi4k0jvEUuaTdRAEjQ4Prklg
+        - name: period
+          in: query
+          description: "Period must have one of the following formats: \n- For a day : 2018-01-01,\n- For a week: 2018-W01, \n- For a month: 2018-01\n- For a year: 2018\nFor a range period: \n-  Date range: 2018-01-01/2018-01-15\n"
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+            format: period
+        - name: metadata
+          in: query
+          description: Metadata and [Dynamic Metadata](https://api.video/blog/endpoints/dynamic-metadata) filter. Send an array of key value pairs you want to filter sessios with.
+          required: false
+          style: deepObject
+          x-is-deep-object: true
+          explode: true
+          schema:
+            type: object
+            additionalProperties:
+              type: string
+          example: metadata[Author]=John Doe&metadata[Format]=Tutorial
+        - $ref: '#/components/parameters/current-page'
+        - $ref: '#/components/parameters/page-size'
       responses:
         "200":
           description: Success
@@ -4798,30 +4738,30 @@ paths:
                 response:
                   value:
                     data:
-                    - session:
-                        sessionId: psEmFwGQUAXR2lFHj5nDOpy
-                        loadedAt: 2019-06-24T11:45:01.109+00
-                        endedAt: 2019-06-24T11:49:19.243+00
-                      location:
-                        country: France
-                        city: Paris
-                      referrer:
-                        url: https://api.video
-                        medium: organic
-                        source: https://google.com
-                        searchTerm: video encoding hosting and delivery
-                      device:
-                        type: desktop
-                        vendor: Dell
-                        model: unknown
-                      os:
-                        name: Microsoft Windows
-                        shortname: W10
-                        version: Windows10
-                      client:
-                        type: browser
-                        name: Firefox
-                        version: "67.0"
+                      - session:
+                          sessionId: psEmFwGQUAXR2lFHj5nDOpy
+                          loadedAt: 2019-06-24T11:45:01.109+00
+                          endedAt: 2019-06-24T11:49:19.243+00
+                        location:
+                          country: France
+                          city: Paris
+                        referrer:
+                          url: https://api.video
+                          medium: organic
+                          source: https://google.com
+                          searchTerm: video encoding hosting and delivery
+                        device:
+                          type: desktop
+                          vendor: Dell
+                          model: unknown
+                        os:
+                          name: Microsoft Windows
+                          shortname: W10
+                          version: Windows10
+                        client:
+                          type: browser
+                          name: Firefox
+                          version: "67.0"
                     pagination:
                       currentPage: 1
                       currentPageItems: 1
@@ -4829,12 +4769,12 @@ paths:
                       pagesTotal: 1
                       itemsTotal: 1
                       links:
-                      - rel: self
-                        uri: /analytics/sessions/psEmFwGQUAXR2lFHj5nDOpy?currentPage=1&pageSize=25
-                      - rel: first
-                        uri: /analytics/sessions/psEmFwGQUAXR2lFHj5nDOpy?currentPage=1&pageSize=25
-                      - rel: last
-                        uri: /analytics/sessions/psEmFwGQUAXR2lFHj5nDOpy?currentPage=1&pageSize=25
+                        - rel: self
+                          uri: /analytics/sessions/psEmFwGQUAXR2lFHj5nDOpy?currentPage=1&pageSize=25
+                        - rel: first
+                          uri: /analytics/sessions/psEmFwGQUAXR2lFHj5nDOpy?currentPage=1&pageSize=25
+                        - rel: last
+                          uri: /analytics/sessions/psEmFwGQUAXR2lFHj5nDOpy?currentPage=1&pageSize=25
         "404":
           description: Not Found
           content:
@@ -4849,104 +4789,86 @@ paths:
                     name: videoId
                     status: 404
       security:
-      - bearerAuth: []
-      x-client-action: listSessions
+        - bearerAuth: []
+      x-client-action: listVideoSessions
       x-group-parameters: true
       x-client-paginated: true
       x-readme:
         code-samples:
-        - language: go
-          code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n    req := apivideosdk.RawStatisticsApiListVideoSessionsRequest{}\n    \n    req.VideoId(\"vi4k0jvEUuaTdRAEjQ4Prklg\") // string | The unique identifier for the video you want to retrieve session information for.\n    req.Period(\"period_example\") // string | Period must have one of the following formats:  - For a day : 2018-01-01, - For a week: 2018-W01, - For a month: 2018-01 - For a year: 2018  For a range period: -  Date range: 2018-01-01/2018-01-15 \n    req.Metadata(map[string]string{\"key\": \"Inner_example\"}) // map[string]string | Metadata and Dynamic Metadata filter. Send an array of key value pairs you want to filter sessios with.\n    req.CurrentPage(int32(2)) // int32 | Choose the number of search results to return per page. Minimum value: 1 (default to 1)\n    req.PageSize(int32(30)) // int32 | Results per page. Allowed values 1-100, default is 25. (default to 25)\n\n    res, err := client.RawStatistics.ListVideoSessions(videoId string, req)\n    \n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `RawStatistics.ListVideoSessions``: %v\\n\", err)\n    }\n    // response from `ListVideoSessions`: RawStatisticsListSessionsResponse\n    fmt.Fprintf(os.Stdout, \"Response from `RawStatistics.ListVideoSessions`: %v\\n\", res)\n}\n"
-        - language: node
-          code: "//install the module with npm or yarn\n//npm install @api.video/nodejs-client --save\n//yarn add @api.video/nodejs-client\n(async () => {\n    try {\n        const client = new ApiVideoClient({ apiKey: \"YOUR_API_TOKEN\" });\n\n        const videoId = 'vi4k0jvEUuaTdRAEjQ4Prklg'; // The unique identifier for the video you want to retrieve session information for.\n        const period = 'period_example'; // Period must have one of the following formats:  - For a day : 2018-01-01, - For a week: 2018-W01, - For a month: 2018-01 - For a year: 2018  For a range period: -  Date range: 2018-01-01/2018-01-15 \n        const metadata = 'metadata[Author]=John Doe&metadata[Format]=Tutorial'; // Metadata and Dynamic Metadata filter. Send an array of key value pairs you want to filter sessios with.\n        const currentPage = '2'; // Choose the number of search results to return per page. Minimum value: 1\n        const pageSize = '30'; // Results per page. Allowed values 1-100, default is 25.\n\n        // RawStatisticsListSessionsResponse\n        const result = await client.rawStatistics.listVideoSessions({ videoId, period, metadata, currentPage, pageSize })\n        console.log(result);\n    } catch (e) {\n        console.error(e);\n    }\n})();\n"
-        - language: python
-          code: |
-            #install the api.video API client library
-            #pip install api.video
-            import apivideo
-            from apivideo.api import raw_statistics_api
-            from apivideo.model.not_found import NotFound
-            from apivideo.model.raw_statistics_list_sessions_response import RawStatisticsListSessionsResponse
-            from pprint import pprint
+          - language: go
+            code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n    req := apivideosdk.RawStatisticsApiListVideoSessionsRequest{}\n    \n    req.VideoId(\"vi4k0jvEUuaTdRAEjQ4Prklg\") // string | The unique identifier for the video you want to retrieve session information for.\n    req.Period(\"period_example\") // string | Period must have one of the following formats:  - For a day : 2018-01-01, - For a week: 2018-W01, - For a month: 2018-01 - For a year: 2018  For a range period: -  Date range: 2018-01-01/2018-01-15 \n    req.Metadata(map[string]string{\"key\": \"Inner_example\"}) // map[string]string | Metadata and Dynamic Metadata filter. Send an array of key value pairs you want to filter sessios with.\n    req.CurrentPage(int32(2)) // int32 | Choose the number of search results to return per page. Minimum value: 1 (default to 1)\n    req.PageSize(int32(30)) // int32 | Results per page. Allowed values 1-100, default is 25. (default to 25)\n\n    res, err := client.RawStatistics.ListVideoSessions(videoId string, req)\n    \n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `RawStatistics.ListVideoSessions``: %v\\n\", err)\n    }\n    // response from `ListVideoSessions`: RawStatisticsListSessionsResponse\n    fmt.Fprintf(os.Stdout, \"Response from `RawStatistics.ListVideoSessions`: %v\\n\", res)\n}\n"
+          - language: node
+            code: "//install the module with npm or yarn\n//npm install @api.video/nodejs-client --save\n//yarn add @api.video/nodejs-client\n(async () => {\n    try {\n        const client = new ApiVideoClient({ apiKey: \"YOUR_API_TOKEN\" });\n\n        const videoId = 'vi4k0jvEUuaTdRAEjQ4Prklg'; // The unique identifier for the video you want to retrieve session information for.\n        const period = 'period_example'; // Period must have one of the following formats:  - For a day : 2018-01-01, - For a week: 2018-W01, - For a month: 2018-01 - For a year: 2018  For a range period: -  Date range: 2018-01-01/2018-01-15 \n        const metadata = 'metadata[Author]=John Doe&metadata[Format]=Tutorial'; // Metadata and Dynamic Metadata filter. Send an array of key value pairs you want to filter sessios with.\n        const currentPage = '2'; // Choose the number of search results to return per page. Minimum value: 1\n        const pageSize = '30'; // Results per page. Allowed values 1-100, default is 25.\n\n        // RawStatisticsListSessionsResponse\n        const result = await client.rawStatistics.listVideoSessions({ videoId, period, metadata, currentPage, pageSize })\n        console.log(result);\n    } catch (e) {\n        console.error(e);\n    }\n})();\n"
+          - language: python
+            code: |
+              #install the api.video API client library
+              #pip install api.video
+              import apivideo
+              from apivideo.api import raw_statistics_api
+              from apivideo.model.not_found import NotFound
+              from apivideo.model.raw_statistics_list_sessions_response import RawStatisticsListSessionsResponse
+              from pprint import pprint
 
-            # Enter a context with an instance of the API client
-            with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
-                # Create an instance of the API class
-                api_instance = raw_statistics_api.RawStatisticsApi(api_client)
-                video_id = "vi4k0jvEUuaTdRAEjQ4Prklg" # str | The unique identifier for the video you want to retrieve session information for.
-                period = "period_example" # str | Period must have one of the following formats:  - For a day : 2018-01-01, - For a week: 2018-W01, - For a month: 2018-01 - For a year: 2018  For a range period: -  Date range: 2018-01-01/2018-01-15  (optional)
-                metadata = {
-                    "key": "key_example",
-                } # {str: (str,)} | Metadata and Dynamic Metadata filter. Send an array of key value pairs you want to filter sessios with. (optional)
-                current_page = 2 # int | Choose the number of search results to return per page. Minimum value: 1 (optional) if omitted the server will use the default value of 1
-                page_size = 30 # int | Results per page. Allowed values 1-100, default is 25. (optional) if omitted the server will use the default value of 25
+              # Enter a context with an instance of the API client
+              with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
+                  # Create an instance of the API class
+                  api_instance = raw_statistics_api.RawStatisticsApi(api_client)
+                  video_id = "vi4k0jvEUuaTdRAEjQ4Prklg" # str | The unique identifier for the video you want to retrieve session information for.
+                  period = "period_example" # str | Period must have one of the following formats:  - For a day : 2018-01-01, - For a week: 2018-W01, - For a month: 2018-01 - For a year: 2018  For a range period: -  Date range: 2018-01-01/2018-01-15  (optional)
+                  metadata = {
+                      "key": "key_example",
+                  } # {str: (str,)} | Metadata and Dynamic Metadata filter. Send an array of key value pairs you want to filter sessios with. (optional)
+                  current_page = 2 # int | Choose the number of search results to return per page. Minimum value: 1 (optional) if omitted the server will use the default value of 1
+                  page_size = 30 # int | Results per page. Allowed values 1-100, default is 25. (optional) if omitted the server will use the default value of 25
 
-                # example passing only required values which don't have defaults set
-                try:
-                    # List video player sessions
-                    api_response = api_instance.list_video_sessions(video_id)
-                    pprint(api_response)
-                except apivideo.ApiException as e:
-                    print("Exception when calling RawStatisticsApi->list_video_sessions: %s\n" % e)
+                  # example passing only required values which don't have defaults set
+                  try:
+                      # List video player sessions
+                      api_response = api_instance.list_video_sessions(video_id)
+                      pprint(api_response)
+                  except apivideo.ApiException as e:
+                      print("Exception when calling RawStatisticsApi->list_video_sessions: %s\n" % e)
 
-                # example passing only required values which don't have defaults set
-                # and optional values
-                try:
-                    # List video player sessions
-                    api_response = api_instance.list_video_sessions(video_id, period=period, metadata=metadata, current_page=current_page, page_size=page_size)
-                    pprint(api_response)
-                except apivideo.ApiException as e:
-                    print("Exception when calling RawStatisticsApi->list_video_sessions: %s\n" % e)
-        - language: java
-          code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.RawStatisticsApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    RawStatisticsApi apiInstance = client.rawStatistics();\n    \n    String videoId = \"vi4k0jvEUuaTdRAEjQ4Prklg\"; // The unique identifier for the video you want to retrieve session information for.\n    String period = \"period_example\"; // Period must have one of the following formats:  - For a day : 2018-01-01, - For a week: 2018-W01, - For a month: 2018-01 - For a year: 2018  For a range period: -  Date range: 2018-01-01/2018-01-15 \n    Map<String, String> metadata = new HashMap(); // Metadata and Dynamic Metadata filter. Send an array of key value pairs you want to filter sessios with.\n    Integer currentPage = 1; // Choose the number of search results to return per page. Minimum value: 1\n    Integer pageSize = 25; // Results per page. Allowed values 1-100, default is 25.\n\n    try {\n      Page<VideoSession> result = apiInstance.listVideoSessions(videoId)\n            .period(period)\n            .metadata(metadata)\n            .currentPage(currentPage)\n            .pageSize(pageSize)\n            .execute();\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling RawStatisticsApi#listVideoSessions\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
-        - language: csharp
-          code: "//install via Nuget\n//Install-Package ApiVideo\nusing System.Diagnostics;\nusing ApiVideo.Client;\n\nnamespace Example\n{\n    public class listVideoSessionsExample\n    {\n        public static void Main()\n        {\n            var basePath = ApiVideoClient.Client.Environment.SANDBOX;\n            var apiKey = \"YOUR_API_KEY\";\n\n            var apiInstance = new ApiVideoClient(apiKey,basePath);\n\n            var videoId = vi4k0jvEUuaTdRAEjQ4Prklg;  // string | The unique identifier for the video you want to retrieve session information for.\n            var period = period_example;  // string | Period must have one of the following formats:  - For a day : 2018-01-01, - For a week: 2018-W01, - For a month: 2018-01 - For a year: 2018  For a range period: -  Date range: 2018-01-01/2018-01-15  (optional) \n            var metadata = new Dictionary<string, string>(); // Dictionary<string, string> | Metadata and Dynamic Metadata filter. Send an array of key value pairs you want to filter sessios with. (optional) \n            var currentPage = 2;  // int? | Choose the number of search results to return per page. Minimum value: 1 (optional)  (default to 1)\n            var pageSize = 30;  // int? | Results per page. Allowed values 1-100, default is 25. (optional)  (default to 25)\n            var apiRawStatisticsInstance = apiInstance.RawStatistics();\n            try\n            {\n                // List video player sessions\n                RawStatisticsListSessionsResponse result = apiRawStatisticsInstance.listVideoSessions(videoId, period, metadata, currentPage, pageSize);\n                Debug.WriteLine(result);\n            }\n            catch (ApiException  e)\n            {\n                Debug.Print(\"Exception when calling RawStatisticsApi.listVideoSessions: \" + e.Message );\n                Debug.Print(\"Status Code: \"+ e.ErrorCode);\n                Debug.Print(e.StackTrace);\n            }\n        }\n    }\n}\n"
+                  # example passing only required values which don't have defaults set
+                  # and optional values
+                  try:
+                      # List video player sessions
+                      api_response = api_instance.list_video_sessions(video_id, period=period, metadata=metadata, current_page=current_page, page_size=page_size)
+                      pprint(api_response)
+                  except apivideo.ApiException as e:
+                      print("Exception when calling RawStatisticsApi->list_video_sessions: %s\n" % e)
+          - language: java
+            code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.RawStatisticsApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    RawStatisticsApi apiInstance = client.rawStatistics();\n    \n    String videoId = \"vi4k0jvEUuaTdRAEjQ4Prklg\"; // The unique identifier for the video you want to retrieve session information for.\n    String period = \"period_example\"; // Period must have one of the following formats:  - For a day : 2018-01-01, - For a week: 2018-W01, - For a month: 2018-01 - For a year: 2018  For a range period: -  Date range: 2018-01-01/2018-01-15 \n    Map<String, String> metadata = new HashMap(); // Metadata and Dynamic Metadata filter. Send an array of key value pairs you want to filter sessios with.\n    Integer currentPage = 1; // Choose the number of search results to return per page. Minimum value: 1\n    Integer pageSize = 25; // Results per page. Allowed values 1-100, default is 25.\n\n    try {\n      Page<VideoSession> result = apiInstance.listVideoSessions(videoId)\n            .period(period)\n            .metadata(metadata)\n            .currentPage(currentPage)\n            .pageSize(pageSize)\n            .execute();\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling RawStatisticsApi#listVideoSessions\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
+          - language: csharp
+            code: "//install via Nuget\n//Install-Package ApiVideo\nusing System.Diagnostics;\nusing ApiVideo.Client;\n\nnamespace Example\n{\n    public class listVideoSessionsExample\n    {\n        public static void Main()\n        {\n            var basePath = ApiVideoClient.Client.Environment.SANDBOX;\n            var apiKey = \"YOUR_API_KEY\";\n\n            var apiInstance = new ApiVideoClient(apiKey,basePath);\n\n            var videoId = vi4k0jvEUuaTdRAEjQ4Prklg;  // string | The unique identifier for the video you want to retrieve session information for.\n            var period = period_example;  // string | Period must have one of the following formats:  - For a day : 2018-01-01, - For a week: 2018-W01, - For a month: 2018-01 - For a year: 2018  For a range period: -  Date range: 2018-01-01/2018-01-15  (optional) \n            var metadata = new Dictionary<string, string>(); // Dictionary<string, string> | Metadata and Dynamic Metadata filter. Send an array of key value pairs you want to filter sessios with. (optional) \n            var currentPage = 2;  // int? | Choose the number of search results to return per page. Minimum value: 1 (optional)  (default to 1)\n            var pageSize = 30;  // int? | Results per page. Allowed values 1-100, default is 25. (optional)  (default to 25)\n            var apiRawStatisticsInstance = apiInstance.RawStatistics();\n            try\n            {\n                // List video player sessions\n                RawStatisticsListSessionsResponse result = apiRawStatisticsInstance.listVideoSessions(videoId, period, metadata, currentPage, pageSize);\n                Debug.WriteLine(result);\n            }\n            catch (ApiException  e)\n            {\n                Debug.Print(\"Exception when calling RawStatisticsApi.listVideoSessions: \" + e.Message );\n                Debug.Print(\"Status Code: \"+ e.ErrorCode);\n                Debug.Print(e.StackTrace);\n            }\n        }\n    }\n}\n"
   /analytics/live-streams/{liveStreamId}:
     get:
       tags:
-      - Analytics
+        - Raw statistics
       summary: List live stream player sessions
       operationId: GET_analytics-live-streams-liveStreamId
       parameters:
-      - name: liveStreamId
-        in: path
-        description: The unique identifier for the live stream you want to retrieve analytics for.
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-        example: vi4k0jvEUuaTdRAEjQ4Jfrgz
-      - name: period
-        in: query
-        description: "Period must have one of the following formats: \n- For a day : \"2018-01-01\",\n- For a week: \"2018-W01\", \n- For a month: \"2018-01\"\n- For a year: \"2018\"\nFor a range period: \n-  Date range: \"2018-01-01/2018-01-15\"\n"
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-          format: period
-        example: 2019-01-01
-      - name: currentPage
-        in: query
-        description: 'Choose the number of search results to return per page. Minimum value: 1'
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          default: 1
-        example: 2
-      - name: pageSize
-        in: query
-        description: Results per page. Allowed values 1-100, default is 25.
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          default: 25
-        example: 30
+        - name: liveStreamId
+          in: path
+          description: The unique identifier for the live stream you want to retrieve analytics for.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: vi4k0jvEUuaTdRAEjQ4Jfrgz
+        - name: period
+          in: query
+          description: "Period must have one of the following formats: \n- For a day : \"2018-01-01\",\n- For a week: \"2018-W01\", \n- For a month: \"2018-01\"\n- For a year: \"2018\"\nFor a range period: \n-  Date range: \"2018-01-01/2018-01-15\"\n"
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+            format: period
+          example: 2019-01-01
+        - $ref: '#/components/parameters/current-page'
+        - $ref: '#/components/parameters/page-size'
       responses:
         "200":
           description: Success
@@ -4958,30 +4880,30 @@ paths:
                 response:
                   value:
                     data:
-                    - session:
-                        sessionId: ps4zRWVOv2If2vzKJLMr3jQo
-                        loadedAt: 2018-09-11T13:04:37.89+00
-                        endedAt: 2018-09-11T14:47:22.186+00
-                      location:
-                        country: France
-                        city: Paris
-                      referrer:
-                        url: unknown
-                        medium: unknown
-                        source: unknown
-                        searchTerm: unknown
-                      device:
-                        type: desktop
-                        vendor: unknown
-                        model: unknown
-                      os:
-                        name: unknown
-                        shortname: unknown
-                        version: unknown
-                      client:
-                        type: browser
-                        name: Firefox
-                        version: "61.0"
+                      - session:
+                          sessionId: ps4zRWVOv2If2vzKJLMr3jQo
+                          loadedAt: 2018-09-11T13:04:37.89+00
+                          endedAt: 2018-09-11T14:47:22.186+00
+                        location:
+                          country: France
+                          city: Paris
+                        referrer:
+                          url: unknown
+                          medium: unknown
+                          source: unknown
+                          searchTerm: unknown
+                        device:
+                          type: desktop
+                          vendor: unknown
+                          model: unknown
+                        os:
+                          name: unknown
+                          shortname: unknown
+                          version: unknown
+                        client:
+                          type: browser
+                          name: Firefox
+                          version: "61.0"
                     pagination:
                       currentPage: 1
                       currentPageItems: 1
@@ -4989,12 +4911,12 @@ paths:
                       pagesTotal: 1
                       itemsTotal: 1
                       links:
-                      - rel: self
-                        uri: /analytics/sessions/ps4zRWVOv2If2vzKJLMr3jQo?currentPage=1&pageSize=25
-                      - rel: first
-                        uri: /analytics/sessions/ps4zRWVOv2If2vzKJLMr3jQo?currentPage=1&pageSize=25
-                      - rel: last
-                        uri: /analytics/sessions/ps4zRWVOv2If2vzKJLMr3jQo?currentPage=1&pageSize=25
+                        - rel: self
+                          uri: /analytics/sessions/ps4zRWVOv2If2vzKJLMr3jQo?currentPage=1&pageSize=25
+                        - rel: first
+                          uri: /analytics/sessions/ps4zRWVOv2If2vzKJLMr3jQo?currentPage=1&pageSize=25
+                        - rel: last
+                          uri: /analytics/sessions/ps4zRWVOv2If2vzKJLMr3jQo?currentPage=1&pageSize=25
         "404":
           description: Not Found
           content:
@@ -5009,92 +4931,74 @@ paths:
                     name: liveStreamId
                     status: 404
       security:
-      - bearerAuth: []
-      x-client-action: getLiveStreamAnalytics
+        - bearerAuth: []
+      x-client-action: listLiveStreamSessions
       x-group-parameters: true
       x-client-paginated: true
       x-readme:
         code-samples:
-        - language: go
-          code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n    req := apivideosdk.RawStatisticsApiListLiveStreamSessionsRequest{}\n    \n    req.LiveStreamId(\"vi4k0jvEUuaTdRAEjQ4Jfrgz\") // string | The unique identifier for the live stream you want to retrieve analytics for.\n    req.Period(\"2019-01-01\") // string | Period must have one of the following formats:  - For a day : \\\"2018-01-01\\\", - For a week: \\\"2018-W01\\\", - For a month: \\\"2018-01\\\" - For a year: \\\"2018\\\"  For a range period: -  Date range: \\\"2018-01-01/2018-01-15\\\" \n    req.CurrentPage(int32(2)) // int32 | Choose the number of search results to return per page. Minimum value: 1 (default to 1)\n    req.PageSize(int32(30)) // int32 | Results per page. Allowed values 1-100, default is 25. (default to 25)\n\n    res, err := client.RawStatistics.ListLiveStreamSessions(liveStreamId string, req)\n    \n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `RawStatistics.ListLiveStreamSessions``: %v\\n\", err)\n    }\n    // response from `ListLiveStreamSessions`: RawStatisticsListLiveStreamAnalyticsResponse\n    fmt.Fprintf(os.Stdout, \"Response from `RawStatistics.ListLiveStreamSessions`: %v\\n\", res)\n}\n"
-        - language: node
-          code: "//install the module with npm or yarn\n//npm install @api.video/nodejs-client --save\n//yarn add @api.video/nodejs-client\n(async () => {\n    try {\n        const client = new ApiVideoClient({ apiKey: \"YOUR_API_TOKEN\" });\n\n        const liveStreamId = 'vi4k0jvEUuaTdRAEjQ4Jfrgz'; // The unique identifier for the live stream you want to retrieve analytics for.\n        const period = '2019-01-01'; // Period must have one of the following formats:  - For a day : \\\"2018-01-01\\\", - For a week: \\\"2018-W01\\\", - For a month: \\\"2018-01\\\" - For a year: \\\"2018\\\"  For a range period: -  Date range: \\\"2018-01-01/2018-01-15\\\" \n        const currentPage = '2'; // Choose the number of search results to return per page. Minimum value: 1\n        const pageSize = '30'; // Results per page. Allowed values 1-100, default is 25.\n\n        // RawStatisticsListLiveStreamAnalyticsResponse\n        const result = await client.rawStatistics.listLiveStreamSessions({ liveStreamId, period, currentPage, pageSize })\n        console.log(result);\n    } catch (e) {\n        console.error(e);\n    }\n})();\n"
-        - language: python
-          code: |
-            #install the api.video API client library
-            #pip install api.video
-            import apivideo
-            from apivideo.api import raw_statistics_api
-            from apivideo.model.raw_statistics_list_live_stream_analytics_response import RawStatisticsListLiveStreamAnalyticsResponse
-            from apivideo.model.not_found import NotFound
-            from pprint import pprint
+          - language: go
+            code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n    req := apivideosdk.RawStatisticsApiListLiveStreamSessionsRequest{}\n    \n    req.LiveStreamId(\"vi4k0jvEUuaTdRAEjQ4Jfrgz\") // string | The unique identifier for the live stream you want to retrieve analytics for.\n    req.Period(\"2019-01-01\") // string | Period must have one of the following formats:  - For a day : \\\"2018-01-01\\\", - For a week: \\\"2018-W01\\\", - For a month: \\\"2018-01\\\" - For a year: \\\"2018\\\"  For a range period: -  Date range: \\\"2018-01-01/2018-01-15\\\" \n    req.CurrentPage(int32(2)) // int32 | Choose the number of search results to return per page. Minimum value: 1 (default to 1)\n    req.PageSize(int32(30)) // int32 | Results per page. Allowed values 1-100, default is 25. (default to 25)\n\n    res, err := client.RawStatistics.ListLiveStreamSessions(liveStreamId string, req)\n    \n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `RawStatistics.ListLiveStreamSessions``: %v\\n\", err)\n    }\n    // response from `ListLiveStreamSessions`: RawStatisticsListLiveStreamAnalyticsResponse\n    fmt.Fprintf(os.Stdout, \"Response from `RawStatistics.ListLiveStreamSessions`: %v\\n\", res)\n}\n"
+          - language: node
+            code: "//install the module with npm or yarn\n//npm install @api.video/nodejs-client --save\n//yarn add @api.video/nodejs-client\n(async () => {\n    try {\n        const client = new ApiVideoClient({ apiKey: \"YOUR_API_TOKEN\" });\n\n        const liveStreamId = 'vi4k0jvEUuaTdRAEjQ4Jfrgz'; // The unique identifier for the live stream you want to retrieve analytics for.\n        const period = '2019-01-01'; // Period must have one of the following formats:  - For a day : \\\"2018-01-01\\\", - For a week: \\\"2018-W01\\\", - For a month: \\\"2018-01\\\" - For a year: \\\"2018\\\"  For a range period: -  Date range: \\\"2018-01-01/2018-01-15\\\" \n        const currentPage = '2'; // Choose the number of search results to return per page. Minimum value: 1\n        const pageSize = '30'; // Results per page. Allowed values 1-100, default is 25.\n\n        // RawStatisticsListLiveStreamAnalyticsResponse\n        const result = await client.rawStatistics.listLiveStreamSessions({ liveStreamId, period, currentPage, pageSize })\n        console.log(result);\n    } catch (e) {\n        console.error(e);\n    }\n})();\n"
+          - language: python
+            code: |
+              #install the api.video API client library
+              #pip install api.video
+              import apivideo
+              from apivideo.api import raw_statistics_api
+              from apivideo.model.raw_statistics_list_live_stream_analytics_response import RawStatisticsListLiveStreamAnalyticsResponse
+              from apivideo.model.not_found import NotFound
+              from pprint import pprint
 
-            # Enter a context with an instance of the API client
-            with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
-                # Create an instance of the API class
-                api_instance = raw_statistics_api.RawStatisticsApi(api_client)
-                live_stream_id = "vi4k0jvEUuaTdRAEjQ4Jfrgz" # str | The unique identifier for the live stream you want to retrieve analytics for.
-                period = "2019-01-01" # str | Period must have one of the following formats:  - For a day : \"2018-01-01\", - For a week: \"2018-W01\", - For a month: \"2018-01\" - For a year: \"2018\"  For a range period: -  Date range: \"2018-01-01/2018-01-15\"  (optional)
-                current_page = 2 # int | Choose the number of search results to return per page. Minimum value: 1 (optional) if omitted the server will use the default value of 1
-                page_size = 30 # int | Results per page. Allowed values 1-100, default is 25. (optional) if omitted the server will use the default value of 25
+              # Enter a context with an instance of the API client
+              with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
+                  # Create an instance of the API class
+                  api_instance = raw_statistics_api.RawStatisticsApi(api_client)
+                  live_stream_id = "vi4k0jvEUuaTdRAEjQ4Jfrgz" # str | The unique identifier for the live stream you want to retrieve analytics for.
+                  period = "2019-01-01" # str | Period must have one of the following formats:  - For a day : \"2018-01-01\", - For a week: \"2018-W01\", - For a month: \"2018-01\" - For a year: \"2018\"  For a range period: -  Date range: \"2018-01-01/2018-01-15\"  (optional)
+                  current_page = 2 # int | Choose the number of search results to return per page. Minimum value: 1 (optional) if omitted the server will use the default value of 1
+                  page_size = 30 # int | Results per page. Allowed values 1-100, default is 25. (optional) if omitted the server will use the default value of 25
 
-                # example passing only required values which don't have defaults set
-                try:
-                    # List live stream player sessions
-                    api_response = api_instance.list_live_stream_sessions(live_stream_id)
-                    pprint(api_response)
-                except apivideo.ApiException as e:
-                    print("Exception when calling RawStatisticsApi->list_live_stream_sessions: %s\n" % e)
+                  # example passing only required values which don't have defaults set
+                  try:
+                      # List live stream player sessions
+                      api_response = api_instance.list_live_stream_sessions(live_stream_id)
+                      pprint(api_response)
+                  except apivideo.ApiException as e:
+                      print("Exception when calling RawStatisticsApi->list_live_stream_sessions: %s\n" % e)
 
-                # example passing only required values which don't have defaults set
-                # and optional values
-                try:
-                    # List live stream player sessions
-                    api_response = api_instance.list_live_stream_sessions(live_stream_id, period=period, current_page=current_page, page_size=page_size)
-                    pprint(api_response)
-                except apivideo.ApiException as e:
-                    print("Exception when calling RawStatisticsApi->list_live_stream_sessions: %s\n" % e)
-        - language: java
-          code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.RawStatisticsApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    RawStatisticsApi apiInstance = client.rawStatistics();\n    \n    String liveStreamId = \"vi4k0jvEUuaTdRAEjQ4Jfrgz\"; // The unique identifier for the live stream you want to retrieve analytics for.\n    String period = \"2019-01-01\"; // Period must have one of the following formats:  - For a day : \\\"2018-01-01\\\", - For a week: \\\"2018-W01\\\", - For a month: \\\"2018-01\\\" - For a year: \\\"2018\\\"  For a range period: -  Date range: \\\"2018-01-01/2018-01-15\\\" \n    Integer currentPage = 1; // Choose the number of search results to return per page. Minimum value: 1\n    Integer pageSize = 25; // Results per page. Allowed values 1-100, default is 25.\n\n    try {\n      Page<LiveStreamSession> result = apiInstance.listLiveStreamSessions(liveStreamId)\n            .period(period)\n            .currentPage(currentPage)\n            .pageSize(pageSize)\n            .execute();\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling RawStatisticsApi#listLiveStreamSessions\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
-        - language: csharp
-          code: "//install via Nuget\n//Install-Package ApiVideo\nusing System.Diagnostics;\nusing ApiVideo.Client;\n\nnamespace Example\n{\n    public class listLiveStreamSessionsExample\n    {\n        public static void Main()\n        {\n            var basePath = ApiVideoClient.Client.Environment.SANDBOX;\n            var apiKey = \"YOUR_API_KEY\";\n\n            var apiInstance = new ApiVideoClient(apiKey,basePath);\n\n            var liveStreamId = vi4k0jvEUuaTdRAEjQ4Jfrgz;  // string | The unique identifier for the live stream you want to retrieve analytics for.\n            var period = 2019-01-01;  // string | Period must have one of the following formats:  - For a day : \\\"2018-01-01\\\", - For a week: \\\"2018-W01\\\", - For a month: \\\"2018-01\\\" - For a year: \\\"2018\\\"  For a range period: -  Date range: \\\"2018-01-01/2018-01-15\\\"  (optional) \n            var currentPage = 2;  // int? | Choose the number of search results to return per page. Minimum value: 1 (optional)  (default to 1)\n            var pageSize = 30;  // int? | Results per page. Allowed values 1-100, default is 25. (optional)  (default to 25)\n            var apiRawStatisticsInstance = apiInstance.RawStatistics();\n            try\n            {\n                // List live stream player sessions\n                RawStatisticsListLiveStreamAnalyticsResponse result = apiRawStatisticsInstance.listLiveStreamSessions(liveStreamId, period, currentPage, pageSize);\n                Debug.WriteLine(result);\n            }\n            catch (ApiException  e)\n            {\n                Debug.Print(\"Exception when calling RawStatisticsApi.listLiveStreamSessions: \" + e.Message );\n                Debug.Print(\"Status Code: \"+ e.ErrorCode);\n                Debug.Print(e.StackTrace);\n            }\n        }\n    }\n}\n"
+                  # example passing only required values which don't have defaults set
+                  # and optional values
+                  try:
+                      # List live stream player sessions
+                      api_response = api_instance.list_live_stream_sessions(live_stream_id, period=period, current_page=current_page, page_size=page_size)
+                      pprint(api_response)
+                  except apivideo.ApiException as e:
+                      print("Exception when calling RawStatisticsApi->list_live_stream_sessions: %s\n" % e)
+          - language: java
+            code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.RawStatisticsApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    RawStatisticsApi apiInstance = client.rawStatistics();\n    \n    String liveStreamId = \"vi4k0jvEUuaTdRAEjQ4Jfrgz\"; // The unique identifier for the live stream you want to retrieve analytics for.\n    String period = \"2019-01-01\"; // Period must have one of the following formats:  - For a day : \\\"2018-01-01\\\", - For a week: \\\"2018-W01\\\", - For a month: \\\"2018-01\\\" - For a year: \\\"2018\\\"  For a range period: -  Date range: \\\"2018-01-01/2018-01-15\\\" \n    Integer currentPage = 1; // Choose the number of search results to return per page. Minimum value: 1\n    Integer pageSize = 25; // Results per page. Allowed values 1-100, default is 25.\n\n    try {\n      Page<LiveStreamSession> result = apiInstance.listLiveStreamSessions(liveStreamId)\n            .period(period)\n            .currentPage(currentPage)\n            .pageSize(pageSize)\n            .execute();\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling RawStatisticsApi#listLiveStreamSessions\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
+          - language: csharp
+            code: "//install via Nuget\n//Install-Package ApiVideo\nusing System.Diagnostics;\nusing ApiVideo.Client;\n\nnamespace Example\n{\n    public class listLiveStreamSessionsExample\n    {\n        public static void Main()\n        {\n            var basePath = ApiVideoClient.Client.Environment.SANDBOX;\n            var apiKey = \"YOUR_API_KEY\";\n\n            var apiInstance = new ApiVideoClient(apiKey,basePath);\n\n            var liveStreamId = vi4k0jvEUuaTdRAEjQ4Jfrgz;  // string | The unique identifier for the live stream you want to retrieve analytics for.\n            var period = 2019-01-01;  // string | Period must have one of the following formats:  - For a day : \\\"2018-01-01\\\", - For a week: \\\"2018-W01\\\", - For a month: \\\"2018-01\\\" - For a year: \\\"2018\\\"  For a range period: -  Date range: \\\"2018-01-01/2018-01-15\\\"  (optional) \n            var currentPage = 2;  // int? | Choose the number of search results to return per page. Minimum value: 1 (optional)  (default to 1)\n            var pageSize = 30;  // int? | Results per page. Allowed values 1-100, default is 25. (optional)  (default to 25)\n            var apiRawStatisticsInstance = apiInstance.RawStatistics();\n            try\n            {\n                // List live stream player sessions\n                RawStatisticsListLiveStreamAnalyticsResponse result = apiRawStatisticsInstance.listLiveStreamSessions(liveStreamId, period, currentPage, pageSize);\n                Debug.WriteLine(result);\n            }\n            catch (ApiException  e)\n            {\n                Debug.Print(\"Exception when calling RawStatisticsApi.listLiveStreamSessions: \" + e.Message );\n                Debug.Print(\"Status Code: \"+ e.ErrorCode);\n                Debug.Print(e.StackTrace);\n            }\n        }\n    }\n}\n"
   /analytics/sessions/{sessionId}/events:
     get:
       tags:
-      - Analytics
+        - Raw statistics
       summary: List player session events
       description: Useful to track and measure video's engagement.
       operationId: GET_analytics-sessions-sessionId-events
       parameters:
-      - name: sessionId
-        in: path
-        description: A unique identifier you can use to reference and track a session with.
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-        example: psEmFwGQUAXR2lFHj5nDOpy
-      - name: currentPage
-        in: query
-        description: 'Choose the number of search results to return per page. Minimum value: 1'
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          default: 1
-        example: 2
-      - name: pageSize
-        in: query
-        description: Results per page. Allowed values 1-100, default is 25.
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          default: 25
-        example: 30
+        - name: sessionId
+          in: path
+          description: A unique identifier you can use to reference and track a session with.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: psEmFwGQUAXR2lFHj5nDOpy
+        - $ref: '#/components/parameters/current-page'
+        - $ref: '#/components/parameters/page-size'
       responses:
         "200":
           description: Success
@@ -5106,86 +5010,86 @@ paths:
                 response:
                   value:
                     data:
-                    - type: ready
-                      emittedAt: 2020-09-15T09:47:42+00:00
-                      at: 0
-                    - type: play
-                      emittedAt: 2020-09-15T21:35:57+00:00
-                      at: 0
-                    - type: pause
-                      emittedAt: 2020-09-15T21:36:05+00:00
-                      at: 7
-                    - type: resume
-                      emittedAt: 2020-09-15T21:36:19+00:00
-                      at: 21
-                    - type: seek.forward
-                      emittedAt: 2020-09-15T21:36:19+00:00
-                      from: 7
-                      to: 21
-                    - type: end
-                      emittedAt: 2020-09-15T21:36:28+00:00
-                      at: 30
-                    - type: play
-                      emittedAt: 2020-09-15T21:36:29+00:00
-                      at: 0
-                    - type: seek.backward
-                      emittedAt: 2020-09-15T21:36:29+00:00
-                      from: 30
-                      to: 0
-                    - type: pause
-                      emittedAt: 2020-09-15T21:36:29+00:00
-                      at: 21
-                    - type: resume
-                      emittedAt: 2020-09-15T21:36:30+00:00
-                      at: 21
-                    - type: seek.forward
-                      emittedAt: 2020-09-15T21:36:30+00:00
-                      from: 0
-                      to: 21
-                    - type: pause
-                      emittedAt: 2020-09-15T21:36:33+00:00
-                      at: 20
-                    - type: resume
-                      emittedAt: 2020-09-15T21:36:33+00:00
-                      at: 20
-                    - type: seek.backward
-                      emittedAt: 2020-09-15T21:36:33+00:00
-                      from: 24
-                      to: 20
-                    - type: pause
-                      emittedAt: 2020-09-15T21:36:39+00:00
-                      at: 17
-                    - type: resume
-                      emittedAt: 2020-09-15T21:36:39+00:00
-                      at: 17
-                    - type: seek.forward
-                      emittedAt: 2020-09-15T21:36:39+00:00
-                      from: 17
-                      to: 17
-                    - type: pause
-                      emittedAt: 2020-09-15T21:36:41+00:00
-                      at: 19
-                    - type: ready
-                      emittedAt: 2020-09-17T09:20:47+00:00
-                      at: 0
-                    - type: ready
-                      emittedAt: 2020-09-17T09:41:01+00:00
-                      at: 0
-                    - type: ready
-                      emittedAt: 2020-09-17T09:41:08+00:00
-                      at: 0
-                    - type: play
-                      emittedAt: 2020-09-17T09:41:10+00:00
-                      at: 0
-                    - type: pause
-                      emittedAt: 2020-09-17T09:41:12+00:00
-                      at: 1
-                    - type: resume
-                      emittedAt: 2020-09-17T09:41:13+00:00
-                      at: 1
-                    - type: pause
-                      emittedAt: 2020-09-17T09:41:15+00:00
-                      at: 3
+                      - type: ready
+                        emittedAt: 2020-09-15T09:47:42+00:00
+                        at: 0
+                      - type: play
+                        emittedAt: 2020-09-15T21:35:57+00:00
+                        at: 0
+                      - type: pause
+                        emittedAt: 2020-09-15T21:36:05+00:00
+                        at: 7
+                      - type: resume
+                        emittedAt: 2020-09-15T21:36:19+00:00
+                        at: 21
+                      - type: seek.forward
+                        emittedAt: 2020-09-15T21:36:19+00:00
+                        from: 7
+                        to: 21
+                      - type: end
+                        emittedAt: 2020-09-15T21:36:28+00:00
+                        at: 30
+                      - type: play
+                        emittedAt: 2020-09-15T21:36:29+00:00
+                        at: 0
+                      - type: seek.backward
+                        emittedAt: 2020-09-15T21:36:29+00:00
+                        from: 30
+                        to: 0
+                      - type: pause
+                        emittedAt: 2020-09-15T21:36:29+00:00
+                        at: 21
+                      - type: resume
+                        emittedAt: 2020-09-15T21:36:30+00:00
+                        at: 21
+                      - type: seek.forward
+                        emittedAt: 2020-09-15T21:36:30+00:00
+                        from: 0
+                        to: 21
+                      - type: pause
+                        emittedAt: 2020-09-15T21:36:33+00:00
+                        at: 20
+                      - type: resume
+                        emittedAt: 2020-09-15T21:36:33+00:00
+                        at: 20
+                      - type: seek.backward
+                        emittedAt: 2020-09-15T21:36:33+00:00
+                        from: 24
+                        to: 20
+                      - type: pause
+                        emittedAt: 2020-09-15T21:36:39+00:00
+                        at: 17
+                      - type: resume
+                        emittedAt: 2020-09-15T21:36:39+00:00
+                        at: 17
+                      - type: seek.forward
+                        emittedAt: 2020-09-15T21:36:39+00:00
+                        from: 17
+                        to: 17
+                      - type: pause
+                        emittedAt: 2020-09-15T21:36:41+00:00
+                        at: 19
+                      - type: ready
+                        emittedAt: 2020-09-17T09:20:47+00:00
+                        at: 0
+                      - type: ready
+                        emittedAt: 2020-09-17T09:41:01+00:00
+                        at: 0
+                      - type: ready
+                        emittedAt: 2020-09-17T09:41:08+00:00
+                        at: 0
+                      - type: play
+                        emittedAt: 2020-09-17T09:41:10+00:00
+                        at: 0
+                      - type: pause
+                        emittedAt: 2020-09-17T09:41:12+00:00
+                        at: 1
+                      - type: resume
+                        emittedAt: 2020-09-17T09:41:13+00:00
+                        at: 1
+                      - type: pause
+                        emittedAt: 2020-09-17T09:41:15+00:00
+                        at: 3
                     pagination:
                       currentPage: 1
                       currentPageItems: 25
@@ -5193,14 +5097,14 @@ paths:
                       pagesTotal: 2
                       itemsTotal: 30
                       links:
-                      - rel: self
-                        uri: /analytics/sessions/ps5ltuhfsTOeh6bP03Tq5OWc/events?currentPage=1&pageSize=25
-                      - rel: first
-                        uri: /analytics/sessions/ps5ltuhfsTOeh6bP03Tq5OWc/events?currentPage=1&pageSize=25
-                      - rel: next
-                        uri: /analytics/sessions/ps5ltuhfsTOeh6bP03Tq5OWc/events?currentPage=2&pageSize=25
-                      - rel: last
-                        uri: /analytics/sessions/ps5ltuhfsTOeh6bP03Tq5OWc/events?currentPage=2&pageSize=25
+                        - rel: self
+                          uri: /analytics/sessions/ps5ltuhfsTOeh6bP03Tq5OWc/events?currentPage=1&pageSize=25
+                        - rel: first
+                          uri: /analytics/sessions/ps5ltuhfsTOeh6bP03Tq5OWc/events?currentPage=1&pageSize=25
+                        - rel: next
+                          uri: /analytics/sessions/ps5ltuhfsTOeh6bP03Tq5OWc/events?currentPage=2&pageSize=25
+                        - rel: last
+                          uri: /analytics/sessions/ps5ltuhfsTOeh6bP03Tq5OWc/events?currentPage=2&pageSize=25
         "404":
           description: Not Found
           content:
@@ -5215,144 +5119,126 @@ paths:
                     name: videoId
                     status: 404
       security:
-      - bearerAuth: []
-      x-client-action: listPlayerSessionEvents
+        - bearerAuth: []
+      x-client-action: listSessionEvents
       x-group-parameters: true
       x-client-paginated: true
       x-readme:
         code-samples:
-        - language: go
-          code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n    req := apivideosdk.RawStatisticsApiListSessionEventsRequest{}\n    \n    req.SessionId(\"psEmFwGQUAXR2lFHj5nDOpy\") // string | A unique identifier you can use to reference and track a session with.\n    req.CurrentPage(int32(2)) // int32 | Choose the number of search results to return per page. Minimum value: 1 (default to 1)\n    req.PageSize(int32(30)) // int32 | Results per page. Allowed values 1-100, default is 25. (default to 25)\n\n    res, err := client.RawStatistics.ListSessionEvents(sessionId string, req)\n    \n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `RawStatistics.ListSessionEvents``: %v\\n\", err)\n    }\n    // response from `ListSessionEvents`: RawStatisticsListPlayerSessionEventsResponse\n    fmt.Fprintf(os.Stdout, \"Response from `RawStatistics.ListSessionEvents`: %v\\n\", res)\n}\n"
-        - language: node
-          code: |
-            //install the module with npm or yarn
-            //npm install @api.video/nodejs-client --save
-            //yarn add @api.video/nodejs-client
-            (async () => {
-                try {
-                    const client = new ApiVideoClient({ apiKey: "YOUR_API_TOKEN" });
+          - language: go
+            code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n    req := apivideosdk.RawStatisticsApiListSessionEventsRequest{}\n    \n    req.SessionId(\"psEmFwGQUAXR2lFHj5nDOpy\") // string | A unique identifier you can use to reference and track a session with.\n    req.CurrentPage(int32(2)) // int32 | Choose the number of search results to return per page. Minimum value: 1 (default to 1)\n    req.PageSize(int32(30)) // int32 | Results per page. Allowed values 1-100, default is 25. (default to 25)\n\n    res, err := client.RawStatistics.ListSessionEvents(sessionId string, req)\n    \n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `RawStatistics.ListSessionEvents``: %v\\n\", err)\n    }\n    // response from `ListSessionEvents`: RawStatisticsListPlayerSessionEventsResponse\n    fmt.Fprintf(os.Stdout, \"Response from `RawStatistics.ListSessionEvents`: %v\\n\", res)\n}\n"
+          - language: node
+            code: |
+              //install the module with npm or yarn
+              //npm install @api.video/nodejs-client --save
+              //yarn add @api.video/nodejs-client
+              (async () => {
+                  try {
+                      const client = new ApiVideoClient({ apiKey: "YOUR_API_TOKEN" });
 
-                    const sessionId = 'psEmFwGQUAXR2lFHj5nDOpy'; // A unique identifier you can use to reference and track a session with.
-                    const currentPage = '2'; // Choose the number of search results to return per page. Minimum value: 1
-                    const pageSize = '30'; // Results per page. Allowed values 1-100, default is 25.
+                      const sessionId = 'psEmFwGQUAXR2lFHj5nDOpy'; // A unique identifier you can use to reference and track a session with.
+                      const currentPage = '2'; // Choose the number of search results to return per page. Minimum value: 1
+                      const pageSize = '30'; // Results per page. Allowed values 1-100, default is 25.
 
-                    // RawStatisticsListPlayerSessionEventsResponse
-                    const result = await client.rawStatistics.listSessionEvents({ sessionId, currentPage, pageSize })
-                    console.log(result);
-                } catch (e) {
-                    console.error(e);
-                }
-            })();
-        - language: python
-          code: |
-            #install the api.video API client library
-            #pip install api.video
-            import apivideo
-            from apivideo.api import raw_statistics_api
-            from apivideo.model.not_found import NotFound
-            from apivideo.model.raw_statistics_list_player_session_events_response import RawStatisticsListPlayerSessionEventsResponse
-            from pprint import pprint
+                      // RawStatisticsListPlayerSessionEventsResponse
+                      const result = await client.rawStatistics.listSessionEvents({ sessionId, currentPage, pageSize })
+                      console.log(result);
+                  } catch (e) {
+                      console.error(e);
+                  }
+              })();
+          - language: python
+            code: |
+              #install the api.video API client library
+              #pip install api.video
+              import apivideo
+              from apivideo.api import raw_statistics_api
+              from apivideo.model.not_found import NotFound
+              from apivideo.model.raw_statistics_list_player_session_events_response import RawStatisticsListPlayerSessionEventsResponse
+              from pprint import pprint
 
-            # Enter a context with an instance of the API client
-            with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
-                # Create an instance of the API class
-                api_instance = raw_statistics_api.RawStatisticsApi(api_client)
-                session_id = "psEmFwGQUAXR2lFHj5nDOpy" # str | A unique identifier you can use to reference and track a session with.
-                current_page = 2 # int | Choose the number of search results to return per page. Minimum value: 1 (optional) if omitted the server will use the default value of 1
-                page_size = 30 # int | Results per page. Allowed values 1-100, default is 25. (optional) if omitted the server will use the default value of 25
+              # Enter a context with an instance of the API client
+              with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
+                  # Create an instance of the API class
+                  api_instance = raw_statistics_api.RawStatisticsApi(api_client)
+                  session_id = "psEmFwGQUAXR2lFHj5nDOpy" # str | A unique identifier you can use to reference and track a session with.
+                  current_page = 2 # int | Choose the number of search results to return per page. Minimum value: 1 (optional) if omitted the server will use the default value of 1
+                  page_size = 30 # int | Results per page. Allowed values 1-100, default is 25. (optional) if omitted the server will use the default value of 25
 
-                # example passing only required values which don't have defaults set
-                try:
-                    # List player session events
-                    api_response = api_instance.list_session_events(session_id)
-                    pprint(api_response)
-                except apivideo.ApiException as e:
-                    print("Exception when calling RawStatisticsApi->list_session_events: %s\n" % e)
+                  # example passing only required values which don't have defaults set
+                  try:
+                      # List player session events
+                      api_response = api_instance.list_session_events(session_id)
+                      pprint(api_response)
+                  except apivideo.ApiException as e:
+                      print("Exception when calling RawStatisticsApi->list_session_events: %s\n" % e)
 
-                # example passing only required values which don't have defaults set
-                # and optional values
-                try:
-                    # List player session events
-                    api_response = api_instance.list_session_events(session_id, current_page=current_page, page_size=page_size)
-                    pprint(api_response)
-                except apivideo.ApiException as e:
-                    print("Exception when calling RawStatisticsApi->list_session_events: %s\n" % e)
-        - language: java
-          code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.RawStatisticsApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    RawStatisticsApi apiInstance = client.rawStatistics();\n    \n    String sessionId = \"psEmFwGQUAXR2lFHj5nDOpy\"; // A unique identifier you can use to reference and track a session with.\n    Integer currentPage = 1; // Choose the number of search results to return per page. Minimum value: 1\n    Integer pageSize = 25; // Results per page. Allowed values 1-100, default is 25.\n\n    try {\n      Page<PlayerSessionEvent> result = apiInstance.listSessionEvents(sessionId)\n            .currentPage(currentPage)\n            .pageSize(pageSize)\n            .execute();\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling RawStatisticsApi#listSessionEvents\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
-        - language: csharp
-          code: |
-            //install via Nuget
-            //Install-Package ApiVideo
-            using System.Diagnostics;
-            using ApiVideo.Client;
+                  # example passing only required values which don't have defaults set
+                  # and optional values
+                  try:
+                      # List player session events
+                      api_response = api_instance.list_session_events(session_id, current_page=current_page, page_size=page_size)
+                      pprint(api_response)
+                  except apivideo.ApiException as e:
+                      print("Exception when calling RawStatisticsApi->list_session_events: %s\n" % e)
+          - language: java
+            code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.RawStatisticsApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    RawStatisticsApi apiInstance = client.rawStatistics();\n    \n    String sessionId = \"psEmFwGQUAXR2lFHj5nDOpy\"; // A unique identifier you can use to reference and track a session with.\n    Integer currentPage = 1; // Choose the number of search results to return per page. Minimum value: 1\n    Integer pageSize = 25; // Results per page. Allowed values 1-100, default is 25.\n\n    try {\n      Page<PlayerSessionEvent> result = apiInstance.listSessionEvents(sessionId)\n            .currentPage(currentPage)\n            .pageSize(pageSize)\n            .execute();\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling RawStatisticsApi#listSessionEvents\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
+          - language: csharp
+            code: |
+              //install via Nuget
+              //Install-Package ApiVideo
+              using System.Diagnostics;
+              using ApiVideo.Client;
 
-            namespace Example
-            {
-                public class listSessionEventsExample
-                {
-                    public static void Main()
-                    {
-                        var basePath = ApiVideoClient.Client.Environment.SANDBOX;
-                        var apiKey = "YOUR_API_KEY";
+              namespace Example
+              {
+                  public class listSessionEventsExample
+                  {
+                      public static void Main()
+                      {
+                          var basePath = ApiVideoClient.Client.Environment.SANDBOX;
+                          var apiKey = "YOUR_API_KEY";
 
-                        var apiInstance = new ApiVideoClient(apiKey,basePath);
+                          var apiInstance = new ApiVideoClient(apiKey,basePath);
 
-                        var sessionId = psEmFwGQUAXR2lFHj5nDOpy;  // string | A unique identifier you can use to reference and track a session with.
-                        var currentPage = 2;  // int? | Choose the number of search results to return per page. Minimum value: 1 (optional)  (default to 1)
-                        var pageSize = 30;  // int? | Results per page. Allowed values 1-100, default is 25. (optional)  (default to 25)
-                        var apiRawStatisticsInstance = apiInstance.RawStatistics();
-                        try
-                        {
-                            // List player session events
-                            RawStatisticsListPlayerSessionEventsResponse result = apiRawStatisticsInstance.listSessionEvents(sessionId, currentPage, pageSize);
-                            Debug.WriteLine(result);
-                        }
-                        catch (ApiException  e)
-                        {
-                            Debug.Print("Exception when calling RawStatisticsApi.listSessionEvents: " + e.Message );
-                            Debug.Print("Status Code: "+ e.ErrorCode);
-                            Debug.Print(e.StackTrace);
-                        }
-                    }
-                }
-            }
+                          var sessionId = psEmFwGQUAXR2lFHj5nDOpy;  // string | A unique identifier you can use to reference and track a session with.
+                          var currentPage = 2;  // int? | Choose the number of search results to return per page. Minimum value: 1 (optional)  (default to 1)
+                          var pageSize = 30;  // int? | Results per page. Allowed values 1-100, default is 25. (optional)  (default to 25)
+                          var apiRawStatisticsInstance = apiInstance.RawStatistics();
+                          try
+                          {
+                              // List player session events
+                              RawStatisticsListPlayerSessionEventsResponse result = apiRawStatisticsInstance.listSessionEvents(sessionId, currentPage, pageSize);
+                              Debug.WriteLine(result);
+                          }
+                          catch (ApiException  e)
+                          {
+                              Debug.Print("Exception when calling RawStatisticsApi.listSessionEvents: " + e.Message );
+                              Debug.Print("Status Code: "+ e.ErrorCode);
+                              Debug.Print(e.StackTrace);
+                          }
+                      }
+                  }
+              }
   /webhooks:
     get:
       tags:
-      - Webhooks
+        - Webhooks
       summary: List all webhooks
       description: Requests to this endpoint return a list of your webhooks (with all their details). You can filter what the webhook list that the API returns using the parameters described below.
       operationId: LIST-webhooks
       parameters:
-      - name: events
-        in: query
-        description: The webhook event that you wish to filter on.
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-        example: video.encoding.quality.completed
-      - name: currentPage
-        in: query
-        description: 'Choose the number of search results to return per page. Minimum value: 1'
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          default: 1
-        example: 2
-      - name: pageSize
-        in: query
-        description: Results per page. Allowed values 1-100, default is 25.
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          default: 25
-        example: 30
+        - name: events
+          in: query
+          description: The webhook event that you wish to filter on.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+          example: video.encoding.quality.completed
+        - $ref: '#/components/parameters/current-page'
+        - $ref: '#/components/parameters/page-size'
       responses:
         "200":
           description: Success
@@ -5364,16 +5250,16 @@ paths:
                 response:
                   value:
                     data:
-                    - webhookId: webhook_XXXXXXXXXXXXXXX
-                      createdAt: 2021-01-08T14:12:18.000+00:00
-                      events:
-                      - video.encoding.quality.completed
-                      url: http://clientnotificationserver.com/notif?myquery=query
-                    - webhookId: webhook_XXXXXXXXXYYYYYY
-                      createdAt: 2021-01-12T12:12:12.000+00:00
-                      events:
-                      - video.encoding.quality.completed
-                      url: http://clientnotificationserver.com/notif?myquery=query2
+                      - webhookId: webhook_XXXXXXXXXXXXXXX
+                        createdAt: 2021-01-08T14:12:18.000+00:00
+                        events:
+                          - video.encoding.quality.completed
+                        url: http://clientnotificationserver.com/notif?myquery=query
+                      - webhookId: webhook_XXXXXXXXXYYYYYY
+                        createdAt: 2021-01-12T12:12:12.000+00:00
+                        events:
+                          - video.encoding.quality.completed
+                        url: http://clientnotificationserver.com/notif?myquery=query2
                     pagination:
                       currentPage: 1
                       pageSize: 25
@@ -5381,81 +5267,83 @@ paths:
                       itemsTotal: 11
                       currentPageItems: 11
                       links:
-                      - rel: self
-                        uri: https://ws.api.video/webhooks?currentPage=1
-                      - rel: first
-                        uri: https://ws.api.video/webhooks?currentPage=1
-                      - rel: last
-                        uri: https://ws.api.video/webhooks?currentPage=1
+                        - rel: self
+                          uri: https://ws.api.video/webhooks?currentPage=1
+                        - rel: first
+                          uri: https://ws.api.video/webhooks?currentPage=1
+                        - rel: last
+                          uri: https://ws.api.video/webhooks?currentPage=1
       security:
-      - bearerAuth: []
+        - bearerAuth: []
       x-group-parameters: true
       x-client-paginated: true
+      x-optional-object: true
       x-client-action: list
       x-readme:
         code-samples:
-        - language: go
-          code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n    req := apivideosdk.WebhooksApiListRequest{}\n    \n    req.Events(\"video.encoding.quality.completed\") // string | The webhook event that you wish to filter on.\n    req.CurrentPage(int32(2)) // int32 | Choose the number of search results to return per page. Minimum value: 1 (default to 1)\n    req.PageSize(int32(30)) // int32 | Results per page. Allowed values 1-100, default is 25. (default to 25)\n\n    res, err := client.Webhooks.List(req)\n    \n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `Webhooks.List``: %v\\n\", err)\n    }\n    // response from `List`: WebhooksListResponse\n    fmt.Fprintf(os.Stdout, \"Response from `Webhooks.List`: %v\\n\", res)\n}\n"
-        - language: node
-          code: |
-            //install the module with npm or yarn
-            //npm install @api.video/nodejs-client --save
-            //yarn add @api.video/nodejs-client
-            (async () => {
-                try {
-                    const client = new ApiVideoClient({ apiKey: "YOUR_API_TOKEN" });
+          - language: go
+            code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n    req := apivideosdk.WebhooksApiListRequest{}\n    \n    req.Events(\"video.encoding.quality.completed\") // string | The webhook event that you wish to filter on.\n    req.CurrentPage(int32(2)) // int32 | Choose the number of search results to return per page. Minimum value: 1 (default to 1)\n    req.PageSize(int32(30)) // int32 | Results per page. Allowed values 1-100, default is 25. (default to 25)\n\n    res, err := client.Webhooks.List(req)\n    \n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `Webhooks.List``: %v\\n\", err)\n    }\n    // response from `List`: WebhooksListResponse\n    fmt.Fprintf(os.Stdout, \"Response from `Webhooks.List`: %v\\n\", res)\n}\n"
+          - language: node
+            code: |
+              //install the module with npm or yarn
+              //npm install @api.video/nodejs-client --save
+              //yarn add @api.video/nodejs-client
+              (async () => {
+                  try {
+                      const client = new ApiVideoClient({ apiKey: "YOUR_API_TOKEN" });
 
-                    const events = 'video.encoding.quality.completed'; // The webhook event that you wish to filter on.
-                    const currentPage = '2'; // Choose the number of search results to return per page. Minimum value: 1
-                    const pageSize = '30'; // Results per page. Allowed values 1-100, default is 25.
+                      const events = 'video.encoding.quality.completed'; // The webhook event that you wish to filter on.
+                      const currentPage = '2'; // Choose the number of search results to return per page. Minimum value: 1
+                      const pageSize = '30'; // Results per page. Allowed values 1-100, default is 25.
 
-                    // WebhooksListResponse
-                    const result = await client.webhooks.list({ events, currentPage, pageSize })
-                    console.log(result);
-                } catch (e) {
-                    console.error(e);
-                }
-            })();
-        - language: python
-          code: |
-            #install the api.video API client library
-            #pip install api.video
-            import apivideo
-            from apivideo.api import webhooks_api
-            from apivideo.model.webhooks_list_response import WebhooksListResponse
-            from pprint import pprint
+                      // WebhooksListResponse
+                      const result = await client.webhooks.list({ events, currentPage, pageSize })
+                      console.log(result);
+                  } catch (e) {
+                      console.error(e);
+                  }
+              })();
+          - language: python
+            code: |
+              #install the api.video API client library
+              #pip install api.video
+              import apivideo
+              from apivideo.api import webhooks_api
+              from apivideo.model.webhooks_list_response import WebhooksListResponse
+              from pprint import pprint
 
-            # Enter a context with an instance of the API client
-            with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
-                # Create an instance of the API class
-                api_instance = webhooks_api.WebhooksApi(api_client)
-                events = "video.encoding.quality.completed" # str | The webhook event that you wish to filter on. (optional)
-                current_page = 2 # int | Choose the number of search results to return per page. Minimum value: 1 (optional) if omitted the server will use the default value of 1
-                page_size = 30 # int | Results per page. Allowed values 1-100, default is 25. (optional) if omitted the server will use the default value of 25
+              # Enter a context with an instance of the API client
+              with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
+                  # Create an instance of the API class
+                  api_instance = webhooks_api.WebhooksApi(api_client)
+                  events = "video.encoding.quality.completed" # str | The webhook event that you wish to filter on. (optional)
+                  current_page = 2 # int | Choose the number of search results to return per page. Minimum value: 1 (optional) if omitted the server will use the default value of 1
+                  page_size = 30 # int | Results per page. Allowed values 1-100, default is 25. (optional) if omitted the server will use the default value of 25
 
-                # example passing only required values which don't have defaults set
-                # and optional values
-                try:
-                    # List all webhooks
-                    api_response = api_instance.list(events=events, current_page=current_page, page_size=page_size)
-                    pprint(api_response)
-                except apivideo.ApiException as e:
-                    print("Exception when calling WebhooksApi->list: %s\n" % e)
-        - language: java
-          code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.WebhooksApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    WebhooksApi apiInstance = client.webhooks();\n    \n    String events = \"video.encoding.quality.completed\"; // The webhook event that you wish to filter on.\n    Integer currentPage = 1; // Choose the number of search results to return per page. Minimum value: 1\n    Integer pageSize = 25; // Results per page. Allowed values 1-100, default is 25.\n\n    try {\n      Page<Webhook> result = apiInstance.list()\n            .events(events)\n            .currentPage(currentPage)\n            .pageSize(pageSize)\n            .execute();\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling WebhooksApi#list\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
-        - language: csharp
-          code: "//install via Nuget\n//Install-Package ApiVideo\nusing System.Diagnostics;\nusing ApiVideo.Client;\n\nnamespace Example\n{\n    public class listExample\n    {\n        public static void Main()\n        {\n            var basePath = ApiVideoClient.Client.Environment.SANDBOX;\n            var apiKey = \"YOUR_API_KEY\";\n\n            var apiInstance = new ApiVideoClient(apiKey,basePath);\n\n            var events = video.encoding.quality.completed;  // string | The webhook event that you wish to filter on. (optional) \n            var currentPage = 2;  // int? | Choose the number of search results to return per page. Minimum value: 1 (optional)  (default to 1)\n            var pageSize = 30;  // int? | Results per page. Allowed values 1-100, default is 25. (optional)  (default to 25)\n            var apiWebhooksInstance = apiInstance.Webhooks();\n            try\n            {\n                // List all webhooks\n                WebhooksListResponse result = apiWebhooksInstance.list(events, currentPage, pageSize);\n                Debug.WriteLine(result);\n            }\n            catch (ApiException  e)\n            {\n                Debug.Print(\"Exception when calling WebhooksApi.list: \" + e.Message );\n                Debug.Print(\"Status Code: \"+ e.ErrorCode);\n                Debug.Print(e.StackTrace);\n            }\n        }\n    }\n}\n"
+                  # example passing only required values which don't have defaults set
+                  # and optional values
+                  try:
+                      # List all webhooks
+                      api_response = api_instance.list(events=events, current_page=current_page, page_size=page_size)
+                      pprint(api_response)
+                  except apivideo.ApiException as e:
+                      print("Exception when calling WebhooksApi->list: %s\n" % e)
+          - language: java
+            code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.WebhooksApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    WebhooksApi apiInstance = client.webhooks();\n    \n    String events = \"video.encoding.quality.completed\"; // The webhook event that you wish to filter on.\n    Integer currentPage = 1; // Choose the number of search results to return per page. Minimum value: 1\n    Integer pageSize = 25; // Results per page. Allowed values 1-100, default is 25.\n\n    try {\n      Page<Webhook> result = apiInstance.list()\n            .events(events)\n            .currentPage(currentPage)\n            .pageSize(pageSize)\n            .execute();\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling WebhooksApi#list\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
+          - language: csharp
+            code: "//install via Nuget\n//Install-Package ApiVideo\nusing System.Diagnostics;\nusing ApiVideo.Client;\n\nnamespace Example\n{\n    public class listExample\n    {\n        public static void Main()\n        {\n            var basePath = ApiVideoClient.Client.Environment.SANDBOX;\n            var apiKey = \"YOUR_API_KEY\";\n\n            var apiInstance = new ApiVideoClient(apiKey,basePath);\n\n            var events = video.encoding.quality.completed;  // string | The webhook event that you wish to filter on. (optional) \n            var currentPage = 2;  // int? | Choose the number of search results to return per page. Minimum value: 1 (optional)  (default to 1)\n            var pageSize = 30;  // int? | Results per page. Allowed values 1-100, default is 25. (optional)  (default to 25)\n            var apiWebhooksInstance = apiInstance.Webhooks();\n            try\n            {\n                // List all webhooks\n                WebhooksListResponse result = apiWebhooksInstance.list(events, currentPage, pageSize);\n                Debug.WriteLine(result);\n            }\n            catch (ApiException  e)\n            {\n                Debug.Print(\"Exception when calling WebhooksApi.list: \" + e.Message );\n                Debug.Print(\"Status Code: \"+ e.ErrorCode);\n                Debug.Print(e.StackTrace);\n            }\n        }\n    }\n}\n"
     post:
       tags:
-      - Webhooks
+        - Webhooks
       summary: Create Webhook
       description: "Webhooks can push notifications to your server, rather than polling api.video for changes. We currently offer four events: \n* ```video.encoding.quality.completed```  When a new video is uploaded into your account, it will be encoded into several different HLS sizes/bitrates.  When each version is encoded, your webhook will get a notification.  It will look like ```{ \\\"type\\\": \\\"video.encoding.quality.completed\\\", \\\"emittedAt\\\": \\\"2021-01-29T16:46:25.217+01:00\\\", \\\"videoId\\\": \\\"viXXXXXXXX\\\", \\\"encoding\\\": \\\"hls\\\", \\\"quality\\\": \\\"720p\\\"} ```. This request says that the 720p HLS encoding was completed.\n* ```live-stream.broadcast.started```  When a livestream begins broadcasting, the broadcasting parameter changes from false to true, and this webhook fires.\n* ```live-stream.broadcast.ended```  This event fores when the livestream has finished broadcasting, and the broadcasting parameter flips from false to true.\n* ```video.source.recorded```  This event is similar to ```video.encoding.quality.completed```, but tells you if a livestream has been recorded as a VOD."
       operationId: POST-webhooks
       requestBody:
+        required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/webhooks-create-payload'
+              $ref: '#/components/schemas/webhooks-creation-payload'
       responses:
         "201":
           description: Created
@@ -5469,7 +5357,7 @@ paths:
                     webhookId: webhook_XXXXXXXXXXXXXXX
                     createdAt: 2021-01-08T14:12:18.000+00:00
                     events:
-                    - video.encoding.quality.completed
+                      - video.encoding.quality.completed
                     url: http://clientnotificationserver.com/notif?myquery=query
         "400":
           description: Bad Request
@@ -5485,46 +5373,46 @@ paths:
                     name: events
                     status: 400
                     problems:
-                    - type: https://docs.api.video/docs/attributerequired
-                      title: This attribute is required.
-                      name: events
-                    - type: https://docs.api.video/docs/attributerequired
-                      title: This attribute is required.
-                      name: url
-                    - type: https://docs.api.video/docs/attributeinvalid
-                      title: This attribute must be an array.
-                      name: events
+                      - type: https://docs.api.video/docs/attributerequired
+                        title: This attribute is required.
+                        name: events
+                      - type: https://docs.api.video/docs/attributerequired
+                        title: This attribute is required.
+                        name: url
+                      - type: https://docs.api.video/docs/attributeinvalid
+                        title: This attribute must be an array.
+                        name: events
       security:
-      - bearerAuth: []
+        - bearerAuth: []
       x-client-action: create
       x-readme:
         code-samples:
-        - language: go
-          code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    webhooksCreationPayload := *apivideosdk.NewWebhooksCreationPayload([]string{\"Events_example\"}, \"https://example.com/webhooks\") // WebhooksCreationPayload | \n\n    \n    res, err := client.Webhooks.Create(webhooksCreationPayload)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `Webhooks.Create``: %v\\n\", err)\n    }\n    // response from `Create`: Webhook\n    fmt.Fprintf(os.Stdout, \"Response from `Webhooks.Create`: %v\\n\", res)\n}\n"
-        - language: node
-          code: "//install the module with npm or yarn\n//npm install @api.video/nodejs-client --save\n//yarn add @api.video/nodejs-client\n(async () => {\n    try {\n        const client = new ApiVideoClient({ apiKey: \"YOUR_API_TOKEN\" });\n\n        const webhooksCreationPayload = {\n      events: [\"video.encoding.quality.completed\"], // A list of the webhooks that you are subscribing to. There are Currently four webhook options: * ```video.encoding.quality.completed```  When a new video is uploaded into your account, it will be encoded into several different HLS sizes/bitrates.  When each version is encoded, your webhook will get a notification.  It will look like ```{ \\\\\\\"type\\\\\\\": \\\\\\\"video.encoding.quality.completed\\\\\\\", \\\\\\\"emittedAt\\\\\\\": \\\\\\\"2021-01-29T16:46:25.217+01:00\\\\\\\", \\\\\\\"videoId\\\\\\\": \\\\\\\"viXXXXXXXX\\\\\\\", \\\\\\\"encoding\\\\\\\": \\\\\\\"hls\\\\\\\", \\\\\\\"quality\\\\\\\": \\\\\\\"720p\\\\\\\"} ```. This request says that the 720p HLS encoding was completed. * ```live-stream.broadcast.started```  When a livestream begins broadcasting, the broadcasting parameter changes from false to true, and this webhook fires. * ```live-stream.broadcast.ended```  This event fores when the livestream has finished broadcasting, and the broadcasting parameter flips from false to true. * ```video.source.recorded```  This event is similar to ```video.encoding.quality.completed```, but tells you if a livestream has been recorded as a VOD.\n      url: \"https://example.com/webhooks\", // The the url to which HTTP notifications are sent. It could be any http or https URL.\n    }; \n\n        // Webhook\n        const result = await client.webhooks.create(webhooksCreationPayload);\n        console.log(result);\n    } catch (e) {\n        console.error(e);\n    }\n})();\n"
-        - language: python
-          code: "#install the api.video API client library\n#pip install api.video\nimport apivideo\nfrom apivideo.api import webhooks_api\nfrom apivideo.model.bad_request import BadRequest\nfrom apivideo.model.webhook import Webhook\nfrom apivideo.model.webhooks_creation_payload import WebhooksCreationPayload\nfrom pprint import pprint\n\n# Enter a context with an instance of the API client\nwith apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:\n    # Create an instance of the API class\n    api_instance = webhooks_api.WebhooksApi(api_client)\n    webhooks_creation_payload = WebhooksCreationPayload(\n        events=[\"video.encoding.quality.completed\"],\n        url=\"https://example.com/webhooks\",\n    ) # WebhooksCreationPayload | \n\n    # example passing only required values which don't have defaults set\n    try:\n        # Create Webhook\n        api_response = api_instance.create(webhooks_creation_payload)\n        pprint(api_response)\n    except apivideo.ApiException as e:\n        print(\"Exception when calling WebhooksApi->create: %s\\n\" % e)\n"
-        - language: java
-          code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.WebhooksApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    WebhooksApi apiInstance = client.webhooks();\n    \n    WebhooksCreationPayload webhooksCreationPayload = new WebhooksCreationPayload(); // \n    webhooksCreationPayload.setEvents(Arrays.asList(\"video.encoding.quality.completed\")); \n    webhooksCreationPayload.setUrl(\"https://example.com/webhooks\"); // The the url to which HTTP notifications are sent. It could be any http or https URL.\n\n\n    try {\n      Webhook result = apiInstance.create(webhooksCreationPayload);\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling WebhooksApi#create\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
-        - language: csharp
-          code: "//install via Nuget\n//Install-Package ApiVideo\nusing System.Diagnostics;\nusing ApiVideo.Client;\n\nnamespace Example\n{\n    public class createExample\n    {\n        public static void Main()\n        {\n            var basePath = ApiVideoClient.Client.Environment.SANDBOX;\n            var apiKey = \"YOUR_API_KEY\";\n\n            var apiInstance = new ApiVideoClient(apiKey,basePath);\n\n            var webhooksCreationPayload = new WebhooksCreationPayload(); // WebhooksCreationPayload | \n            var apiWebhooksInstance = apiInstance.Webhooks();\n            try\n            {\n                // Create Webhook\n                Webhook result = apiWebhooksInstance.create(webhooksCreationPayload);\n                Debug.WriteLine(result);\n            }\n            catch (ApiException  e)\n            {\n                Debug.Print(\"Exception when calling WebhooksApi.create: \" + e.Message );\n                Debug.Print(\"Status Code: \"+ e.ErrorCode);\n                Debug.Print(e.StackTrace);\n            }\n        }\n    }\n}\n"
+          - language: go
+            code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    webhooksCreationPayload := *apivideosdk.NewWebhooksCreationPayload([]string{\"Events_example\"}, \"https://example.com/webhooks\") // WebhooksCreationPayload | \n\n    \n    res, err := client.Webhooks.Create(webhooksCreationPayload)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `Webhooks.Create``: %v\\n\", err)\n    }\n    // response from `Create`: Webhook\n    fmt.Fprintf(os.Stdout, \"Response from `Webhooks.Create`: %v\\n\", res)\n}\n"
+          - language: node
+            code: "//install the module with npm or yarn\n//npm install @api.video/nodejs-client --save\n//yarn add @api.video/nodejs-client\n(async () => {\n    try {\n        const client = new ApiVideoClient({ apiKey: \"YOUR_API_TOKEN\" });\n\n        const webhooksCreationPayload = {\n      events: [\"video.encoding.quality.completed\"], // A list of the webhooks that you are subscribing to. There are Currently four webhook options: * ```video.encoding.quality.completed```  When a new video is uploaded into your account, it will be encoded into several different HLS sizes/bitrates.  When each version is encoded, your webhook will get a notification.  It will look like ```{ \\\\\\\"type\\\\\\\": \\\\\\\"video.encoding.quality.completed\\\\\\\", \\\\\\\"emittedAt\\\\\\\": \\\\\\\"2021-01-29T16:46:25.217+01:00\\\\\\\", \\\\\\\"videoId\\\\\\\": \\\\\\\"viXXXXXXXX\\\\\\\", \\\\\\\"encoding\\\\\\\": \\\\\\\"hls\\\\\\\", \\\\\\\"quality\\\\\\\": \\\\\\\"720p\\\\\\\"} ```. This request says that the 720p HLS encoding was completed. * ```live-stream.broadcast.started```  When a livestream begins broadcasting, the broadcasting parameter changes from false to true, and this webhook fires. * ```live-stream.broadcast.ended```  This event fores when the livestream has finished broadcasting, and the broadcasting parameter flips from false to true. * ```video.source.recorded```  This event is similar to ```video.encoding.quality.completed```, but tells you if a livestream has been recorded as a VOD.\n      url: \"https://example.com/webhooks\", // The the url to which HTTP notifications are sent. It could be any http or https URL.\n    }; \n\n        // Webhook\n        const result = await client.webhooks.create(webhooksCreationPayload);\n        console.log(result);\n    } catch (e) {\n        console.error(e);\n    }\n})();\n"
+          - language: python
+            code: "#install the api.video API client library\n#pip install api.video\nimport apivideo\nfrom apivideo.api import webhooks_api\nfrom apivideo.model.bad_request import BadRequest\nfrom apivideo.model.webhook import Webhook\nfrom apivideo.model.webhooks_creation_payload import WebhooksCreationPayload\nfrom pprint import pprint\n\n# Enter a context with an instance of the API client\nwith apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:\n    # Create an instance of the API class\n    api_instance = webhooks_api.WebhooksApi(api_client)\n    webhooks_creation_payload = WebhooksCreationPayload(\n        events=[\"video.encoding.quality.completed\"],\n        url=\"https://example.com/webhooks\",\n    ) # WebhooksCreationPayload | \n\n    # example passing only required values which don't have defaults set\n    try:\n        # Create Webhook\n        api_response = api_instance.create(webhooks_creation_payload)\n        pprint(api_response)\n    except apivideo.ApiException as e:\n        print(\"Exception when calling WebhooksApi->create: %s\\n\" % e)\n"
+          - language: java
+            code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.WebhooksApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    WebhooksApi apiInstance = client.webhooks();\n    \n    WebhooksCreationPayload webhooksCreationPayload = new WebhooksCreationPayload(); // \n    webhooksCreationPayload.setEvents(Arrays.asList(\"video.encoding.quality.completed\")); \n    webhooksCreationPayload.setUrl(\"https://example.com/webhooks\"); // The the url to which HTTP notifications are sent. It could be any http or https URL.\n\n\n    try {\n      Webhook result = apiInstance.create(webhooksCreationPayload);\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling WebhooksApi#create\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
+          - language: csharp
+            code: "//install via Nuget\n//Install-Package ApiVideo\nusing System.Diagnostics;\nusing ApiVideo.Client;\n\nnamespace Example\n{\n    public class createExample\n    {\n        public static void Main()\n        {\n            var basePath = ApiVideoClient.Client.Environment.SANDBOX;\n            var apiKey = \"YOUR_API_KEY\";\n\n            var apiInstance = new ApiVideoClient(apiKey,basePath);\n\n            var webhooksCreationPayload = new WebhooksCreationPayload(); // WebhooksCreationPayload | \n            var apiWebhooksInstance = apiInstance.Webhooks();\n            try\n            {\n                // Create Webhook\n                Webhook result = apiWebhooksInstance.create(webhooksCreationPayload);\n                Debug.WriteLine(result);\n            }\n            catch (ApiException  e)\n            {\n                Debug.Print(\"Exception when calling WebhooksApi.create: \" + e.Message );\n                Debug.Print(\"Status Code: \"+ e.ErrorCode);\n                Debug.Print(e.StackTrace);\n            }\n        }\n    }\n}\n"
   /webhooks/{webhookId}:
     get:
       tags:
-      - Webhooks
+        - Webhooks
       summary: Show Webhook details
       description: This call provides the same JSON information provided on Webjhook creation.
       operationId: GET-Webhook
       parameters:
-      - name: webhookId
-        in: path
-        description: The unique webhook you wish to retreive details on.
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
+        - name: webhookId
+          in: path
+          description: The unique webhook you wish to retreive details on.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
       responses:
         "200":
           description: Success
@@ -5538,107 +5426,107 @@ paths:
                     webhookId: webhook_XXXXXXXXXXXXXXX
                     createdAt: 2021-01-08T14:12:18.000+00:00
                     events:
-                    - video.encoding.quality.completed
+                      - video.encoding.quality.completed
                     url: http://clientnotificationserver.com/notif?myquery=query
       security:
-      - bearerAuth: []
+        - bearerAuth: []
       x-client-action: get
       x-readme:
         code-samples:
-        - language: go
-          code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    webhookId := \"webhookId_example\" // string | The unique webhook you wish to retreive details on.\n\n    \n    res, err := client.Webhooks.Get(webhookId)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `Webhooks.Get``: %v\\n\", err)\n    }\n    // response from `Get`: Webhook\n    fmt.Fprintf(os.Stdout, \"Response from `Webhooks.Get`: %v\\n\", res)\n}\n"
-        - language: node
-          code: |
-            //install the module with npm or yarn
-            //npm install @api.video/nodejs-client --save
-            //yarn add @api.video/nodejs-client
-            (async () => {
-                try {
-                    const client = new ApiVideoClient({ apiKey: "YOUR_API_TOKEN" });
+          - language: go
+            code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    webhookId := \"webhookId_example\" // string | The unique webhook you wish to retreive details on.\n\n    \n    res, err := client.Webhooks.Get(webhookId)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `Webhooks.Get``: %v\\n\", err)\n    }\n    // response from `Get`: Webhook\n    fmt.Fprintf(os.Stdout, \"Response from `Webhooks.Get`: %v\\n\", res)\n}\n"
+          - language: node
+            code: |
+              //install the module with npm or yarn
+              //npm install @api.video/nodejs-client --save
+              //yarn add @api.video/nodejs-client
+              (async () => {
+                  try {
+                      const client = new ApiVideoClient({ apiKey: "YOUR_API_TOKEN" });
 
-                    const webhookId = 'webhookId_example'; // The unique webhook you wish to retreive details on.
+                      const webhookId = 'webhookId_example'; // The unique webhook you wish to retreive details on.
 
-                    // Webhook
-                    const result = await client.webhooks.get(webhookId);
-                    console.log(result);
-                } catch (e) {
-                    console.error(e);
-                }
-            })();
-        - language: python
-          code: |
-            #install the api.video API client library
-            #pip install api.video
-            import apivideo
-            from apivideo.api import webhooks_api
-            from apivideo.model.webhook import Webhook
-            from pprint import pprint
+                      // Webhook
+                      const result = await client.webhooks.get(webhookId);
+                      console.log(result);
+                  } catch (e) {
+                      console.error(e);
+                  }
+              })();
+          - language: python
+            code: |
+              #install the api.video API client library
+              #pip install api.video
+              import apivideo
+              from apivideo.api import webhooks_api
+              from apivideo.model.webhook import Webhook
+              from pprint import pprint
 
-            # Enter a context with an instance of the API client
-            with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
-                # Create an instance of the API class
-                api_instance = webhooks_api.WebhooksApi(api_client)
-                webhook_id = "webhookId_example" # str | The unique webhook you wish to retreive details on.
+              # Enter a context with an instance of the API client
+              with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
+                  # Create an instance of the API class
+                  api_instance = webhooks_api.WebhooksApi(api_client)
+                  webhook_id = "webhookId_example" # str | The unique webhook you wish to retreive details on.
 
-                # example passing only required values which don't have defaults set
-                try:
-                    # Show Webhook details
-                    api_response = api_instance.get(webhook_id)
-                    pprint(api_response)
-                except apivideo.ApiException as e:
-                    print("Exception when calling WebhooksApi->get: %s\n" % e)
-        - language: java
-          code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.WebhooksApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    WebhooksApi apiInstance = client.webhooks();\n    \n    String webhookId = \"webhookId_example\"; // The unique webhook you wish to retreive details on.\n\n    try {\n      Webhook result = apiInstance.get(webhookId);\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling WebhooksApi#get\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
-        - language: csharp
-          code: |
-            //install via Nuget
-            //Install-Package ApiVideo
-            using System.Diagnostics;
-            using ApiVideo.Client;
+                  # example passing only required values which don't have defaults set
+                  try:
+                      # Show Webhook details
+                      api_response = api_instance.get(webhook_id)
+                      pprint(api_response)
+                  except apivideo.ApiException as e:
+                      print("Exception when calling WebhooksApi->get: %s\n" % e)
+          - language: java
+            code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.WebhooksApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    WebhooksApi apiInstance = client.webhooks();\n    \n    String webhookId = \"webhookId_example\"; // The unique webhook you wish to retreive details on.\n\n    try {\n      Webhook result = apiInstance.get(webhookId);\n      System.out.println(result);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling WebhooksApi#get\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
+          - language: csharp
+            code: |
+              //install via Nuget
+              //Install-Package ApiVideo
+              using System.Diagnostics;
+              using ApiVideo.Client;
 
-            namespace Example
-            {
-                public class getExample
-                {
-                    public static void Main()
-                    {
-                        var basePath = ApiVideoClient.Client.Environment.SANDBOX;
-                        var apiKey = "YOUR_API_KEY";
+              namespace Example
+              {
+                  public class getExample
+                  {
+                      public static void Main()
+                      {
+                          var basePath = ApiVideoClient.Client.Environment.SANDBOX;
+                          var apiKey = "YOUR_API_KEY";
 
-                        var apiInstance = new ApiVideoClient(apiKey,basePath);
+                          var apiInstance = new ApiVideoClient(apiKey,basePath);
 
-                        var webhookId = webhookId_example;  // string | The unique webhook you wish to retreive details on.
-                        var apiWebhooksInstance = apiInstance.Webhooks();
-                        try
-                        {
-                            // Show Webhook details
-                            Webhook result = apiWebhooksInstance.get(webhookId);
-                            Debug.WriteLine(result);
-                        }
-                        catch (ApiException  e)
-                        {
-                            Debug.Print("Exception when calling WebhooksApi.get: " + e.Message );
-                            Debug.Print("Status Code: "+ e.ErrorCode);
-                            Debug.Print(e.StackTrace);
-                        }
-                    }
-                }
-            }
+                          var webhookId = webhookId_example;  // string | The unique webhook you wish to retreive details on.
+                          var apiWebhooksInstance = apiInstance.Webhooks();
+                          try
+                          {
+                              // Show Webhook details
+                              Webhook result = apiWebhooksInstance.get(webhookId);
+                              Debug.WriteLine(result);
+                          }
+                          catch (ApiException  e)
+                          {
+                              Debug.Print("Exception when calling WebhooksApi.get: " + e.Message );
+                              Debug.Print("Status Code: "+ e.ErrorCode);
+                              Debug.Print(e.StackTrace);
+                          }
+                      }
+                  }
+              }
     delete:
       tags:
-      - Webhooks
+        - Webhooks
       summary: Delete a Webhook
       description: This endpoint will delete the indicated webhook.
       operationId: DELETE-webhook
       parameters:
-      - name: webhookId
-        in: path
-        description: The webhook you wish to delete.
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
+        - name: webhookId
+          in: path
+          description: The webhook you wish to delete.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
       responses:
         "204":
           description: No Content
@@ -5656,132 +5544,87 @@ paths:
                     name: webhookId
                     status: 404
       security:
-      - bearerAuth: []
+        - bearerAuth: []
       x-client-action: delete
       x-readme:
         code-samples:
-        - language: go
-          code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    webhookId := \"webhookId_example\" // string | The webhook you wish to delete.\n\n    \n    err := client.Webhooks.Delete(webhookId)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `Webhooks.Delete``: %v\\n\", err)\n    }\n}\n"
-        - language: node
-          code: |
-            //install the module with npm or yarn
-            //npm install @api.video/nodejs-client --save
-            //yarn add @api.video/nodejs-client
-            (async () => {
-                try {
-                    const client = new ApiVideoClient({ apiKey: "YOUR_API_TOKEN" });
+          - language: go
+            code: "//install the Go API client\n//go get github.com/apivideo/go-api-client\npackage main\n\nimport (\n    \"context\"\n    \"fmt\"\n    \"os\"\n    apivideosdk \"github.com/apivideo/go-api-client\"\n)\n\nfunc main() {\n    client := apivideosdk.ClientBuilder(\"YOUR_API_TOKEN\").Build()\n    // if you rather like to use the sandbox environment:\n    // client := apivideosdk.SandboxClientBuilder(\"YOU_SANDBOX_API_TOKEN\").Build()\n        \n    webhookId := \"webhookId_example\" // string | The webhook you wish to delete.\n\n    \n    err := client.Webhooks.Delete(webhookId)\n\n    if err != nil {\n        fmt.Fprintf(os.Stderr, \"Error when calling `Webhooks.Delete``: %v\\n\", err)\n    }\n}\n"
+          - language: node
+            code: |
+              //install the module with npm or yarn
+              //npm install @api.video/nodejs-client --save
+              //yarn add @api.video/nodejs-client
+              (async () => {
+                  try {
+                      const client = new ApiVideoClient({ apiKey: "YOUR_API_TOKEN" });
 
-                    const webhookId = 'webhookId_example'; // The webhook you wish to delete.
+                      const webhookId = 'webhookId_example'; // The webhook you wish to delete.
 
-                    // void
-                    const result = await client.webhooks.delete(webhookId);
-                    console.log(result);
-                } catch (e) {
-                    console.error(e);
-                }
-            })();
-        - language: python
-          code: |
-            #install the api.video API client library
-            #pip install api.video
-            import apivideo
-            from apivideo.api import webhooks_api
-            from apivideo.model.not_found import NotFound
-            from pprint import pprint
+                      // void
+                      const result = await client.webhooks.delete(webhookId);
+                      console.log(result);
+                  } catch (e) {
+                      console.error(e);
+                  }
+              })();
+          - language: python
+            code: |
+              #install the api.video API client library
+              #pip install api.video
+              import apivideo
+              from apivideo.api import webhooks_api
+              from apivideo.model.not_found import NotFound
+              from pprint import pprint
 
-            # Enter a context with an instance of the API client
-            with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
-                # Create an instance of the API class
-                api_instance = webhooks_api.WebhooksApi(api_client)
-                webhook_id = "webhookId_example" # str | The webhook you wish to delete.
+              # Enter a context with an instance of the API client
+              with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
+                  # Create an instance of the API class
+                  api_instance = webhooks_api.WebhooksApi(api_client)
+                  webhook_id = "webhookId_example" # str | The webhook you wish to delete.
 
-                # example passing only required values which don't have defaults set
-                try:
-                    # Delete a Webhook
-                    api_instance.delete(webhook_id)
-                except apivideo.ApiException as e:
-                    print("Exception when calling WebhooksApi->delete: %s\n" % e)
-        - language: java
-          code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.WebhooksApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    WebhooksApi apiInstance = client.webhooks();\n    \n    String webhookId = \"webhookId_example\"; // The webhook you wish to delete.\n\n    try {\n      apiInstance.delete(webhookId);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling WebhooksApi#delete\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
-        - language: csharp
-          code: |
-            //install via Nuget
-            //Install-Package ApiVideo
-            using System.Diagnostics;
-            using ApiVideo.Client;
+                  # example passing only required values which don't have defaults set
+                  try:
+                      # Delete a Webhook
+                      api_instance.delete(webhook_id)
+                  except apivideo.ApiException as e:
+                      print("Exception when calling WebhooksApi->delete: %s\n" % e)
+          - language: java
+            code: "//dependency addition instructions\n//https://github.com/apivideo/java-api-client\n// Import classes:\nimport video.api.client.ApiVideoClient;\nimport video.api.client.api.ApiException;\nimport video.api.client.api.models.*;\nimport video.api.client.api.clients.WebhooksApi;\nimport java.util.*;\n\npublic class Example {\n  public static void main(String[] args) {\n    ApiVideoClient client = new ApiVideoClient(\"YOUR_API_TOKEN\");\n    // if you rather like to use the sandbox environment:\n    // ApiVideoClient client = new ApiVideoClient(\"YOU_SANDBOX_API_TOKEN\", ApiVideoClient.Environment.SANDBOX);\n\n    WebhooksApi apiInstance = client.webhooks();\n    \n    String webhookId = \"webhookId_example\"; // The webhook you wish to delete.\n\n    try {\n      apiInstance.delete(webhookId);\n    } catch (ApiException e) {\n      System.err.println(\"Exception when calling WebhooksApi#delete\");\n      System.err.println(\"Status code: \" + e.getCode());\n      System.err.println(\"Reason: \" + e.getMessage());\n      System.err.println(\"Response headers: \" + e.getResponseHeaders());\n      e.printStackTrace();\n    }\n  }\n}\n"
+          - language: csharp
+            code: |
+              //install via Nuget
+              //Install-Package ApiVideo
+              using System.Diagnostics;
+              using ApiVideo.Client;
 
-            namespace Example
-            {
-                public class deleteExample
-                {
-                    public static void Main()
-                    {
-                        var basePath = ApiVideoClient.Client.Environment.SANDBOX;
-                        var apiKey = "YOUR_API_KEY";
+              namespace Example
+              {
+                  public class deleteExample
+                  {
+                      public static void Main()
+                      {
+                          var basePath = ApiVideoClient.Client.Environment.SANDBOX;
+                          var apiKey = "YOUR_API_KEY";
 
-                        var apiInstance = new ApiVideoClient(apiKey,basePath);
+                          var apiInstance = new ApiVideoClient(apiKey,basePath);
 
-                        var webhookId = webhookId_example;  // string | The webhook you wish to delete.
-                        var apiWebhooksInstance = apiInstance.Webhooks();
-                        try
-                        {
-                            // Delete a Webhook
-                            apiWebhooksInstance.delete(webhookId);
-                        }
-                        catch (ApiException  e)
-                        {
-                            Debug.Print("Exception when calling WebhooksApi.delete: " + e.Message );
-                            Debug.Print("Status Code: "+ e.ErrorCode);
-                            Debug.Print(e.StackTrace);
-                        }
-                    }
-                }
-            }
-  /account:
-    get:
-      tags:
-      - Account
-      summary: Show account
-      description: Deprecated. Authenticate and get a token, then you can use the bearer token here to retrieve details about your account.
-      operationId: GET_account
-      responses:
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/account'
-              examples:
-                response:
-                  value:
-                    quota:
-                      quotaUsed: 6
-                      quotaRemaining: 54
-                      quotaTotal: 60
-                    environment: production
-                    features:
-                    - app.dynamic_metadata
-                    - app.event_log
-                    - player.white_label
-                    - stats.player_events
-                    - transcode.mp4_support
-        "404":
-          description: Not Found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/not-found'
-              examples:
-                response:
-                  value:
-                    type: https://docs.api.video/docs/resourcenot_found
-                    title: The requested resource was not found.
-                    name: ""
-                    status: 404
-      deprecated: true
-      security:
-      - bearerAuth: []
-      x-client-action: get
+                          var webhookId = webhookId_example;  // string | The webhook you wish to delete.
+                          var apiWebhooksInstance = apiInstance.Webhooks();
+                          try
+                          {
+                              // Delete a Webhook
+                              apiWebhooksInstance.delete(webhookId);
+                          }
+                          catch (ApiException  e)
+                          {
+                              Debug.Print("Exception when calling WebhooksApi.delete: " + e.Message );
+                              Debug.Print("Status Code: "+ e.ErrorCode);
+                              Debug.Print(e.StackTrace);
+                          }
+                      }
+                  }
+              }
 components:
   schemas:
     link:
@@ -5818,7 +5661,7 @@ components:
     pagination:
       title: Pagination
       required:
-      - links
+        - links
       type: object
       properties:
         itemsTotal:
@@ -5844,7 +5687,7 @@ components:
         links:
           type: array
           items:
-            $ref: '#/components/schemas/pagination_link'
+            $ref: '#/components/schemas/pagination-link'
       example:
         itemsTotal: 123
         pagesTotal: 7
@@ -5894,13 +5737,18 @@ components:
         status:
           type: integer
     video:
-      title: video
+      title: Video
       type: object
       properties:
         videoId:
           type: string
           description: The unique identifier of the video object.
           example: vi4k0jvEUuaTdRAEjQ4Prklg
+        createdAt:
+          type: string
+          format: date-time
+          description: 'When a video was created, presented in ISO-8601 format.'
+          example: '2019-06-24T11:45:01.109+00'
         title:
           type: string
           description: |
@@ -5924,7 +5772,8 @@ components:
           type: array
           description: "One array of tags (each tag is a string) in order to categorize a video. Tags may include spaces. \n"
           example: '"tags": ["maths", "string theory", "video"]'
-          items: {}
+          items:
+            type: string
         metadata:
           type: array
           description: |
@@ -5933,9 +5782,9 @@ components:
           items:
             $ref: '#/components/schemas/metadata'
         source:
-          $ref: '#/components/schemas/videoSource'
+          $ref: '#/components/schemas/video-source'
         assets:
-          $ref: '#/components/schemas/videoAssets'
+          $ref: '#/components/schemas/video-assets'
         playerId:
           type: string
           description: |
@@ -5956,72 +5805,29 @@ components:
           description: |
             This lets you know whether mp4 is supported. If enabled, an mp4 URL will be provided in the response for the video.
           example: true
+      required:
+        - videoId
+        - title
       example:
         videoId: vi4k0jvEUuaTdRAEjQ4Jfrgz
         title: Maths video
         description: An amazing video explaining the string theory
         tags:
-        - maths
-        - string theory
-        - video
+          - maths
+          - string theory
+          - video
         metadata:
-        - key: Author
-          value: John Doe
-        - key: Format
-          value: Tutorial
+          - key: Author
+            value: John Doe
+          - key: Format
+            value: Tutorial
         scheduledAt: 4251-03-03T12:52:03.085Z
         publishedAt: 4665-07-14T23:36:18.598Z
         actions:
-        - video_delete
-        - video_download
-        - video_update
-    player:
-      title: Player
-      allOf:
-      - $ref: '#/components/schemas/playerinput'
-      - type: object
-        properties:
-          playerId:
-            type: string
-            example: pl45KFKdlddgk654dspkze
-          createdAt:
-            type: string
-            description: When the player was created, presented in ISO-8601 format.
-            format: date-time
-            example: 2020-01-31T10:17:47Z
-          updatedAt:
-            type: string
-            description: When the player was last updated, presented in ISO-8601 format.
-            format: date-time
-            example: 2020-01-31T10:18:47Z
-          shapeMargin:
-            type: integer
-            description: Deprecated
-          shapeRadius:
-            type: integer
-            description: Deprecated
-          shapeAspect:
-            type: string
-            description: Deprecated
-          shapeBackgroundTop:
-            type: string
-            description: Deprecated
-          shapeBackgroundBottom:
-            type: string
-            description: Deprecated
-          linkActive:
-            type: string
-            description: Deprecated
-          assets:
-            $ref: '#/components/schemas/player_assets'
-    playerCreationPayload:
-      allOf:
-      - $ref: '#/components/schemas/playerinput'
-    playerUpdatePayload:
-      allOf:
-      - $ref: '#/components/schemas/playerinput'
-    playerinput:
-      title: PlayerInput
+          - video_delete
+          - video_download
+          - video_update
+    player-theme:
       type: object
       properties:
         text:
@@ -6032,16 +5838,108 @@ components:
           description: 'RGBA color for all controls. Default: rgba(255, 255, 255, 1)'
         linkHover:
           type: string
-          description: 'RGBA color for all controls when hovered. Default: rgba(255, 255, 255, 1)'
+          description: >-
+            RGBA color for all controls when hovered. Default: rgba(255, 255,
+            255, 1)
         trackPlayed:
           type: string
-          description: 'RGBA color playback bar: played content. Default: rgba(88, 131, 255, .95)'
+          description: >-
+            RGBA color playback bar: played content. Default: rgba(88, 131, 255,
+            .95)
         trackUnplayed:
           type: string
-          description: 'RGBA color playback bar: downloaded but unplayed (buffered) content. Default: rgba(255, 255, 255, .35)'
+          description: >-
+            RGBA color playback bar: downloaded but unplayed (buffered) content.
+            Default: rgba(255, 255, 255, .35)
         trackBackground:
           type: string
-          description: 'RGBA color playback bar: background. Default: rgba(255, 255, 255, .2)'
+          description: >-
+            RGBA color playback bar: background. Default: rgba(255, 255, 255,
+            .2)
+        backgroundTop:
+          type: string
+          description: 'RGBA color: top 50% of background. Default: rgba(0, 0, 0, .7)'
+        backgroundBottom:
+          type: string
+          description: 'RGBA color: bottom 50% of background. Default: rgba(0, 0, 0, .7)'
+        backgroundText:
+          type: string
+          description: 'RGBA color for title text. Default: rgba(255, 255, 255, 1)'
+        enableApi:
+          type: boolean
+          description: 'enable/disable player SDK access. Default: true'
+        enableControls:
+          type: boolean
+          description: 'enable/disable player controls. Default: true'
+        forceAutoplay:
+          type: boolean
+          description: 'enable/disable player autoplay. Default: false'
+        hideTitle:
+          type: boolean
+          description: 'enable/disable title. Default: false'
+        forceLoop:
+          type: boolean
+          description: 'enable/disable looping. Default: false'
+        playerId:
+          type: string
+          example: pl45KFKdlddgk654dspkze
+        createdAt:
+          type: string
+          description: 'When the player was created, presented in ISO-8601 format.'
+          format: date-time
+          example: '2020-01-31T10:17:47+00:00'
+        updatedAt:
+          type: string
+          description: 'When the player was last updated, presented in ISO-8601 format.'
+          format: date-time
+          example: '2020-01-31T10:18:47+00:00'
+        linkActive:
+          type: string
+          description: Deprecated
+        assets:
+          type: object
+          properties:
+            logo:
+              type: string
+              description: The name of the file containing the logo you want to use.
+              example: mylogo.jpg
+            link:
+              type: string
+              description: The path to the file containing your logo.
+              example: path/to/my/logo/mylogo.jpg
+      title: PlayerTheme
+      required:
+        - playerId
+    player-theme-creation-payload:
+      title: PlayerThemeCreationPayload
+      type: object
+      properties:
+        text:
+          type: string
+          description: 'RGBA color for timer text. Default: rgba(255, 255, 255, 1)'
+        link:
+          type: string
+          description: 'RGBA color for all controls. Default: rgba(255, 255, 255, 1)'
+        linkHover:
+          type: string
+          description: >-
+            RGBA color for all controls when hovered. Default: rgba(255, 255,
+            255, 1)
+        trackPlayed:
+          type: string
+          description: >-
+            RGBA color playback bar: played content. Default: rgba(88, 131, 255,
+            .95)
+        trackUnplayed:
+          type: string
+          description: >-
+            RGBA color playback bar: downloaded but unplayed (buffered) content.
+            Default: rgba(255, 255, 255, .35)
+        trackBackground:
+          type: string
+          description: >-
+            RGBA color playback bar: background. Default: rgba(255, 255, 255,
+            .2)
         backgroundTop:
           type: string
           description: 'RGBA color: top 50% of background. Default: rgba(0, 0, 0, .7)'
@@ -6096,8 +5994,62 @@ components:
         forceAutoplay: false
         hideTitle: false
         forceLoop: false
-    subtitle:
-      title: Subtitle
+    player-theme-update-payload:
+      title: PlayerThemeUpdatePayload
+      type: object
+      properties:
+        text:
+          type: string
+          description: 'RGBA color for timer text. Default: rgba(255, 255, 255, 1)'
+        link:
+          type: string
+          description: 'RGBA color for all controls. Default: rgba(255, 255, 255, 1)'
+        linkHover:
+          type: string
+          description: >-
+            RGBA color for all controls when hovered. Default: rgba(255, 255,
+            255, 1)
+        trackPlayed:
+          type: string
+          description: >-
+            RGBA color playback bar: played content. Default: rgba(88, 131, 255,
+            .95)
+        trackUnplayed:
+          type: string
+          description: >-
+            RGBA color playback bar: downloaded but unplayed (buffered) content.
+            Default: rgba(255, 255, 255, .35)
+        trackBackground:
+          type: string
+          description: >-
+            RGBA color playback bar: background. Default: rgba(255, 255, 255,
+            .2)
+        backgroundTop:
+          type: string
+          description: 'RGBA color: top 50% of background. Default: rgba(0, 0, 0, .7)'
+        backgroundBottom:
+          type: string
+          description: 'RGBA color: bottom 50% of background. Default: rgba(0, 0, 0, .7)'
+        backgroundText:
+          type: string
+          description: 'RGBA color for title text. Default: rgba(255, 255, 255, 1)'
+        enableApi:
+          type: boolean
+          description: 'enable/disable player SDK access. Default: true'
+        enableControls:
+          type: boolean
+          description: 'enable/disable player controls. Default: true'
+        forceAutoplay:
+          type: boolean
+          description: 'enable/disable player autoplay. Default: false'
+        hideTitle:
+          type: boolean
+          description: 'enable/disable title. Default: false'
+        forceLoop:
+          type: boolean
+          description: 'enable/disable looping. Default: false'
+    caption:
+      title: Caption
       type: object
       properties:
         uri:
@@ -6112,21 +6064,21 @@ components:
           example: false
           default: false
     video-session:
-      title: Video Session
+      title: VideoSession
       type: object
       properties:
         session:
-          $ref: '#/components/schemas/video_session_session'
+          $ref: '#/components/schemas/video-session-session'
         location:
-          $ref: '#/components/schemas/video_session_location'
+          $ref: '#/components/schemas/video-session-location'
         referrer:
-          $ref: '#/components/schemas/video_session_referrer'
+          $ref: '#/components/schemas/video-session-referrer'
         device:
-          $ref: '#/components/schemas/video_session_device'
+          $ref: '#/components/schemas/video-session-device'
         os:
-          $ref: '#/components/schemas/video_session_os'
+          $ref: '#/components/schemas/video-session-os'
         client:
-          $ref: '#/components/schemas/video_session_client'
+          $ref: '#/components/schemas/video-session-client'
       example:
         session:
           sessionId: psEmFwGQUAXR2lFHj5nDOpy
@@ -6177,7 +6129,7 @@ components:
           description: BETA FEATURE Please limit all public = false ("private") livestreams to 3,000 users. Whether your video can be viewed by everyone, or requires authentication to see it. A setting of false will require a unique token for each view.
           example: true
         assets:
-          $ref: '#/components/schemas/live_stream_assets'
+          $ref: '#/components/schemas/live-stream-assets'
         playerId:
           type: string
           description: The unique identifier for the player.
@@ -6186,24 +6138,36 @@ components:
           type: boolean
           description: Whether or not you are broadcasting the live video you recorded for others to see. True means you are broadcasting to viewers, false means you are not.
           example: true
+        createdAt:
+          type: string
+          description: 'When the player was created, presented in ISO-8601 format.'
+          format: date-time
+          example: '2020-01-31T10:17:47+00:00'
+        updatedAt:
+          type: string
+          description: 'When the player was last updated, presented in ISO-8601 format.'
+          format: date-time
+          example: '2020-01-31T10:18:47+00:00'
+      required:
+        - liveStreamId
     live-stream-session:
-      title: Live Stream Session
+      title: LiveStreamSession
       type: object
       properties:
         session:
-          $ref: '#/components/schemas/live_stream_session_session'
+          $ref: '#/components/schemas/live-stream-session-session'
         location:
-          $ref: '#/components/schemas/live_stream_session_location'
+          $ref: '#/components/schemas/live-stream-session-location'
         referrer:
-          $ref: '#/components/schemas/live_stream_session_referrer'
+          $ref: '#/components/schemas/live-stream-session-referrer'
         device:
-          $ref: '#/components/schemas/live_stream_session_device'
+          $ref: '#/components/schemas/live-stream-session-device'
         os:
-          $ref: '#/components/schemas/video_session_os'
+          $ref: '#/components/schemas/video-session-os'
         client:
-          $ref: '#/components/schemas/live_stream_session_client'
+          $ref: '#/components/schemas/live-stream-session-client'
     player-session-event:
-      title: Player Session Event
+      title: PlayerSessionEvent
       type: object
       properties:
         type:
@@ -6214,7 +6178,7 @@ components:
           type: string
           description: When an event occurred, presented in ISO-8601 format.
           format: date-time
-          example: 2019-06-24T11:45:01.109Z
+          example: 2019-06-24T11:45:01.109+00
         at:
           type: integer
         from:
@@ -6233,7 +6197,7 @@ components:
           type: string
           description: When an webhook was created, presented in ISO-8601 format.
           format: date-time
-          example: 2019-06-24T11:45:01.109Z
+          example: 2019-06-24T11:45:01.109+00
         events:
           type: array
           description: A list of events that will trigger the webhook.
@@ -6244,43 +6208,43 @@ components:
           type: string
           description: URL of the webhook
           example: http://clientnotificationserver.com/notif?myquery=query
-    videostatus:
+    video-status:
       title: VideoStatus
       type: object
       properties:
         ingest:
-          $ref: '#/components/schemas/videostatus_ingest'
+          $ref: '#/components/schemas/video-status-ingest'
         encoding:
-          $ref: '#/components/schemas/videostatus_encoding'
+          $ref: '#/components/schemas/video-status-encoding'
       example:
         ingest:
           status: uploaded
           filesize: 273579401
           receivedBytes:
-          - to: 134217727
-            from: 0
-            total: 273579401
-          - to: 268435455
-            from: 134217728
-            total: 273579401
-          - to: 273579400
-            from: 268435456
-            total: 273579401
+            - to: 134217727
+              from: 0
+              total: 273579401
+            - to: 268435455
+              from: 134217728
+              total: 273579401
+            - to: 273579400
+              from: 268435456
+              total: 273579401
         encoding:
           playable: true
           qualities:
-          - quality: 240p
-            status: encoded
-          - quality: 360p
-            status: encoded
-          - quality: 480p
-            status: encoded
-          - quality: 720p
-            status: encoded
-          - quality: 1080p
-            status: encoding
-          - quality: 2160p
-            status: waiting
+            - quality: 240p
+              status: encoded
+            - quality: 360p
+              status: encoded
+            - quality: 480p
+              status: encoded
+            - quality: 720p
+              status: encoded
+            - quality: 1080p
+              status: encoding
+            - quality: 2160p
+              status: waiting
           metadata:
             width: 424
             height: 240
@@ -6292,30 +6256,38 @@ components:
             audioCodec: aac
             aspectRatio: 16/9
     quality:
-      title: quality
+      title: Quality
       type: object
       properties:
+        type:
+          type: string
+          description: >-
+            The type of video (hls or mp4).
+          example: hls
+          enum:
+            - hls
+            - mp4
         quality:
           type: string
           description: The quality of the video you have, in pixels. Choices include 360p, 480p, 720p, 1080p, and 2160p.
           example: 720p
           enum:
-          - 240p
-          - 360p
-          - 480p
-          - 720p
-          - 1080p
-          - 2160p
+            - 240p
+            - 360p
+            - 480p
+            - 720p
+            - 1080p
+            - 2160p
         status:
           type: string
           description: The status of your video. Statuses include waiting - the video is waiting to be encoded. encoding - the video is in the process of being encoded. encoded - the video was successfully encoded. failed - the video failed to be encoded.
           enum:
-          - waiting
-          - encoding
-          - encoded
-          - failed
-    bytes_range:
-      title: bytes_range
+            - waiting
+            - encoding
+            - encoded
+            - failed
+    bytes-range:
+      title: BytesRange
       type: object
       properties:
         from:
@@ -6359,16 +6331,17 @@ components:
           type: string
           description: When the token was created, displayed in ISO-8601 format.
           format: date-time
-          example: 2019-12-16T08:25:51Z
+          example: 2019-12-16T08:25:51+00:00
         expiresAt:
           type: string
           description: When the token expires, displayed in ISO-8601 format.
           format: date-time
-          example: 2019-12-16T09:25:51Z
+          example: 2019-12-16T09:25:51+00:00
+          nullable: true
     authenticate-payload:
-      title: apiKey
+      title: ApiKey
       required:
-      - apiKey
+        - apiKey
       type: object
       properties:
         apiKey:
@@ -6377,9 +6350,9 @@ components:
       example:
         apiKey: 9VxMaPgsaFg7EBqmuspSzF7
     refresh-token-payload:
-      title: refreshToken
+      title: RefreshToken
       required:
-      - refreshToken
+        - refreshToken
       type: object
       properties:
         refreshToken:
@@ -6391,8 +6364,8 @@ components:
     videos-list-response:
       title: Videos
       required:
-      - data
-      - pagination
+        - data
+        - pagination
       type: object
       properties:
         data:
@@ -6402,7 +6375,7 @@ components:
         pagination:
           $ref: '#/components/schemas/pagination'
     metadata:
-      title: metadata
+      title: Metadata
       type: object
       properties:
         key:
@@ -6414,10 +6387,10 @@ components:
           description: A variable which belongs to the data set.
           example: Green
       x-client-all-args-constructor: true
-    video-create-payload:
-      title: videoCreationPayload
+    video-creation-payload:
+      title: VideoCreationPayload
       required:
-      - title
+        - title
       type: object
       properties:
         title:
@@ -6463,11 +6436,6 @@ components:
           example: '[{"key": "Author", "value": "John Doe"}]'
           items:
             $ref: '#/components/schemas/metadata'
-        publishedAt:
-          type: string
-          description: The API uses ISO-8601 format for time, and includes 3 places for milliseconds.
-          format: date-time
-          example: 2020-07-14T23:36:18.598Z
       example:
         title: Maths video
         description: An amazing video explaining string theory.
@@ -6476,17 +6444,17 @@ components:
         mp4Support: true
         playerId: pl45KFKdlddgk654dspkze
         tags:
-        - maths
-        - string theory
-        - video
+          - maths
+          - string theory
+          - video
         metadata:
-        - key: Author
-          value: John Doe
-        - key: Format
-          value: Tutorial
+          - key: Author
+            value: John Doe
+          - key: Format
+            value: Tutorial
     video-upload-payload:
       required:
-      - file
+        - file
       type: object
       properties:
         file:
@@ -6494,21 +6462,23 @@ components:
           description: The path to the video you would like to upload. The path must be local. If you want to use a video from an online source, you must use the "/videos" endpoint and add the "source" parameter when you create a new video.
           format: binary
           x-client-chunk-upload: "true"
+          example: '@/path/to/video.mp4'
     video-thumbnail-pick-payload:
-      title: pickThumbnailPayload
+      title: ThumbnailPickPayload
       required:
-      - timecode
+        - timecode
       type: object
       properties:
         timecode:
-          pattern: 00:00:00.00
+          pattern: \d{2}:\d{2}:\d{2}(\.\d{2})?
           type: string
           description: "Frame in video to be used as a placeholder before the video plays. \nExample: '\"00:01:00.000\" for 1 minute into the video.'\nValid Patterns: \n\"hh:mm:ss.ms\"\n\"hh:mm:ss:frameNumber\"\n\"124\" (integer value is reported as seconds) \nIf selection is out of range, \"00:00:00.00\" will be chosen."
       example:
-        timecode: 00:00:00.000
+        timecode: "00:00:00.000"
     video-thumbnail-upload-payload:
+      title: VideoThumbnailUploadPayload
       required:
-      - file
+        - file
       type: object
       properties:
         file:
@@ -6516,7 +6486,7 @@ components:
           description: The image to be added as a thumbnail.
           format: binary
     video-update-payload:
-      title: videoUpdatePayload
+      title: VideoUpdatePayload
       type: object
       properties:
         playerId:
@@ -6561,19 +6531,19 @@ components:
         panoramic: false
         mp4Support: true
         tags:
-        - maths
-        - string theory
-        - video
+          - maths
+          - string theory
+          - video
         metadata:
-        - key: Author
-          value: John Doe
-        - key: Format
-          value: Tutorial
+          - key: Author
+            value: John Doe
+          - key: Format
+            value: Tutorial
     token-list-response:
-      title: uploadTokens
+      title: UploadTokens
       required:
-      - data
-      - pagination
+        - data
+        - pagination
       type: object
       properties:
         data:
@@ -6583,8 +6553,8 @@ components:
             $ref: '#/components/schemas/upload-token'
         pagination:
           $ref: '#/components/schemas/pagination'
-    token-create-payload:
-      title: tokenCreationPayload
+    token-creation-payload:
+      title: TokenCreationPayload
       type: object
       properties:
         ttl:
@@ -6596,8 +6566,9 @@ components:
       example:
         ttl: 3600
     token-upload-payload:
+      title: tokenUploadPayload
       required:
-      - file
+        - file
       type: object
       properties:
         file:
@@ -6605,6 +6576,7 @@ components:
           description: The path to the video you want to upload.
           format: binary
           x-client-chunk-upload: "true"
+          example: path/to/video/video.mp4
         videoId:
           type: string
           description: The video id returned by the first call to this endpoint in a large video upload scenario.
@@ -6613,8 +6585,8 @@ components:
     live-stream-list-response:
       title: LiveStreams
       required:
-      - data
-      - pagination
+        - data
+        - pagination
       type: object
       properties:
         data:
@@ -6623,10 +6595,10 @@ components:
             $ref: '#/components/schemas/live-stream'
         pagination:
           $ref: '#/components/schemas/pagination'
-    live-stream-create-payload:
-      title: liveStreamCreationPayload
+    live-stream-creation-payload:
+      title: LiveStreamCreationPayload
       required:
-      - name
+        - name
       type: object
       properties:
         name:
@@ -6669,25 +6641,29 @@ components:
           description: The unique ID for the player associated with a live stream that you want to update.
           example: pl45KFKdlddgk654dspkze
     captions-upload-payload:
+      title: CaptionsUploadPayload
       required:
-      - file
+        - file
       type: object
       properties:
         file:
           type: string
           description: The video text track (VTT) you want to upload.
           format: binary
+          example: 'https://cdn.api.video/vod/vi3N6cDinStg3oBbN79GklWS/captions/en.vtt'
     live-stream-thumbnail-upload-payload:
+      title: LiveStreamThumbnailUploadPayload
       required:
-      - file
+        - file
       type: object
       properties:
         file:
           type: string
           description: The image to be added as a thumbnail.
           format: binary
+          example: 'https://cdn.api.video/vod/vi3N6cDinStg3oBbN79GklWS/captions/en.vtt'
     captions-update-payload:
-      title: UpdateCaptionPayload
+      title: CaptionsUpdatePayload
       type: object
       properties:
         default:
@@ -6699,13 +6675,16 @@ components:
         data:
           type: array
           items:
-            $ref: '#/components/schemas/subtitle'
+            $ref: '#/components/schemas/caption'
         pagination:
           $ref: '#/components/schemas/pagination'
-    chapters-update-payload:
-      title: UpdateChapterPayload
       required:
-      - file
+        - data
+        - pagination
+    chapters-update-payload:
+      title: ChaptersUpdatePayload
+      required:
+        - file
       type: object
       properties:
         file:
@@ -6722,31 +6701,38 @@ components:
             $ref: '#/components/schemas/chapter'
         pagination:
           $ref: '#/components/schemas/pagination'
-    players-list-response:
-      title: Players
+      required:
+        - data
+        - pagination
+    player-themes-list-response:
+      title: PlayerThemes
       type: object
       properties:
         data:
           type: array
           items:
-            $ref: '#/components/schemas/player'
+            $ref: '#/components/schemas/player-theme'
         pagination:
           $ref: '#/components/schemas/pagination'
-    players-upload-logo-payload:
       required:
-      - file
-      - link
+        - data
+        - pagination
+    player-theme-upload-logo-payload:
+      title: PlayerThemeUploadLogoPayload
+      required:
+        - file
       type: object
       properties:
         file:
           type: string
           description: The name of the file you want to use for your logo.
           format: binary
+          example: mylogo.jpg
         link:
           type: string
-          description: The path to the file you want to upload and use as a logo.
           format: string
-          example: path/to/my/logo/mylogo.jpg
+          description: A public link that you want to advertise in your player. For example, you could add a link to your company. When a viewer clicks on your logo, they will be taken to this address.
+          example: https://my-company.com
     raw-statistics-list-sessions-response:
       title: VideoSessions
       type: object
@@ -6757,6 +6743,9 @@ components:
             $ref: '#/components/schemas/video-session'
         pagination:
           $ref: '#/components/schemas/pagination'
+      required:
+        - data
+        - pagination
     raw-statistics-list-live-stream-analytics-response:
       title: LiveStreamSessions
       type: object
@@ -6767,6 +6756,9 @@ components:
             $ref: '#/components/schemas/live-stream-session'
         pagination:
           $ref: '#/components/schemas/pagination'
+      required:
+        - data
+        - pagination
     raw-statistics-list-player-session-events-response:
       title: PlayerSessionEvents
       type: object
@@ -6777,6 +6769,9 @@ components:
             $ref: '#/components/schemas/player-session-event'
         pagination:
           $ref: '#/components/schemas/pagination'
+      required:
+        - data
+        - pagination
     webhooks-list-response:
       title: Webhooks
       type: object
@@ -6787,10 +6782,14 @@ components:
             $ref: '#/components/schemas/webhook'
         pagination:
           $ref: '#/components/schemas/pagination'
-    webhooks-create-payload:
       required:
-      - events
-      - url
+        - data
+        - pagination
+    webhooks-creation-payload:
+      title: WebhooksCreationPayload
+      required:
+        - events
+        - url
       type: object
       properties:
         events:
@@ -6801,7 +6800,7 @@ components:
             * ```live-stream.broadcast.started```  When a livestream begins broadcasting, the broadcasting parameter changes from false to true, and this webhook fires.
             * ```live-stream.broadcast.ended```  This event fores when the livestream has finished broadcasting, and the broadcasting parameter flips from false to true.
             * ```video.source.recorded```  This event is similar to ```video.encoding.quality.completed```, but tells you if a livestream has been recorded as a VOD.
-          example: video.encoding.quality.completed
+          example: ['video.encoding.quality.completed']
           items:
             type: string
         url:
@@ -6810,26 +6809,25 @@ components:
           example: https://example.com/webhooks
       example:
         events:
-        - video.encoding.quality.completed
+          - video.encoding.quality.completed
         url: http://clientnotificationserver.com/notif?myquery=query
-    pagination_link:
+    pagination-link:
       title: PaginationLink
       type: object
       properties:
         rel:
-          pattern: ^self$
           type: string
         uri:
           type: string
           format: uri
-    video_source_live_stream_link:
+    video-source-live-stream-link:
       type: object
       properties:
         rel:
           type: string
         uri:
           type: string
-    video_source_live_stream:
+    video-source-live-stream:
       type: object
       properties:
         liveStreamId:
@@ -6839,9 +6837,10 @@ components:
         links:
           type: array
           items:
-            $ref: '#/components/schemas/video_source_live_stream_link'
+            $ref: '#/components/schemas/video-source-live-stream-link'
       description: This appears if the video is from a Live Record.
-    videoSource:
+    video-source:
+      title: VideoSource
       type: object
       properties:
         uri:
@@ -6851,9 +6850,10 @@ components:
         type:
           type: string
         liveStream:
-          $ref: '#/components/schemas/video_source_live_stream'
+          $ref: '#/components/schemas/video-source-live-stream'
       description: Source information about the video.
-    videoAssets:
+    video-assets:
+      title: VideoAssets
       type: object
       properties:
         hls:
@@ -6880,7 +6880,8 @@ components:
           format: uri
           example: https://cdn.api.video/vod/vi4k0jvEUuaTdRAEjQ4Jfrgz/token/8fd70443-d9f0-45d2-b01c-12c8cfc707c9/mp4/720/source.mp4
       description: Collection of details about the video object that you can use to work with the video object.
-    video_session_session:
+    video-session-session:
+      title: VideoSessionSession
       type: object
       properties:
         sessionId:
@@ -6891,13 +6892,24 @@ components:
           type: string
           description: When the video session started, presented in ISO-8601 format.
           format: date-time
-          example: 2019-06-24T11:45:01.109Z
+          example: 2019-06-24T11:45:01.109+00
         endedAt:
           type: string
           description: When the video session ended, presented in ISO-8601 format.
           format: date-time
-          example: 2019-06-24T12:45:01.109Z
-    video_session_location:
+          example: 2019-06-24T12:45:01.109+00
+        metadata:
+          type: array
+          description: >-
+            A list of key value pairs that you use to provide metadata for your
+            video. These pairs can be made dynamic, allowing you to segment your
+            audience. You can also just use the pairs as another way to tag and
+            categorize your videos.
+          example: '[{"key": "Author", "value": "John Doe"}]'
+          items:
+            $ref: '#/components/schemas/metadata'
+    video-session-location:
+      title: VideoSessionLocation
       type: object
       properties:
         country:
@@ -6908,14 +6920,17 @@ components:
           type: string
           description: The city of the viewer.
           example: Paris
+          nullable: true
       description: The location of the viewer.
-    video_session_referrer:
+    video-session-referrer:
+      title: VideoSessionReferrer
       type: object
       properties:
         url:
           type: string
           description: The link the viewer used to reach the video session.
           example: https://api.video
+          nullable: true
         medium:
           type: string
           description: How they arrived at the site, for example organic or paid. Organic meaning they found it themselves and paid meaning they followed a link from an advertisement.
@@ -6927,7 +6942,8 @@ components:
         searchTerm:
           type: string
           description: The search term they typed to arrive at the video session.
-    video_session_device:
+    video-session-device:
+      title: VideoSessionDevice
       type: object
       properties:
         type:
@@ -6943,7 +6959,8 @@ components:
           description: The specific model of the device, if known.
           example: unknown
       description: What type of device the user is on when in the video session.
-    video_session_os:
+    video-session-os:
+      title: VideoSessionOs
       type: object
       properties:
         name:
@@ -6959,7 +6976,8 @@ components:
           description: The version of the operating system.
           example: Windows 10
       description: The operating system the viewer is on.
-    video_session_client:
+    video-session-client:
+      title: VideoSessionClient
       type: object
       properties:
         name:
@@ -6975,7 +6993,8 @@ components:
           description: The type of client used to view the video session.
           example: browser
       description: What kind of browser the viewer is using for the video session.
-    live_stream_assets:
+    live-stream-assets:
+      title: LiveStreamAssets
       type: object
       properties:
         hls:
@@ -6997,7 +7016,8 @@ components:
           description: A link to the thumbnail for your video.
           format: uri
           example: https://cdn.api.video/live/li400mYKSgQ6xs7taUeSaEKr/thumbnail.jpg
-    live_stream_session_session:
+    live-stream-session-session:
+      title: LiveStreamSessionSession
       type: object
       properties:
         sessionId:
@@ -7007,13 +7027,14 @@ components:
           type: string
           description: When the session started, with the date and time presented in ISO-8601 format.
           format: date-time
-          example: 2019-06-24T11:45:01.109Z
+          example: 2019-06-24T11:45:01.109+00
         endedAt:
           type: string
           description: When the session ended, with the date and time presented in ISO-8601 format.
           format: date-time
-          example: 2019-06-24T12:45:01.109Z
-    live_stream_session_location:
+          example: 2019-06-24T12:45:01.109+00
+    live-stream-session-location:
+      title: LiveStreamSessionLocation
       type: object
       properties:
         country:
@@ -7025,7 +7046,8 @@ components:
           description: The city of the viewer of the live stream.
           example: Paris
       description: The location of the viewer of the live stream.
-    live_stream_session_referrer:
+    live-stream-session-referrer:
+      title: LiveStreamSessionReferrer
       type: object
       properties:
         url:
@@ -7044,7 +7066,8 @@ components:
           type: string
           description: What term they searched for that led them to the live stream.
           example: video stream
-    live_stream_session_device:
+    live-stream-session-device:
+      title: LiveStreamSessionDevice
       type: object
       properties:
         type:
@@ -7060,7 +7083,8 @@ components:
           description: The specific model of the device, if known.
           example: unknown
       description: What type of device the user is on when in the live stream session.
-    live_stream_session_client:
+    live-stream-session-client:
+      title: LiveStreamSessionClient
       type: object
       properties:
         name:
@@ -7076,7 +7100,8 @@ components:
           description: The type of client used to view the live stream session.
           example: browser
       description: What kind of browser the viewer is using for the live stream session.
-    videostatus_ingest:
+    video-status-ingest:
+      title: VideoStatusIngest
       type: object
       properties:
         status:
@@ -7084,9 +7109,9 @@ components:
           description: There are three possible ingest statuses. missing - you are missing information required to ingest the video. uploading - the video is in the process of being uploaded. uploaded - the video is ready for use.
           example: uploaded
           enum:
-          - missing
-          - uploading
-          - uploaded
+            - missing
+            - uploading
+            - uploaded
         filesize:
           type: integer
           description: The size of your file in bytes.
@@ -7095,9 +7120,10 @@ components:
           type: array
           description: The total number of bytes received, listed for each chunk of the upload.
           items:
-            $ref: '#/components/schemas/bytes_range'
+            $ref: '#/components/schemas/bytes-range'
       description: Details about the capturing, transferring, and storing of your video for use immediately or in the future.
-    videostatus_encoding_metadata:
+    video-status-encoding-metadata:
+      title: VideoStatusEncodingMetadata
       type: object
       properties:
         width:
@@ -7128,7 +7154,8 @@ components:
           description: The method used to compress and decompress digital audio for your video.
         aspectRatio:
           type: string
-    videostatus_encoding:
+    video-status-encoding:
+      title: VideoStatusEncoding
       type: object
       properties:
         playable:
@@ -7141,13 +7168,13 @@ components:
           items:
             $ref: '#/components/schemas/quality'
         metadata:
-          $ref: '#/components/schemas/videostatus_encoding_metadata'
+          $ref: '#/components/schemas/video-status-encoding-metadata'
     account:
       title: Account
       type: object
       properties:
         quota:
-          $ref: '#/components/schemas/account_quota'
+          $ref: '#/components/schemas/quota'
         features:
           type: array
           description: 'Deprecated. What features are enabled for your account. Choices include: app.dynamic_metadata - the ability to dynamically tag videos to better segment and understand your audiences, app.event_log - the ability to create and retrieve a log detailing how your videos were interacted with, player.white_label - the ability to customise your player, stats.player_events - the ability to see statistics about how your player is being used, transcode.mp4_support - the ability to reformat content into mp4 using the H264 codec.'
@@ -7158,18 +7185,8 @@ components:
           type: string
           description: Deprecated. Whether you are using your production or sandbox API key will impact what environment is displayed here, as well as stats and features information. If you use your sandbox key, the environment is "sandbox." If you use your production key, the environment is "production."
       deprecated: true
-    player_assets:
-      type: object
-      properties:
-        logo:
-          type: string
-          description: The name of the file containing the logo you want to use.
-          example: mylogo.jpg
-        link:
-          type: string
-          description: The path to the file containing your logo.
-          example: path/to/my/logo/mylogo.jpg
-    account_quota:
+    quota:
+      title: AccountQuota
       type: object
       properties:
         quotaUsed:
@@ -7183,7 +7200,7 @@ components:
           description: Deprecated
       description: Deprecated
   parameters:
-    currentPage:
+    current-page:
       name: currentPage
       in: query
       description: 'Choose the number of search results to return per page. Minimum value: 1'
@@ -7194,7 +7211,7 @@ components:
         type: integer
         default: 1
       example: 2
-    pageSize:
+    page-size:
       name: pageSize
       in: query
       description: Results per page. Allowed values 1-100, default is 25.
@@ -7217,8 +7234,8 @@ x-readme:
   proxy-enabled: true
   samples-enabled: true
   samples-languages:
-  - curl
-  - go
-  - node
-  - php
-  - python
+    - curl
+    - go
+    - node
+    - php
+    - python


### PR DESCRIPTION
- payload names consistency (case, _ vs. -, ...) 
- things renamed:
    - Videos - Delegated upload => Upload tokens
    - deletagedUpload.upload => videos.uploadWithUploadToken
    - Live => Live Streams
    - Subtitle => Caption
    - Players => Player Themes
- removed deprecated account endpoint
- remove usage of "allOf" since it introduces awful models in generated clients